### PR TITLE
fix: install.sh auto-adds forgia to PATH (#25)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Forgia Installer
+# Usage: git clone ... && cd forgia && ./install.sh [--no-interactive]
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+INTERACTIVE=true
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-interactive) INTERACTIVE=false ;;
+  esac
+done
+
+echo "=== Forgia Installer ==="
+echo ""
+
+# Sanity check
+if [[ ! -f "$REPO_DIR/bin/forgia" ]]; then
+  echo "Error: bin/forgia not found in $REPO_DIR" >&2
+  echo "  Make sure you're running this from the forgia repo root." >&2
+  exit 1
+fi
+
+# --- 1. Symlink forgia binary ---
+
+mkdir -p "$INSTALL_DIR"
+
+if [[ -e "$INSTALL_DIR/forgia" ]] && [[ ! -L "$INSTALL_DIR/forgia" ]]; then
+  echo "⚠ $INSTALL_DIR/forgia exists and is not a symlink."
+  if [[ "$INTERACTIVE" == "true" ]]; then
+    read -rp "  Overwrite? (y/N) " confirm
+    [[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+  else
+    echo "  Overwriting (--no-interactive)"
+  fi
+fi
+
+ln -sf "$REPO_DIR/bin/forgia" "$INSTALL_DIR/forgia"
+chmod +x "$REPO_DIR/bin/forgia"
+echo "✓ forgia linked: $INSTALL_DIR/forgia → $REPO_DIR/bin/forgia"
+
+# --- 2. Add to PATH automatically ---
+
+# Detect the right shell RC file
+detect_shell_rc() {
+  # Check $SHELL first (most reliable)
+  case "${SHELL:-}" in
+    */zsh)
+      [[ -f "$HOME/.zshrc" ]] && echo "$HOME/.zshrc" && return
+      echo "$HOME/.zshrc" && return  # create it
+      ;;
+    */bash)
+      [[ -f "$HOME/.bashrc" ]] && echo "$HOME/.bashrc" && return
+      [[ -f "$HOME/.bash_profile" ]] && echo "$HOME/.bash_profile" && return
+      echo "$HOME/.bashrc" && return
+      ;;
+  esac
+
+  # Fallback: check which files exist
+  [[ -f "$HOME/.zshrc" ]] && echo "$HOME/.zshrc" && return
+  [[ -f "$HOME/.bashrc" ]] && echo "$HOME/.bashrc" && return
+  [[ -f "$HOME/.profile" ]] && echo "$HOME/.profile" && return
+
+  echo ""
+}
+
+PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
+shell_rc=$(detect_shell_rc)
+
+if echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+  echo "✓ $INSTALL_DIR already in PATH"
+elif [[ -n "$shell_rc" ]]; then
+  # Check if already in RC file (don't duplicate)
+  if grep -qF '.local/bin' "$shell_rc" 2>/dev/null; then
+    echo "✓ PATH entry already in $shell_rc (restart shell to activate)"
+  else
+    if [[ "$INTERACTIVE" == "true" ]]; then
+      echo ""
+      echo "  $INSTALL_DIR is not in your PATH."
+      read -rp "  Add to $shell_rc? (Y/n) " confirm
+      if [[ ! "$confirm" =~ ^[Nn]$ ]]; then
+        echo "" >> "$shell_rc"
+        echo "# Forgia CLI" >> "$shell_rc"
+        echo "$PATH_LINE" >> "$shell_rc"
+        echo "✓ PATH added to $shell_rc"
+        # Source it for the current verification step
+        export PATH="$INSTALL_DIR:$PATH"
+      else
+        echo "  Skipped. Add manually:"
+        echo "    echo '$PATH_LINE' >> $shell_rc"
+      fi
+    else
+      # Non-interactive: just add it
+      echo "" >> "$shell_rc"
+      echo "# Forgia CLI" >> "$shell_rc"
+      echo "$PATH_LINE" >> "$shell_rc"
+      echo "✓ PATH added to $shell_rc (--no-interactive)"
+      export PATH="$INSTALL_DIR:$PATH"
+    fi
+  fi
+else
+  echo "⚠ Could not detect shell RC file. Add manually:"
+  echo "    $PATH_LINE"
+fi
+
+# --- 3. Install Claude Code commands ---
+
+if command -v mise >/dev/null 2>&1; then
+  echo ""
+  echo "→ Installing Claude Code commands..."
+  (cd "$REPO_DIR" && mise trust 2>/dev/null || true)
+  (cd "$REPO_DIR" && mise run claude:install) || echo "  ⚠ Failed (non-blocking)"
+
+  echo ""
+  echo "→ Installing optional tools (fswatch, yq)..."
+  (cd "$REPO_DIR" && mise run tools:install) || echo "  ⚠ Some tools failed (non-blocking)"
+else
+  echo ""
+  echo "⚠ mise not found — skipping Claude Code commands and tools"
+  echo "  Install mise: https://mise.jdx.dev"
+  echo "  Then run: cd $REPO_DIR && mise run claude:install"
+fi
+
+# --- 4. Verify ---
+
+echo ""
+echo "=== Verifying ==="
+
+if command -v forgia >/dev/null 2>&1; then
+  echo "✓ forgia is in PATH"
+else
+  echo "✗ forgia not found in PATH"
+  echo "  Restart your terminal, then try: forgia doctor"
+fi
+
+# --- 5. Summary ---
+
+echo ""
+echo "=== Installation Complete ==="
+echo ""
+echo "Next steps:"
+echo "  1. Open a new terminal (or: source $shell_rc)"
+echo "  2. cd /path/to/your/project"
+echo "  3. forgia init"
+echo "  4. forgia doctor"
+echo ""
+echo "First time? https://github.com/Deepzima/forgia#quick-start"


### PR DESCRIPTION
## Summary

Fixes #25 — install.sh now automatically adds `~/.local/bin` to PATH in the user's shell RC file, instead of just warning.

### What changed

| Before | After |
|--------|-------|
| Warns user to manually edit RC | Asks and appends automatically |
| No shell detection | Detects from `$SHELL` (zsh/bash) |
| No duplicate check | Checks `grep -qF '.local/bin'` before appending |
| No CI support | `--no-interactive` flag |
| No verification | Exports PATH and verifies `forgia` is reachable |

### Flow

```bash
./install.sh

=== Forgia Installer ===

✓ forgia linked: ~/.local/bin/forgia → /path/to/forgia/bin/forgia

  ~/.local/bin is not in your PATH.
  Add to ~/.zshrc? (Y/n) y
✓ PATH added to ~/.zshrc

→ Installing Claude Code commands...
✓ Comandi Claude Code installati

=== Verifying ===
✓ forgia is in PATH

=== Installation Complete ===

Next steps:
  1. Open a new terminal (or: source ~/.zshrc)
  2. cd /path/to/your/project
  3. forgia init
  4. forgia doctor
```

### Test plan

- [ ] Fresh install on macOS (zsh) — adds to `.zshrc`
- [ ] Fresh install on Linux (bash) — adds to `.bashrc`
- [ ] Re-run — detects duplicate, doesn't append twice
- [ ] `--no-interactive` — no prompts, auto-adds
- [ ] Existing non-symlink file — asks before overwriting
- [ ] `forgia` reachable after install without restarting terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)