### PR TITLE
feat: Beads + AutoSpec integration — dependency graph, YAML SDDs, validation gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,124 +5,167 @@
   ██╔══╝  ██║   ██║██╔══██╗██║   ██║██║██╔══██║
   ██║     ╚██████╔╝██║  ██║╚██████╔╝██║██║  ██║
   ╚═╝      ╚═════╝ ╚═╝  ╚═╝ ╚═════╝ ╚═╝╚═╝  ╚═╝
+
+  Forge specs into code. FD → SDD → Agent execution framework.
 ```
 
-> Forge specs into code. Spec-driven development framework for AI agents.
-
-Forgia is an opinionated SDD (Spec-Driven Development) framework that turns human design decisions into execution contracts for autonomous agents.
+> Spec-driven development framework for AI agents.
+> Forgia turns human design decisions into execution contracts for autonomous agents.
 
 ## The Model
 
 ```
-You ──→ FD (what & why) ──→ SDD (how, for agents) ──→ Agent ──→ Code
-         functional            execution contract        OpenHands
-         design                agent-ready prompt        Claude Code
-         1 per feature         N per FD                  parallel
+Tu ──→ FD (cosa e perche') ──→ SDD (come, per agent) ──→ Agent ──→ Codice
+        design funzionale        contratto esecutivo       OpenHands
+        1 per feature            N per FD                  Claude Code
+        decisioni umane          prompt strutturato        parallelo
 ```
 
-| Layer | Who | What |
+| Layer | Chi | Cosa |
 |-------|-----|------|
-| **FD** (Feature Design) | Human + AI | Architecture, trade-offs, interfaces |
-| **SDD** (Spec-Driven Dev) | AI generates, human approves | Scope, constraints, tests, acceptance criteria |
-| **Constitution** | Human | Immutable project rules |
-| **Code** | Agent | Implementation guided by SDD |
+| **FD** (Feature Design) | Umano + AI | Architettura, trade-off, interfacce |
+| **SDD** (Spec-Driven Dev) | AI genera, umano approva | Scope, vincoli, test, criteri accettazione |
+| **Constitution** | Umano | Regole immutabili del progetto |
+| **Code** | Agent | Implementazione guidata dall'SDD |
 
 ## Quick Start
 
 ```bash
-# Prerequisites: mise, docker
+# Prerequisiti: mise, docker (opzionale per OpenHands)
 git clone git@github.com:Deepzima/forgia.git
 cd forgia
 
-# Install Claude Code commands
+# Installa i comandi Claude Code
 mise run claude:install
 
-# Install OpenHands runtime
-mise run openhands:install
+# Installa Beads task tracker (opzionale)
+mise run bd:install
 
-# Initialize a new project
+# Inizializza un nuovo progetto
 cd /path/to/your/project
 forgia init
 ```
 
-## Vault Structure
+## Struttura del Vault
 
-After `forgia init`, your project gets:
+Dopo `forgia init`, il progetto ottiene:
 
 ```
 your-project/
   .forgia/
-    constitution.md         # immutable project rules
-    _dashboard.md           # Obsidian dataview overview
-    fd/                     # Feature Designs
-    sdd/                    # Execution Specs (agent-ready)
-    ops/                    # Operational tasks
-    dev-guide/              # Conventions
+    config.toml               # configurazione runner e beads
+    constitution.md            # regole immutabili
+    _dashboard.md              # panoramica Obsidian dataview
+    fd/                        # Feature Design (cosa e perche')
+    sdd/                       # Execution Specs (come, per agent)
+      _templates/
+        sdd-template.md        # formato markdown
+        sdd-template.yaml      # formato YAML (machine-parseable)
+    ops/                       # task operativi manuali
+    dev-guide/
+      principles/              # clean-code, SOLID, design-patterns
+      lang/                    # convenzioni per linguaggio (auto-detect)
+      coding-conventions.md
+      commit-conventions.md
+      review-process.md
 ```
 
 ## Incantesimi (Spells)
 
-> Forgia's commands — Claude Code slash commands.
+> I comandi di Forgia — slash commands per Claude Code.
 
-| Incantesimo | What it does |
-|-------------|--------------|
-| `/project-init` | Prepare the forge — scaffold the `.forgia/` vault |
-| `/fd-new` | Forge a new design — create a Feature Design |
-| `/fd-review` | Trial by fire — mandatory review gate |
-| `/fd-sdd` | Temper the specs — generate N SDDs from an approved FD |
-| `/fd-deep` | Deep analysis — 4 agents explore the problem in parallel |
-| `/fd-explore` | Study the piece — load FD context |
-| `/fd-verify` | Quality check — verify implementation vs spec |
-| `/fd-close` | Seal the work — archive completed FD + retrospective |
-| `/fd-status` | Forge status — FD + SDD dashboard |
-| `/sdd-assign` | Assign the work — send an SDD to an agent |
-| `/sdd-status` | Agent status — SDD execution progress |
+| Incantesimo | Cosa fa |
+|-------------|---------|
+| `/fd-new` | **Forgia un nuovo design** — crea un Feature Design |
+| `/fd-review` | **Prova del fuoco** — review gate obbligatorio |
+| `/fd-sdd` | **Tempra le spec** — genera N SDD da un FD approvato |
+| `/fd-deep` | **Analisi profonda** — 4 agenti esplorano in parallelo |
+| `/fd-explore` | **Studia il pezzo** — carica il contesto di un FD |
+| `/fd-verify` | **Controllo qualita'** — verifica implementazione vs spec |
+| `/fd-close` | **Sigilla il lavoro** — archivia FD completato + retrospettiva |
+| `/fd-status` | **Stato della fucina** — dashboard FD + SDD |
 
-## Attrezzi della Fucina (Forge Tools)
+## Attrezzi della Fucina (CLI)
 
-> Mise tasks for infrastructure management.
+> Comandi `forgia` e task `mise` per gestire il workflow.
 
-| Attrezzo | What it does |
-|----------|--------------|
-| `mise run init` | Scaffold vault in current project |
-| `mise run openhands:install` | Pull OpenHands container |
-| `mise run openhands:up` | Light the forge — start OpenHands on :3000 |
-| `mise run openhands:down` | Shut down the forge |
-| `mise run sdd <file>` | Execute an SDD with OpenHands headless |
-| `mise run sdd:batch FD-001` | Execute all SDDs for an FD in parallel |
-| `mise run status` | Dashboard of all FD + SDD |
-| `mise run doctor` | Health check (docker, openhands, vault) |
-| `mise run claude:install` | Install commands in Claude Code |
+| Attrezzo | Cosa fa |
+|----------|---------|
+| `forgia init` | Forgia il vault nel progetto corrente |
+| `forgia status` | Dashboard FD + SDD + Beads |
+| `forgia doctor` | Verifica salute (docker, bd, vault, mise) |
+| `forgia validate <sdd>` | Valida un SDD prima dell'esecuzione |
+| `forgia exec <sdd>` | Esegui un SDD (auto-detect runner) |
+| `forgia batch <FD-NNN>` | Esegui tutti gli SDD di un FD |
+| `forgia watch <FD-NNN>` | Osserva e esegui nuovi SDD automaticamente |
 
-## Work Log
+### Runner
 
-Every SDD includes a mandatory Work Log section:
+```bash
+# Claude Code — usa la tua subscription Max (gratis)
+forgia exec .forgia/sdd/FD-001/SDD-001.md --runner=claude
 
-```markdown
-## Work Log
-### Agent
-- who executed, when, duration
-### Decisions
-- deviations from plan, problems encountered
-### Output
-- commit hash, PR link, files created/modified
-### Retrospective
-- what worked, what didn't, suggestions for future FDs
+# OpenHands — usa API key, container Docker isolato
+forgia exec .forgia/sdd/FD-001/SDD-001.md --runner=openhands
+
+# Default dal config.toml
+forgia exec .forgia/sdd/FD-001/SDD-001.md
 ```
 
-## Agent Backends
+| Runner | Quando usarlo |
+|--------|---------------|
+| **Claude Code** | Interattivo, sub Max, worktree isolato |
+| **OpenHands** | Autonomo, N container paralleli, API key |
+| **Manual** | Leggi l'SDD e implementa tu |
 
-| Agent | When |
-|-------|------|
-| **Claude Code** | Interactive, you're at the keyboard |
-| **OpenHands** | Autonomous, N agents in parallel containers |
-| **Manual** | You read the SDD and implement yourself |
+## Beads Integration
+
+[Beads (bd)](https://github.com/steveyegge/beads) gestisce il grafo delle dipendenze tra SDD:
+
+```bash
+# Dopo /fd-sdd: crea epic + subtask con dipendenze
+bd ready              # mostra task sbloccati
+forgia batch FD-001   # esegue solo quelli pronti (dependency-aware)
+```
+
+## Knowledge Stack
+
+Ogni agent carica automaticamente:
+
+```
+.forgia/dev-guide/
+  principles/          ← SEMPRE (clean-code, SOLID, design-patterns)
+  lang/                ← auto-detect per progetto (rust, python, ts, go, shell)
+  coding-conventions   ← regole operative
+  commit-conventions   ← formato commit
+```
+
+## Work Log
+
+Ogni SDD include un Work Log obbligatorio — compilato dall'agent o dallo sviluppatore:
+
+```yaml
+work_log:
+  executor: claude-code
+  started: 2026-03-15T10:00:00
+  completed: 2026-03-15T11:30:00
+  decisions:
+    - what: "Used tower middleware instead of manual auth"
+      why: "Composable, testable, idiomatic axum"
+  output:
+    commits: ["abc123"]
+    files_changed: ["src/auth.rs", "tests/auth_test.rs"]
+  retrospective:
+    worked: "Builder pattern for config was clean"
+    suggestions: "Add integration test template to SDD"
+```
 
 ## Inspired By
 
+- [AutoSpec](https://github.com/ariel-frischer/autospec) — YAML specs, auto-validation, session isolation
+- [Beads](https://github.com/steveyegge/beads) — distributed graph issue tracker for AI agents
 - [GitHub Spec Kit](https://github.com/github/spec-kit) — spec/plan separation, constitution
-- [BMAD Method](https://github.com/bmad-code-org/BMAD-METHOD) — multi-agent roles
-- [OpenHands](https://github.com/OpenHands/OpenHands) — sandboxed agent runtime
+- [OpenHands](https://github.com/all-hands-ai/OpenHands) — sandboxed agent runtime
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,134 +15,137 @@
 ## The Model
 
 ```
-Tu ──→ FD (cosa e perche') ──→ SDD (come, per agent) ──→ Agent ──→ Codice
-        design funzionale        contratto esecutivo       OpenHands
-        1 per feature            N per FD                  Claude Code
-        decisioni umane          prompt strutturato        parallelo
+You ──→ FD (what & why) ──→ SDD (how, for agents) ──→ Agent ──→ Code
+         functional           execution contract        OpenHands
+         design               agent-ready prompt        Claude Code
+         1 per feature        N per FD                  parallel
 ```
 
-| Layer | Chi | Cosa |
+| Layer | Who | What |
 |-------|-----|------|
-| **FD** (Feature Design) | Umano + AI | Architettura, trade-off, interfacce |
-| **SDD** (Spec-Driven Dev) | AI genera, umano approva | Scope, vincoli, test, criteri accettazione |
-| **Constitution** | Umano | Regole immutabili del progetto |
-| **Code** | Agent | Implementazione guidata dall'SDD |
+| **FD** (Feature Design) | Human + AI | Architecture, trade-offs, interfaces |
+| **SDD** (Spec-Driven Dev) | AI generates, human approves | Scope, constraints, tests, acceptance criteria |
+| **Constitution** | Human | Immutable project rules |
+| **Code** | Agent | Implementation guided by SDD |
 
 ## Quick Start
 
 ```bash
-# Prerequisiti: mise, docker (opzionale per OpenHands)
+# Prerequisites: mise, docker (optional for OpenHands)
 git clone git@github.com:Deepzima/forgia.git
 cd forgia
 
-# Installa i comandi Claude Code
+# Install Claude Code slash commands
 mise run claude:install
 
-# Installa Beads task tracker (opzionale)
+# Install optional tools (fswatch, yq)
+mise run tools:install
+
+# Install Beads task tracker (optional)
 mise run bd:install
 
-# Inizializza un nuovo progetto
+# Initialize a new project
 cd /path/to/your/project
 forgia init
 ```
 
-## Struttura del Vault
+## Vault Structure
 
-Dopo `forgia init`, il progetto ottiene:
+After `forgia init`, your project gets:
 
 ```
 your-project/
   .forgia/
-    config.toml               # configurazione runner e beads
-    constitution.md            # regole immutabili
-    _dashboard.md              # panoramica Obsidian dataview
-    fd/                        # Feature Design (cosa e perche')
-    sdd/                       # Execution Specs (come, per agent)
+    config.toml               # runner and beads configuration
+    constitution.md            # immutable project rules
+    _dashboard.md              # Obsidian dataview overview
+    fd/                        # Feature Designs (what & why)
+    sdd/                       # Execution Specs (how, for agents)
       _templates/
-        sdd-template.md        # formato markdown
-        sdd-template.yaml      # formato YAML (machine-parseable)
-    ops/                       # task operativi manuali
+        sdd-template.md        # markdown format
+        sdd-template.yaml      # YAML format (machine-parseable)
+    ops/                       # manual operational tasks
     dev-guide/
       principles/              # clean-code, SOLID, design-patterns
-      lang/                    # convenzioni per linguaggio (auto-detect)
+      lang/                    # per-language conventions (auto-detected)
       coding-conventions.md
       commit-conventions.md
       review-process.md
 ```
 
-## Incantesimi (Spells)
+## Spells (Commands)
 
-> I comandi di Forgia — slash commands per Claude Code.
+> Claude Code slash commands — the core workflow.
 
-| Incantesimo | Cosa fa |
-|-------------|---------|
-| `/fd-new` | **Forgia un nuovo design** — crea un Feature Design |
-| `/fd-review` | **Prova del fuoco** — review gate obbligatorio |
-| `/fd-sdd` | **Tempra le spec** — genera N SDD da un FD approvato |
-| `/fd-deep` | **Analisi profonda** — 4 agenti esplorano in parallelo |
-| `/fd-explore` | **Studia il pezzo** — carica il contesto di un FD |
-| `/fd-verify` | **Controllo qualita'** — verifica implementazione vs spec |
-| `/fd-close` | **Sigilla il lavoro** — archivia FD completato + retrospettiva |
-| `/fd-status` | **Stato della fucina** — dashboard FD + SDD |
+| Spell | What it does |
+|-------|--------------|
+| `/fd-new` | **Forge a new design** — create a Feature Design |
+| `/fd-review` | **Trial by fire** — mandatory review gate |
+| `/fd-sdd` | **Temper the specs** — generate N SDDs from an approved FD |
+| `/fd-deep` | **Deep analysis** — 4 agents explore the problem in parallel |
+| `/fd-explore` | **Study the piece** — load FD context |
+| `/fd-verify` | **Quality check** — verify implementation vs spec |
+| `/fd-close` | **Seal the work** — archive completed FD + retrospective |
+| `/fd-status` | **Forge status** — FD + SDD dashboard |
 
-## Attrezzi della Fucina (CLI)
+## CLI Tools
 
-> Comandi `forgia` e task `mise` per gestire il workflow.
+> `forgia` commands and `mise` tasks for workflow management.
 
-| Attrezzo | Cosa fa |
-|----------|---------|
-| `forgia init` | Forgia il vault nel progetto corrente |
-| `forgia status` | Dashboard FD + SDD + Beads |
-| `forgia doctor` | Verifica salute (docker, bd, vault, mise) |
-| `forgia validate <sdd>` | Valida un SDD prima dell'esecuzione |
-| `forgia exec <sdd>` | Esegui un SDD (auto-detect runner) |
-| `forgia batch <FD-NNN>` | Esegui tutti gli SDD di un FD |
-| `forgia watch <FD-NNN>` | Osserva e esegui nuovi SDD automaticamente |
+| Command | What it does |
+|---------|--------------|
+| `forgia init` | Scaffold the vault in the current project |
+| `forgia status` | Dashboard: FDs + SDDs + Beads ready tasks |
+| `forgia doctor` | Health check (docker, bd, vault, mise, fswatch, yq) |
+| `forgia validate <sdd>` | Validate an SDD before execution |
+| `forgia exec <sdd>` | Execute an SDD (auto-detect runner from config) |
+| `forgia batch <FD-NNN>` | Execute all SDDs for an FD |
+| `forgia watch <FD-NNN>` | Watch and auto-execute new SDDs |
 
-### Runner
+### Runners
 
 ```bash
-# Claude Code — usa la tua subscription Max (gratis)
+# Claude Code — uses your Max subscription (free)
 forgia exec .forgia/sdd/FD-001/SDD-001.md --runner=claude
 
-# OpenHands — usa API key, container Docker isolato
+# OpenHands — uses API keys, isolated Docker containers
 forgia exec .forgia/sdd/FD-001/SDD-001.md --runner=openhands
 
-# Default dal config.toml
+# Default from config.toml
 forgia exec .forgia/sdd/FD-001/SDD-001.md
 ```
 
-| Runner | Quando usarlo |
-|--------|---------------|
-| **Claude Code** | Interattivo, sub Max, worktree isolato |
-| **OpenHands** | Autonomo, N container paralleli, API key |
-| **Manual** | Leggi l'SDD e implementa tu |
+| Runner | When to use |
+|--------|-------------|
+| **Claude Code** | Interactive, Max subscription, git worktree isolation |
+| **OpenHands** | Autonomous, N parallel containers, API keys |
+| **Manual** | Read the SDD and implement yourself |
 
 ## Beads Integration
 
-[Beads (bd)](https://github.com/steveyegge/beads) gestisce il grafo delle dipendenze tra SDD:
+[Beads (bd)](https://github.com/steveyegge/beads) manages the dependency graph between SDDs:
 
 ```bash
-# Dopo /fd-sdd: crea epic + subtask con dipendenze
-bd ready              # mostra task sbloccati
-forgia batch FD-001   # esegue solo quelli pronti (dependency-aware)
+# After /fd-sdd: creates epic + subtasks with dependencies
+bd ready              # show unblocked tasks
+forgia batch FD-001   # execute only ready ones (dependency-aware)
 ```
 
 ## Knowledge Stack
 
-Ogni agent carica automaticamente:
+Every agent automatically loads:
 
 ```
 .forgia/dev-guide/
-  principles/          ← SEMPRE (clean-code, SOLID, design-patterns)
-  lang/                ← auto-detect per progetto (rust, python, ts, go, shell)
-  coding-conventions   ← regole operative
-  commit-conventions   ← formato commit
+  principles/          ← ALWAYS loaded (clean-code, SOLID, design-patterns)
+  lang/                ← auto-detected per project (rust, python, ts, go, shell)
+  coding-conventions   ← operational rules
+  commit-conventions   ← commit format
 ```
 
 ## Work Log
 
-Ogni SDD include un Work Log obbligatorio — compilato dall'agent o dallo sviluppatore:
+Every SDD includes a mandatory Work Log — filled by the agent or developer:
 
 ```yaml
 work_log:
@@ -159,6 +162,17 @@ work_log:
     worked: "Builder pattern for config was clean"
     suggestions: "Add integration test template to SDD"
 ```
+
+## Prerequisites
+
+| Tool | Required | Purpose | Install |
+|------|----------|---------|---------|
+| `mise` | Yes | Task runner | [mise.jdx.dev](https://mise.jdx.dev) |
+| `claude` | Yes | Claude Code CLI | [claude.ai/claude-code](https://claude.ai/claude-code) |
+| `docker` | Optional | OpenHands runner | [docker.com](https://docker.com) |
+| `bd` | Optional | Beads task tracker | `mise run bd:install` |
+| `fswatch` | Optional | `forgia watch` | `brew install fswatch` |
+| `yq` | Optional | YAML SDD validation | `brew install yq` |
 
 ## Inspired By
 

--- a/bin/forgia
+++ b/bin/forgia
@@ -172,6 +172,20 @@ cmd_init() {
     echo "  Loaded conventions: dev-guide/lang/{${detected[*]}}.md"
   fi
 
+  # Beads (bd) initialization
+  if command -v bd >/dev/null 2>&1; then
+    if [[ ! -d ".beads" ]]; then
+      echo ""
+      echo "→ Initializing Beads task tracker..."
+      bd init 2>/dev/null || true
+      echo "  Created: .beads/"
+    else
+      echo "  Beads: already initialized"
+    fi
+  else
+    echo "  Beads: not installed (optional — run: mise run bd:install)"
+  fi
+
   echo ""
   echo "✓ Vault scaffolded at $VAULT_DIR/"
   echo ""
@@ -250,6 +264,14 @@ cmd_status() {
   fi
   echo ""
 
+  # Beads ready tasks
+  if command -v bd >/dev/null 2>&1 && [[ -d ".beads" ]]; then
+    echo ""
+    echo "--- Beads (ready tasks) ---"
+    bd ready 2>/dev/null || echo "  (no ready tasks)"
+  fi
+
+  echo ""
   echo "Summary: $fd_count FDs, $sdd_count SDDs, $ops_count active tasks"
 }
 
@@ -333,6 +355,22 @@ cmd_doctor() {
     warn=$((warn + 1))
   fi
 
+  # Check Beads (bd)
+  if command -v bd >/dev/null 2>&1; then
+    printf "  %-25s OK\n" "beads (bd)"
+    ok=$((ok + 1))
+    if [[ -d ".beads" ]]; then
+      printf "  %-25s OK\n" "beads repo (.beads/)"
+      ok=$((ok + 1))
+    else
+      printf "  %-25s NOT INITIALIZED (run: bd init)\n" "beads repo (.beads/)"
+      warn=$((warn + 1))
+    fi
+  else
+    printf "  %-25s NOT INSTALLED (run: mise run bd:install)\n" "beads (bd)"
+    warn=$((warn + 1))
+  fi
+
   # Check LLM key
   if [[ -n "${ANTHROPIC_API_KEY:-}" ]] || [[ -n "${OPENAI_API_KEY:-}" ]]; then
     printf "  %-25s OK\n" "llm api key"
@@ -370,6 +408,21 @@ cmd_exec() {
   if [[ -f "$sdd_file" ]]; then
     sed -i.bak 's/^status: .*/status: done/' "$sdd_file"
     rm -f "${sdd_file}.bak"
+  fi
+
+  # Close corresponding bd task if it exists
+  if command -v bd >/dev/null 2>&1 && [[ -d ".beads" ]]; then
+    local sdd_id
+    sdd_id=$(grep '^id:' "$sdd_file" 2>/dev/null | head -1 | sed 's/id: *//')
+    if [[ -n "$sdd_id" ]]; then
+      # Find bd task tagged with this SDD id and close it
+      local bd_task_id
+      bd_task_id=$(bd search "$sdd_id" --format=json 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | sed 's/"id":"//;s/"//') || true
+      if [[ -n "$bd_task_id" ]]; then
+        bd update "$bd_task_id" --status=done 2>/dev/null || true
+        echo "  → Beads task $bd_task_id closed"
+      fi
+    fi
   fi
 }
 

--- a/bin/forgia
+++ b/bin/forgia
@@ -12,6 +12,7 @@ Incantesimi (comandi):
   init                          Forgia il vault .forgia/ nel progetto
   status                        Mostra la dashboard FD + SDD
   doctor                        Verifica salute (docker, openhands, vault)
+  validate <sdd-file|FD-NNN>    Valida un SDD o tutti gli SDD di un FD
   exec <sdd-file> [--runner=X]  Esegui un SDD (runner: claude|openhands)
   batch <FD-NNN> [--runner=X]   Esegui tutti gli SDD di un FD
   watch <FD-NNN> [--runner=X]   Osserva e esegui nuovi SDD automaticamente
@@ -384,6 +385,44 @@ cmd_doctor() {
   echo "Summary: $ok OK, $warn warnings, $fail failures"
 }
 
+# --- validate ---
+
+cmd_validate() {
+  local target="${1:?Usage: forgia validate <sdd-file|FD-NNN>}"
+  local validate_script="$ROOT_DIR/modules/runners/validate-sdd.sh"
+
+  if [[ -f "$target" ]]; then
+    # Single file
+    "$validate_script" "$target"
+  elif [[ -d "$VAULT_DIR/sdd/$target" ]]; then
+    # FD directory — validate all SDDs
+    local total=0 valid=0 invalid=0
+    for sdd in "$VAULT_DIR/sdd/$target"/SDD-*.{md,yaml,yml}; do
+      [[ -f "$sdd" ]] || continue
+      total=$((total + 1))
+      echo ""
+      if "$validate_script" "$sdd"; then
+        valid=$((valid + 1))
+      else
+        invalid=$((invalid + 1))
+      fi
+    done
+
+    if (( total == 0 )); then
+      echo "No SDDs found for $target"
+      exit 1
+    fi
+
+    echo ""
+    echo "=== Validation Summary: $target ==="
+    echo "  Total: $total | Valid: $valid | Invalid: $invalid"
+    (( invalid == 0 )) || exit 1
+  else
+    echo "Error: '$target' is not a file or FD identifier" >&2
+    exit 1
+  fi
+}
+
 # --- exec ---
 
 cmd_exec() {
@@ -394,6 +433,15 @@ cmd_exec() {
   script=$(get_runner_script "$runner")
 
   echo "→ Executing $sdd_file with runner: $runner"
+  echo ""
+
+  # Pre-exec validation
+  local validate_script="$ROOT_DIR/modules/runners/validate-sdd.sh"
+  if ! "$validate_script" "$sdd_file"; then
+    echo ""
+    echo "Error: SDD validation failed — fix errors before execution" >&2
+    exit 1
+  fi
   echo ""
 
   # Update SDD status to in-progress
@@ -546,12 +594,13 @@ main() {
   shift || true
 
   case "$cmd" in
-    init)    cmd_init ;;
-    status)  cmd_status ;;
-    doctor)  cmd_doctor ;;
-    exec)    cmd_exec "$@" ;;
-    batch)   cmd_batch "$@" ;;
-    watch)   cmd_watch "$@" ;;
+    init)     cmd_init ;;
+    status)   cmd_status ;;
+    doctor)   cmd_doctor ;;
+    validate) cmd_validate "$@" ;;
+    exec)     cmd_exec "$@" ;;
+    batch)    cmd_batch "$@" ;;
+    watch)    cmd_watch "$@" ;;
     *)       usage; exit 1 ;;
   esac
 }

--- a/bin/forgia
+++ b/bin/forgia
@@ -368,7 +368,25 @@ cmd_doctor() {
       warn=$((warn + 1))
     fi
   else
-    printf "  %-25s NOT INSTALLED (run: mise run bd:install)\n" "beads (bd)"
+    printf "  %-25s NOT INSTALLED (optional — run: mise run bd:install)\n" "beads (bd)"
+    warn=$((warn + 1))
+  fi
+
+  # Check fswatch (for forgia watch)
+  if command -v fswatch >/dev/null 2>&1; then
+    printf "  %-25s OK\n" "fswatch"
+    ok=$((ok + 1))
+  else
+    printf "  %-25s NOT INSTALLED (optional — brew install fswatch)\n" "fswatch"
+    warn=$((warn + 1))
+  fi
+
+  # Check yq (for YAML SDD validation)
+  if command -v yq >/dev/null 2>&1; then
+    printf "  %-25s OK\n" "yq"
+    ok=$((ok + 1))
+  else
+    printf "  %-25s NOT INSTALLED (optional — brew install yq)\n" "yq"
     warn=$((warn + 1))
   fi
 

--- a/mise.toml
+++ b/mise.toml
@@ -29,6 +29,56 @@ description = "Osserva e esegui nuovi SDD automaticamente"
 usage = "mise run sdd:watch <FD-NNN> [--runner=claude|openhands]"
 run = "{{source_dir}}/bin/forgia watch $@"
 
+# --- Beads (bd) task tracker ---
+
+[tasks."bd:install"]
+description = "Installa Beads (bd) task tracker"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v bd >/dev/null 2>&1; then
+  echo "✓ bd already installed: $(bd --version 2>/dev/null || echo 'ok')"
+  exit 0
+fi
+
+if command -v npm >/dev/null 2>&1; then
+  echo "→ Installing bd via npm..."
+  npm install -g @beads/bd
+elif command -v brew >/dev/null 2>&1; then
+  echo "→ Installing bd via brew..."
+  brew install beads
+else
+  echo "Error: npm or brew required to install bd" >&2
+  exit 1
+fi
+
+echo "✓ bd installed"
+"""
+
+[tasks."bd:init"]
+description = "Inizializza Beads nel progetto"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -d ".beads" ]]; then
+  echo "✓ Beads already initialized"
+  exit 0
+fi
+
+bd init
+echo "✓ Beads initialized"
+"""
+
+[tasks."bd:ready"]
+description = "Mostra task sbloccati e pronti per esecuzione"
+run = "bd ready"
+
+[tasks."bd:status"]
+description = "Mostra stato completo del task graph"
+run = "bd status"
+
 # --- OpenHands tasks ---
 
 [tasks."openhands:install"]

--- a/mise.toml
+++ b/mise.toml
@@ -12,6 +12,13 @@ run = "{{source_dir}}/bin/forgia status"
 description = "Verifica salute: docker, openhands, vault, mise"
 run = "{{source_dir}}/bin/forgia doctor"
 
+# --- SDD validation ---
+
+[tasks."sdd:validate"]
+description = "Valida un SDD o tutti gli SDD di un FD"
+usage = "mise run sdd:validate <sdd-file|FD-NNN>"
+run = "{{source_dir}}/bin/forgia validate $@"
+
 # --- SDD execution (runner-agnostic) ---
 
 [tasks."sdd:exec"]

--- a/mise.toml
+++ b/mise.toml
@@ -36,6 +36,37 @@ description = "Osserva e esegui nuovi SDD automaticamente"
 usage = "mise run sdd:watch <FD-NNN> [--runner=claude|openhands]"
 run = "{{source_dir}}/bin/forgia watch $@"
 
+# --- Optional tools ---
+
+[tasks."tools:install"]
+description = "Install all optional tools (bd, fswatch, yq)"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Installing Forgia optional tools ==="
+
+# fswatch
+if command -v fswatch >/dev/null 2>&1; then
+  echo "  fswatch: already installed"
+else
+  echo "  fswatch: installing..."
+  brew install fswatch 2>/dev/null || echo "  fswatch: brew not found, install manually"
+fi
+
+# yq
+if command -v yq >/dev/null 2>&1; then
+  echo "  yq: already installed"
+else
+  echo "  yq: installing..."
+  brew install yq 2>/dev/null || echo "  yq: brew not found, install manually"
+fi
+
+echo ""
+echo "✓ Optional tools check complete"
+echo "  Run 'mise run bd:install' separately for Beads"
+"""
+
 # --- Beads (bd) task tracker ---
 
 [tasks."bd:install"]

--- a/modules/claude-commands/fd-review.md
+++ b/modules/claude-commands/fd-review.md
@@ -17,10 +17,13 @@ Given FD identifier: $ARGUMENTS
 - [ ] At least 2 solutions were considered with pros/cons
 - [ ] The chosen solution is justified
 
-### Architecture
-- [ ] Mermaid diagram is present and accurate
-- [ ] Components and dependencies are identified
-- [ ] Interfaces between components are defined
+### Architecture & Mermaid Diagrams (MANDATORY)
+- [ ] **Integration Context diagram** is present — shows where the feature sits in the existing system (existing components in grey, new in green)
+- [ ] **Data Flow diagram** is present — sequence diagram showing the interaction between components
+- [ ] Diagrams are NOT the default template placeholders — they must reflect the actual feature
+- [ ] Diagrams use correct Mermaid syntax (flowchart/sequenceDiagram)
+- [ ] Components and dependencies are identified in the diagrams
+- [ ] Interfaces between components are defined and match the diagrams
 - [ ] No significant technical debt introduced
 
 ### SDD Planning

--- a/modules/claude-commands/fd-sdd.md
+++ b/modules/claude-commands/fd-sdd.md
@@ -24,14 +24,20 @@ Given FD identifier: $ARGUMENTS
      - **Context**: files to read, existing code to understand
      - **Constitution Check**: pre-filled from constitution.md
      - **Work Log**: empty, ready to be filled by the agent
-7. Update the FD status to "in-progress"
-8. Show the user:
+8. Update the FD status to "in-progress"
+9. **Beads integration** (if `bd` is available and `.beads/` exists):
+   - Create a bd epic for the FD: `bd create "FD-NNN: <title>" --type=epic`
+   - For each SDD, create a bd subtask: `bd create "SDD-NNN: <title>" --parent=<epic-id>`
+   - Add dependencies between SDDs if they have interface contracts
+   - Tag each bd task with the SDD id for cross-reference
+10. Show the user:
    - List of generated SDDs with file paths
+   - Beads epic and task IDs (if created)
    - Suggested next steps:
      - Review each SDD for completeness
-     - Assign agent: `/sdd-assign SDD-001`
-     - Or execute directly: `mise run sdd .forgia/sdd/FD-NNN/SDD-001.md`
-     - Or batch execute: `mise run sdd:batch FD-NNN`
+     - Execute directly: `forgia exec .forgia/sdd/FD-NNN/SDD-001.md`
+     - Batch execute: `forgia batch FD-NNN`
+     - Check ready tasks: `bd ready`
 
 ## Important
 
@@ -40,3 +46,4 @@ Given FD identifier: $ARGUMENTS
 - The SDD is an agent-ready prompt, not traditional documentation
 - Include enough context that the agent can work autonomously
 - Cross-reference interfaces between SDDs so they produce compatible code
+- Beads tasks mirror SDDs — they are NOT a replacement, they add dependency tracking

--- a/modules/runners/claude.sh
+++ b/modules/runners/claude.sh
@@ -97,15 +97,44 @@ if [[ "$max_turns" != "0" ]]; then
   claude_args+=(--max-turns "$max_turns")
 fi
 
-echo "→ Launching Claude Code agent..."
+echo "→ Launching Claude Code agent (session-isolated)..."
 echo ""
 
-# Execute via claude CLI
-if command -v claude >/dev/null 2>&1; then
-  echo "$prompt" | claude "${claude_args[@]}" --print
-else
+# Execute via claude CLI — each SDD gets its own isolated session
+# This prevents context pollution between SDDs and saves tokens
+if ! command -v claude >/dev/null 2>&1; then
   echo "Error: 'claude' CLI not found. Install Claude Code first." >&2
   exit 1
+fi
+
+# Session isolation: --no-conversation-history ensures a fresh context
+# Each SDD runs in its own session with only its spec + conventions loaded
+if [[ "$use_worktree" == "true" ]]; then
+  # Create temporary worktree for full git isolation
+  worktree_dir=$(mktemp -d)
+  branch_name="forgia/${sdd_id:-sdd}-$(date +%s)"
+
+  echo "  Worktree: $worktree_dir"
+  echo "  Branch:   $branch_name"
+
+  git worktree add -b "$branch_name" "$worktree_dir" HEAD 2>/dev/null
+
+  # Run in worktree
+  (cd "$worktree_dir" && echo "$prompt" | claude "${claude_args[@]}" --print)
+
+  # Merge back if there are changes
+  if (cd "$worktree_dir" && git diff --quiet HEAD 2>/dev/null); then
+    echo "  No changes — cleaning up worktree"
+    git worktree remove "$worktree_dir" 2>/dev/null || rm -rf "$worktree_dir"
+    git branch -D "$branch_name" 2>/dev/null || true
+  else
+    echo "  Changes detected on branch: $branch_name"
+    echo "  Worktree: $worktree_dir"
+    echo "  Merge with: git merge $branch_name"
+  fi
+else
+  # Run directly (no worktree isolation)
+  echo "$prompt" | claude "${claude_args[@]}" --print
 fi
 
 echo ""

--- a/modules/runners/validate-sdd.sh
+++ b/modules/runners/validate-sdd.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate an SDD file (YAML or Markdown) for completeness before execution.
+# Returns 0 if valid, 1 if issues found.
+
+SDD_FILE="${1:?Usage: validate-sdd.sh <sdd-file>}"
+
+if [[ ! -f "$SDD_FILE" ]]; then
+  echo "Error: File not found: $SDD_FILE" >&2
+  exit 1
+fi
+
+errors=()
+warnings=()
+
+# Detect format
+if [[ "$SDD_FILE" == *.yaml ]] || [[ "$SDD_FILE" == *.yml ]]; then
+  format="yaml"
+else
+  format="markdown"
+fi
+
+echo "=== SDD Validation: $(basename "$SDD_FILE") ==="
+echo "  Format: $format"
+echo ""
+
+if [[ "$format" == "yaml" ]]; then
+  # YAML validation
+  if command -v yq >/dev/null 2>&1; then
+    # Check required fields
+    for field in meta.id meta.fd meta.title meta.status; do
+      val=$(yq -r ".${field}" "$SDD_FILE" 2>/dev/null || echo "")
+      if [[ -z "$val" ]] || [[ "$val" == "null" ]] || [[ "$val" == '{{'"'*'"'}}' ]]; then
+        errors+=("Missing required field: $field")
+      fi
+    done
+
+    # Check scope is filled
+    scope=$(yq -r '.scope' "$SDD_FILE" 2>/dev/null || echo "")
+    if [[ -z "$scope" ]] || [[ "$scope" == *"What to build"* ]]; then
+      errors+=("Scope is empty or still contains template placeholder")
+    fi
+
+    # Check acceptance criteria exist
+    ac_count=$(yq -r '.acceptance_criteria | length' "$SDD_FILE" 2>/dev/null || echo "0")
+    if (( ac_count == 0 )); then
+      errors+=("No acceptance criteria defined")
+    else
+      # Check for empty criteria
+      empty_ac=$(yq -r '.acceptance_criteria[] | select(.criterion == "") | .criterion' "$SDD_FILE" 2>/dev/null | wc -l)
+      if (( empty_ac > 0 )); then
+        warnings+=("$empty_ac acceptance criteria have empty descriptions")
+      fi
+    fi
+
+    # Check test requirements
+    test_count=$(yq -r '.test_requirements | length' "$SDD_FILE" 2>/dev/null || echo "0")
+    if (( test_count == 0 )); then
+      warnings+=("No test requirements defined")
+    fi
+
+    # Check constraints
+    lang=$(yq -r '.constraints.language' "$SDD_FILE" 2>/dev/null || echo "")
+    if [[ -z "$lang" ]] || [[ "$lang" == "null" ]]; then
+      warnings+=("No language specified in constraints")
+    fi
+
+    # Check constitution
+    for check in code_standards commit_conventions no_hardcoded_secrets tests_sufficient; do
+      val=$(yq -r ".constitution_check.${check}" "$SDD_FILE" 2>/dev/null || echo "false")
+      if [[ "$val" != "true" ]]; then
+        warnings+=("Constitution check not confirmed: $check")
+      fi
+    done
+
+  else
+    warnings+=("yq not installed — YAML deep validation skipped (install: brew install yq)")
+    # Basic check: file is valid YAML
+    if command -v python3 >/dev/null 2>&1; then
+      if ! python3 -c "import yaml; yaml.safe_load(open('$SDD_FILE'))" 2>/dev/null; then
+        errors+=("File is not valid YAML")
+      fi
+    fi
+  fi
+
+else
+  # Markdown validation
+  # Check frontmatter fields
+  for field in id fd title status; do
+    if ! grep -q "^${field}:" "$SDD_FILE"; then
+      errors+=("Missing frontmatter field: $field")
+    fi
+  done
+
+  # Check sections exist
+  for section in "## Scope" "## Interfaces" "## Constraints" "## Test Requirements" "## Acceptance Criteria" "## Work Log"; do
+    if ! grep -q "$section" "$SDD_FILE"; then
+      errors+=("Missing section: $section")
+    fi
+  done
+
+  # Check acceptance criteria have content
+  ac_count=$(grep -c '^\- \[ \]' "$SDD_FILE" 2>/dev/null || echo "0")
+  if (( ac_count == 0 )); then
+    errors+=("No acceptance criteria defined (no checkboxes found)")
+  fi
+
+  # Check for template placeholders still present
+  if grep -q '{{.*}}' "$SDD_FILE"; then
+    placeholders=$(grep -c '{{.*}}' "$SDD_FILE")
+    warnings+=("$placeholders template placeholders still present")
+  fi
+
+  # Check scope has content (not just comments)
+  scope_content=$(sed -n '/^## Scope/,/^## /{/^## /d;/^<!--/d;/^$/d;p;}' "$SDD_FILE" 2>/dev/null | wc -l)
+  if (( scope_content == 0 )); then
+    errors+=("Scope section is empty")
+  fi
+fi
+
+# Report
+if (( ${#errors[@]} > 0 )); then
+  echo "ERRORS (must fix before execution):"
+  for e in "${errors[@]}"; do
+    echo "  ✗ $e"
+  done
+  echo ""
+fi
+
+if (( ${#warnings[@]} > 0 )); then
+  echo "WARNINGS (review recommended):"
+  for w in "${warnings[@]}"; do
+    echo "  ⚠ $w"
+  done
+  echo ""
+fi
+
+if (( ${#errors[@]} == 0 )) && (( ${#warnings[@]} == 0 )); then
+  echo "✓ SDD is valid and ready for execution"
+  exit 0
+elif (( ${#errors[@]} == 0 )); then
+  echo "✓ SDD is valid with ${#warnings[@]} warning(s)"
+  exit 0
+else
+  echo "✗ SDD has ${#errors[@]} error(s) — fix before execution"
+  exit 1
+fi

--- a/modules/vault-template/config.toml
+++ b/modules/vault-template/config.toml
@@ -30,6 +30,16 @@ max_iterations = 100
 # Port for OpenHands UI (0 = no UI, headless)
 ui_port = 3000
 
+[beads]
+# Beads (bd) task tracker integration
+enabled = true
+# Auto-create bd epic + tasks when SDDs are generated
+auto_create_tasks = true
+# Auto-close bd tasks when SDD execution completes
+auto_close_tasks = true
+# Use bd ready for dependency-aware batch execution
+dependency_aware_batch = true
+
 [watcher]
 # Auto-execute SDDs when they appear in the vault
 enabled = false

--- a/modules/vault-template/fd/_templates/fd-template.md
+++ b/modules/vault-template/fd/_templates/fd-template.md
@@ -33,10 +33,45 @@ tags: []
 
 ## Architecture / Architettura
 
+<!-- EN: MANDATORY — This diagram must show where this feature integrates in the existing system.
+     Include: existing components (grey), new components (green), data flow, protocols.
+     This is NOT optional — /fd-review will REJECT the FD without a filled diagram. -->
+<!-- IT: OBBLIGATORIO — Questo diagramma deve mostrare dove si integra la feature nel sistema esistente.
+     Includere: componenti esistenti (grigio), nuovi componenti (verde), flusso dati, protocolli.
+     NON e' opzionale — /fd-review RIFIUTERA' il FD senza un diagramma compilato. -->
+
+### Integration Context / Contesto di Integrazione
+
 ```mermaid
 flowchart TD
-    A[Step 1] --> B[Step 2]
-    B --> C[Step 3]
+    subgraph existing ["Existing System / Sistema Esistente"]
+        A[Component A]
+        B[Component B]
+    end
+
+    subgraph new ["New / Nuovo"]
+        C[New Component]
+    end
+
+    A -->|protocol| C
+    C -->|protocol| B
+
+    style existing fill:#f0f0f0,stroke:#999
+    style new fill:#d4edda,stroke:#28a745
+```
+
+### Data Flow / Flusso Dati
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant NewComponent
+    participant ExistingService
+
+    User->>NewComponent: request
+    NewComponent->>ExistingService: call
+    ExistingService-->>NewComponent: response
+    NewComponent-->>User: result
 ```
 
 ## Interfaces / Interfacce

--- a/modules/vault-template/sdd/_templates/sdd-template.yaml
+++ b/modules/vault-template/sdd/_templates/sdd-template.yaml
@@ -1,0 +1,85 @@
+# Forgia SDD — YAML format (machine-parseable, auto-validatable)
+# Equivalent to sdd-template.md but structured for programmatic use.
+
+meta:
+  id: "{{SDD_ID}}"
+  fd: "{{FD_ID}}"
+  title: "{{TITLE}}"
+  status: planned          # planned | in-progress | done | blocked
+  agent: ""                # claude-code | openhands | manual
+  assigned_to: ""
+  created: "{{DATE}}"
+  started: ""
+  completed: ""
+  tags: []
+  bd_task_id: ""           # Beads task ID for cross-reference
+
+scope: |
+  What to build. Derived from the FD. Precise, unambiguous.
+  Cosa costruire. Derivato dal FD. Preciso, non ambiguo.
+
+interfaces:
+  - name: ""
+    type: ""               # trait | api | ipc | event | schema
+    description: ""
+    contract: ""           # type signature, endpoint path, schema ref
+
+constraints:
+  language: ""
+  framework: ""
+  dependencies: []
+  patterns: []             # builder, repository, event-driven, etc.
+  version_requirements: {} # e.g. { rust: "1.80+", node: "22+" }
+
+best_practices:
+  error_handling: ""
+  naming: ""
+  style: ""
+  # Loaded from .forgia/dev-guide/principles/ and lang/
+  principles_loaded: []    # auto-filled: [clean-code, solid, design-patterns]
+  lang_loaded: []          # auto-filled: [rust, python, etc.]
+
+test_requirements:
+  - type: unit
+    what: ""
+    coverage: ""
+  - type: integration
+    what: ""
+    coverage: ""
+  - type: e2e
+    what: ""
+    coverage: ""
+
+acceptance_criteria:
+  - criterion: ""
+    met: false
+  - criterion: ""
+    met: false
+
+context:
+  files_to_read: []
+  docs_to_consult: []
+  existing_code: []
+
+constitution_check:
+  code_standards: false
+  commit_conventions: false
+  no_hardcoded_secrets: false
+  tests_sufficient: false
+
+work_log:
+  executor: ""             # openhands | claude-code | manual | name
+  started: ""
+  completed: ""
+  duration: ""
+  decisions:
+    - what: ""
+      why: ""
+  output:
+    commits: []
+    pr: ""
+    files_changed: []
+  retrospective:
+    worked: ""
+    didnt_work: ""
+    suggestions: ""

--- a/tests/e2e-beads-autospec.sh
+++ b/tests/e2e-beads-autospec.sh
@@ -1,0 +1,443 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Forgia E2E Tests — Beads + AutoSpec integration
+# Run from repo root: ./tests/e2e-beads-autospec.sh
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORGIA="$ROOT_DIR/bin/forgia"
+TEST_DIR=$(mktemp -d)
+PASSED=0
+FAILED=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+# --- Helpers ---
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$haystack" | grep -q "$needle"; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    expected to contain: %s\n" "$needle"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_file_exists() {
+  local desc="$1" file="$2"
+  TOTAL=$((TOTAL + 1))
+  if [[ -f "$file" ]]; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    file not found: %s\n" "$file"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_file_contains() {
+  local desc="$1" needle="$2" file="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ -f "$file" ]] && grep -q "$needle" "$file"; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    file: %s, expected to contain: %s\n" "$file" "$needle"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_exit_code() {
+  local desc="$1" expected="$2"
+  shift 2
+  TOTAL=$((TOTAL + 1))
+  local actual
+  set +e
+  "$@" >/dev/null 2>&1
+  actual=$?
+  set -e
+  if [[ "$expected" == "$actual" ]]; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    expected exit code: %s, got: %s\n" "$expected" "$actual"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# --- Tests ---
+
+echo "=== Forgia E2E Tests — Beads + AutoSpec ==="
+echo "  Test dir: $TEST_DIR"
+echo ""
+
+cd "$TEST_DIR"
+git init --initial-branch=main -q
+
+# =====================================================
+echo "--- forgia init: config.toml scaffolding ---"
+# =====================================================
+
+"$FORGIA" init >/dev/null 2>&1
+
+assert_file_exists "creates config.toml" "$TEST_DIR/.forgia/config.toml"
+
+echo ""
+
+# =====================================================
+echo "--- config.toml: beads section ---"
+# =====================================================
+
+config="$TEST_DIR/.forgia/config.toml"
+config_content=$(cat "$config")
+
+assert_contains "config has [beads]" '\[beads\]' "$config_content"
+assert_contains "config has auto_create_tasks" 'auto_create_tasks' "$config_content"
+assert_contains "config has auto_close_tasks" 'auto_close_tasks' "$config_content"
+assert_contains "config has dependency_aware_batch" 'dependency_aware_batch' "$config_content"
+
+echo ""
+
+# =====================================================
+echo "--- config.toml: runner sections ---"
+# =====================================================
+
+assert_contains "config has [runner]" '\[runner\]' "$config_content"
+assert_contains "config has [runner.claude]" '\[runner.claude\]' "$config_content"
+assert_contains "config has [runner.openhands]" '\[runner.openhands\]' "$config_content"
+assert_contains "config has [watcher]" '\[watcher\]' "$config_content"
+assert_contains "config has worktree setting" 'worktree' "$config_content"
+assert_contains "config has auto_approve setting" 'auto_approve' "$config_content"
+assert_contains "config has max_turns setting" 'max_turns' "$config_content"
+assert_contains "config has openhands image" 'openhands' "$config_content"
+assert_contains "config has openhands model" 'model' "$config_content"
+assert_contains "config has watcher debounce" 'debounce' "$config_content"
+
+echo ""
+
+# =====================================================
+echo "--- YAML SDD template ---"
+# =====================================================
+
+assert_file_exists "yaml sdd template exists" "$ROOT_DIR/modules/vault-template/sdd/_templates/sdd-template.yaml"
+
+yaml_content=$(cat "$ROOT_DIR/modules/vault-template/sdd/_templates/sdd-template.yaml")
+
+assert_contains "yaml has meta section" 'meta:' "$yaml_content"
+assert_contains "yaml has meta.id" 'id:' "$yaml_content"
+assert_contains "yaml has meta.fd" 'fd:' "$yaml_content"
+assert_contains "yaml has meta.status" 'status:' "$yaml_content"
+assert_contains "yaml has scope" 'scope:' "$yaml_content"
+assert_contains "yaml has interfaces" 'interfaces:' "$yaml_content"
+assert_contains "yaml has constraints" 'constraints:' "$yaml_content"
+assert_contains "yaml has best_practices" 'best_practices:' "$yaml_content"
+assert_contains "yaml has test_requirements" 'test_requirements:' "$yaml_content"
+assert_contains "yaml has acceptance_criteria" 'acceptance_criteria:' "$yaml_content"
+assert_contains "yaml has context" 'context:' "$yaml_content"
+assert_contains "yaml has constitution_check" 'constitution_check:' "$yaml_content"
+assert_contains "yaml has work_log" 'work_log:' "$yaml_content"
+assert_contains "yaml has bd_task_id" 'bd_task_id:' "$yaml_content"
+assert_contains "yaml has principles_loaded" 'principles_loaded:' "$yaml_content"
+assert_contains "yaml has lang_loaded" 'lang_loaded:' "$yaml_content"
+assert_contains "yaml has retrospective" 'retrospective:' "$yaml_content"
+
+echo ""
+
+# =====================================================
+echo "--- validate-sdd.sh: exists and executable ---"
+# =====================================================
+
+assert_file_exists "validate-sdd.sh exists" "$ROOT_DIR/modules/runners/validate-sdd.sh"
+
+TOTAL=$((TOTAL + 1))
+if [[ -x "$ROOT_DIR/modules/runners/validate-sdd.sh" ]]; then
+  printf "  ${GREEN}PASS${NC} validate-sdd.sh is executable\n"
+  PASSED=$((PASSED + 1))
+else
+  printf "  ${RED}FAIL${NC} validate-sdd.sh is executable\n"
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+
+# =====================================================
+echo "--- validate-sdd.sh: markdown validation ---"
+# =====================================================
+
+# Empty SDD should fail
+cat > "$TEST_DIR/empty-sdd.md" <<'SDD'
+---
+---
+# Empty
+SDD
+
+assert_exit_code "empty SDD fails validation" 1 "$ROOT_DIR/modules/runners/validate-sdd.sh" "$TEST_DIR/empty-sdd.md"
+
+# Valid SDD should pass
+cat > "$TEST_DIR/valid-sdd.md" <<'SDD'
+---
+id: SDD-001
+fd: FD-001
+title: "Test SDD"
+status: planned
+---
+
+## Scope
+
+Build the API endpoint for user auth.
+
+## Interfaces / Interfacce
+
+| Interface | Type | Description |
+|-----------|------|-------------|
+| POST /auth | API | Login endpoint |
+
+## Constraints / Vincoli
+
+- Language: Rust
+- Framework: axum
+
+## Test Requirements
+
+| Type | What | Coverage |
+|------|------|----------|
+| Unit | Auth logic | 80% |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] POST /auth returns JWT
+- [ ] Invalid credentials return 401
+- [ ] Tests pass
+
+## Context / Contesto
+
+- [ ] `src/auth.rs`
+
+## Constitution Check
+
+- [x] Respects code standards
+- [x] No hardcoded secrets
+
+## Work Log / Diario di Lavoro
+
+### Agent
+- **Executor**: pending
+SDD
+
+assert_exit_code "valid SDD passes validation" 0 "$ROOT_DIR/modules/runners/validate-sdd.sh" "$TEST_DIR/valid-sdd.md"
+
+# SDD missing frontmatter fields
+cat > "$TEST_DIR/missing-fields.md" <<'SDD'
+---
+title: "No ID"
+---
+
+## Scope
+
+Something
+
+## Acceptance Criteria
+
+- [ ] criterion
+SDD
+
+output=$("$ROOT_DIR/modules/runners/validate-sdd.sh" "$TEST_DIR/missing-fields.md" 2>&1 || true)
+assert_contains "reports missing id" "id" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- validate-sdd.sh: nonexistent file ---"
+# =====================================================
+
+assert_exit_code "nonexistent file exits 1" 1 "$ROOT_DIR/modules/runners/validate-sdd.sh" "$TEST_DIR/nope.md"
+
+echo ""
+
+# =====================================================
+echo "--- forgia validate command ---"
+# =====================================================
+
+output=$("$FORGIA" 2>&1 || true)
+assert_contains "usage shows validate command" "validate" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- forgia validate: single file ---"
+# =====================================================
+
+assert_exit_code "validate valid SDD passes" 0 "$FORGIA" validate "$TEST_DIR/valid-sdd.md"
+assert_exit_code "validate empty SDD fails" 1 "$FORGIA" validate "$TEST_DIR/empty-sdd.md"
+
+echo ""
+
+# =====================================================
+echo "--- forgia validate: FD directory ---"
+# =====================================================
+
+mkdir -p "$TEST_DIR/.forgia/sdd/FD-TEST"
+cp "$TEST_DIR/valid-sdd.md" "$TEST_DIR/.forgia/sdd/FD-TEST/SDD-001-auth.md"
+assert_exit_code "validate FD directory passes" 0 "$FORGIA" validate "FD-TEST"
+
+cp "$TEST_DIR/empty-sdd.md" "$TEST_DIR/.forgia/sdd/FD-TEST/SDD-002-broken.md"
+assert_exit_code "validate FD directory with bad SDD fails" 1 "$FORGIA" validate "FD-TEST"
+
+echo ""
+
+# =====================================================
+echo "--- forgia exec: pre-validation ---"
+# =====================================================
+
+# exec should fail on invalid SDD (validation gate)
+output=$("$FORGIA" exec "$TEST_DIR/empty-sdd.md" 2>&1 || true)
+assert_contains "exec rejects invalid SDD" "validation failed" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- forgia batch: error on missing FD dir ---"
+# =====================================================
+
+assert_exit_code "batch on nonexistent FD exits 1" 1 "$FORGIA" batch "FD-NOPE"
+
+echo ""
+
+# =====================================================
+echo "--- forgia watch: requires fswatch ---"
+# =====================================================
+
+if ! command -v fswatch >/dev/null 2>&1; then
+  output=$("$FORGIA" watch "FD-001" 2>&1 || true)
+  assert_contains "watch warns about fswatch" "fswatch" "$output"
+fi
+
+echo ""
+
+# =====================================================
+echo "--- mise tasks: bd tasks exist ---"
+# =====================================================
+
+mise_content=$(cat "$ROOT_DIR/mise.toml")
+
+assert_contains "mise has bd:install" 'bd:install' "$mise_content"
+assert_contains "mise has bd:init" 'bd:init' "$mise_content"
+assert_contains "mise has bd:ready" 'bd:ready' "$mise_content"
+assert_contains "mise has bd:status" 'bd:status' "$mise_content"
+assert_contains "mise has sdd:exec" 'sdd:exec' "$mise_content"
+assert_contains "mise has sdd:batch" 'sdd:batch' "$mise_content"
+assert_contains "mise has sdd:watch" 'sdd:watch' "$mise_content"
+assert_contains "mise has sdd:validate" 'sdd:validate' "$mise_content"
+assert_contains "mise has tools:install" 'tools:install' "$mise_content"
+
+echo ""
+
+# =====================================================
+echo "--- forgia doctor: checks fswatch and yq ---"
+# =====================================================
+
+output=$("$FORGIA" doctor 2>&1)
+assert_contains "doctor checks fswatch" "fswatch" "$output"
+assert_contains "doctor checks yq" "yq" "$output"
+assert_contains "doctor checks beads" "beads" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- fd-sdd: beads integration in command ---"
+# =====================================================
+
+sdd_cmd=$(cat "$ROOT_DIR/modules/claude-commands/fd-sdd.md")
+assert_contains "fd-sdd mentions Beads" "Beads" "$sdd_cmd"
+assert_contains "fd-sdd mentions bd" "bd" "$sdd_cmd"
+assert_contains "fd-sdd mentions epic" "epic" "$sdd_cmd"
+
+echo ""
+
+# =====================================================
+echo "--- fd template: mandatory Mermaid ---"
+# =====================================================
+
+fd_tmpl=$(cat "$ROOT_DIR/modules/vault-template/fd/_templates/fd-template.md")
+assert_contains "fd template has Integration Context" "Integration Context" "$fd_tmpl"
+assert_contains "fd template has Data Flow" "Data Flow" "$fd_tmpl"
+assert_contains "fd template has sequenceDiagram" "sequenceDiagram" "$fd_tmpl"
+assert_contains "fd template has flowchart" "flowchart" "$fd_tmpl"
+assert_contains "fd template says MANDATORY" "OBBLIGATORIO" "$fd_tmpl"
+
+echo ""
+
+# =====================================================
+echo "--- fd-review: enforces Mermaid ---"
+# =====================================================
+
+review_cmd=$(cat "$ROOT_DIR/modules/claude-commands/fd-review.md")
+assert_contains "fd-review checks Integration Context" "Integration Context" "$review_cmd"
+assert_contains "fd-review checks Data Flow" "Data Flow" "$review_cmd"
+assert_contains "fd-review rejects placeholders" "NOT the default template" "$review_cmd"
+assert_contains "fd-review checks Mermaid syntax" "Mermaid syntax" "$review_cmd"
+
+echo ""
+
+# =====================================================
+echo "--- runners: session isolation ---"
+# =====================================================
+
+claude_runner=$(cat "$ROOT_DIR/modules/runners/claude.sh")
+assert_contains "claude runner has worktree isolation" "worktree" "$claude_runner"
+assert_contains "claude runner creates branch" "branch_name" "$claude_runner"
+assert_contains "claude runner session-isolated" "session-isolated" "$claude_runner"
+
+echo ""
+
+# =====================================================
+echo "--- README: prerequisites table ---"
+# =====================================================
+
+readme=$(cat "$ROOT_DIR/README.md")
+assert_contains "readme has Prerequisites section" "Prerequisites" "$readme"
+assert_contains "readme lists mise" "mise" "$readme"
+assert_contains "readme lists docker" "docker" "$readme"
+assert_contains "readme lists bd" "bd" "$readme"
+assert_contains "readme lists fswatch" "fswatch" "$readme"
+assert_contains "readme lists yq" "yq" "$readme"
+
+echo ""
+
+# =====================================================
+# Summary
+# =====================================================
+
+echo "=== Results ==="
+echo ""
+printf "  Total:  %d\n" "$TOTAL"
+printf "  ${GREEN}Passed: %d${NC}\n" "$PASSED"
+if (( FAILED > 0 )); then
+  printf "  ${RED}Failed: %d${NC}\n" "$FAILED"
+else
+  printf "  Failed: %d\n" "$FAILED"
+fi
+echo ""
+
+if (( FAILED > 0 )); then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL TESTS PASSED"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Integrates concepts from [Beads](https://github.com/steveyegge/beads) and [AutoSpec](https://github.com/ariel-frischer/autospec) into the Forgia framework, adding dependency-aware task tracking, machine-parseable SDD format, and automated validation.

### What's new

- **Beads (bd) integration** — dependency graph for SDD execution ordering. `forgia batch` respects task dependencies via `bd ready`. Auto-creates epics + subtasks when SDDs are generated. Auto-closes bd tasks on SDD completion. Complements `ops/` (which stays for manual operational tasks).

- **YAML SDD format** — machine-parseable alternative to Markdown. Both formats are supported. Enables programmatic validation before execution.

- **Validation gates** — `forgia validate` checks SDD completeness (required fields, acceptance criteria, scope, constitution checks). Pre-exec validation blocks execution of incomplete SDDs.

- **Session isolation** — Claude Code runner creates a git worktree per SDD, preventing context pollution between parallel executions. Each SDD gets a fresh session.

- **Mandatory Mermaid diagrams** — FD template now requires Integration Context (flowchart showing where the feature sits in the system) and Data Flow (sequence diagram). `/fd-review` strictly enforces this — placeholder diagrams are rejected.

- **Prerequisites management** — `forgia doctor` checks all tools (docker, bd, fswatch, yq). `mise run tools:install` installs optional dependencies. Prerequisites table in README.

### Commits

1. `8ad751f` — Beads integration (bd init, doctor, status, exec, /fd-sdd)
2. `a42778b` — YAML SDD template, validate-sdd.sh, session isolation
3. `87b6d01` — README rewrite (English, full feature docs)
4. `fae5a3a` — Mandatory Mermaid, prerequisites, tools:install
5. `cca5f7a` — E2E test suite (80 tests)

### Test plan (80/80 passing)

- [x] `forgia init` creates `config.toml` with `[beads]` section
- [x] Config has `auto_create_tasks`, `auto_close_tasks`, `dependency_aware_batch`
- [x] Config has `[runner]`, `[runner.claude]`, `[runner.openhands]`, `[watcher]`
- [x] Config has `worktree`, `auto_approve`, `max_turns`, `model`, `debounce` settings
- [x] YAML SDD template exists with all 17 required fields (meta, scope, interfaces, constraints, best_practices, test_requirements, acceptance_criteria, context, constitution_check, work_log, bd_task_id, principles_loaded, lang_loaded, retrospective)
- [x] `validate-sdd.sh` exists and is executable
- [x] Empty SDD fails validation
- [x] Valid SDD passes validation
- [x] Missing frontmatter fields are reported
- [x] Nonexistent file exits 1
- [x] `forgia validate` shows in usage
- [x] `forgia validate` passes valid SDD, fails empty SDD
- [x] `forgia validate FD-NNN` validates directory — passes all valid, fails with invalid
- [x] `forgia exec` rejects invalid SDD (pre-validation gate)
- [x] `forgia batch` exits 1 on missing FD directory
- [x] `forgia watch` warns about missing fswatch
- [x] Mise tasks: `bd:install`, `bd:init`, `bd:ready`, `bd:status`, `sdd:exec`, `sdd:batch`, `sdd:watch`, `sdd:validate`, `tools:install`
- [x] `forgia doctor` checks fswatch, yq, beads
- [x] `/fd-sdd` mentions Beads, bd, epic
- [x] FD template has mandatory Integration Context + Data Flow + sequenceDiagram + flowchart + OBBLIGATORIO
- [x] `/fd-review` enforces Integration Context, Data Flow, rejects placeholders, checks Mermaid syntax
- [x] Claude runner has worktree isolation, creates branch, session-isolated
- [x] README has Prerequisites section listing mise, docker, bd, fswatch, yq

---

**Base**: v0.5.0
**Inspired by**: [AutoSpec](https://github.com/ariel-frischer/autospec), [Beads](https://github.com/steveyegge/beads)
