### PR TITLE
feat: multi-engineer workflow phase 1 (#30)

### DIFF
--- a/bin/forgia
+++ b/bin/forgia
@@ -205,15 +205,51 @@ cmd_init() {
     echo "  Beads: not installed (optional — run: mise run bd:install)"
   fi
 
+  # .gitignore for .forgia/ (exclude local-only files)
+  if [[ ! -f "$VAULT_DIR/.gitignore" ]]; then
+    cat > "$VAULT_DIR/.gitignore" <<'GITIGNORE'
+# Local execution artifacts (not shared)
+logs/
+run/
+*.pid
+
+# Beads database (local, not portable)
+.beads/
+GITIGNORE
+    echo "  Created: .gitignore (excludes logs, run, beads)"
+  fi
+
+  # CODEOWNERS template (if .github/ exists)
+  if [[ -d ".github" ]] && [[ ! -f ".github/CODEOWNERS" ]]; then
+    local git_user
+    git_user=$(git config user.name 2>/dev/null || echo "MAINTAINER")
+    cat > ".github/CODEOWNERS" <<OWNERS
+# Forgia vault — protect critical files
+# Edit this file to match your team structure
+
+.forgia/constitution.md           @${git_user}
+.forgia/guardrails/               @${git_user}
+.forgia/architecture/             @${git_user}
+.forgia/contexts/                 @${git_user}
+.forgia/config.toml               @${git_user}
+.forgia/fd/                       *
+.forgia/sdd/                      *
+OWNERS
+    echo "  Created: .github/CODEOWNERS"
+  elif [[ ! -d ".github" ]]; then
+    echo "  Skipped: .github/CODEOWNERS (no .github/ directory)"
+  fi
+
   echo ""
   echo "✓ Vault scaffolded at $VAULT_DIR/"
   echo ""
   echo "Next steps:"
   echo "  1. Edit $VAULT_DIR/constitution.md with your project rules"
   echo "  2. Review $VAULT_DIR/dev-guide/lang/ conventions for your stack"
-  echo "  3. Use /fd-new to create your first Feature Design"
-  echo "  4. Use /fd-review to approve it"
-  echo "  5. Use /fd-sdd to generate execution specs"
+  echo "  3. Commit .forgia/ to share with your team"
+  echo "  4. Use /fd-new to create your first Feature Design"
+  echo "  5. Use /fd-review to approve it"
+  echo "  6. Use /fd-sdd to generate execution specs"
 }
 
 # --- status ---
@@ -233,11 +269,16 @@ cmd_status() {
   for fd in "$VAULT_DIR"/fd/FD-*.md; do
     [[ -f "$fd" ]] || continue
     fd_count=$((fd_count + 1))
-    local id title status
+    local id title status author
     id="$(grep '^id:' "$fd" | head -1 | sed 's/id: *//')"
     title="$(grep '^title:' "$fd" | head -1 | sed 's/title: *"*//;s/"*$//')"
     status="$(grep '^status:' "$fd" | head -1 | sed 's/status: *//')"
-    printf "  %-10s %-12s %s\n" "$id" "[$status]" "$title"
+    author="$(grep '^author:' "$fd" | head -1 | sed 's/author: *"*//;s/"*$//' || true)"
+    if [[ -n "$author" ]]; then
+      printf "  %-10s %-12s %-15s %s\n" "$id" "[$status]" "($author)" "$title"
+    else
+      printf "  %-10s %-12s %s\n" "$id" "[$status]" "$title"
+    fi
   done
   if (( fd_count == 0 )); then
     echo "  (no FDs yet — use /fd-new to create one)"

--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,33 @@
 # --- Test ---
 
 [tasks.test]
-description = "Run E2E tests"
-run = "{{config_root}}/tests/e2e.sh"
+description = "Run all E2E tests"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="{{config_root}}"
+failed=0
+
+for test_file in "$root"/tests/e2e*.sh; do
+  [[ -f "$test_file" ]] || continue
+  echo ""
+  echo "========================================="
+  echo "Running: $(basename "$test_file")"
+  echo "========================================="
+  if ! bash "$test_file"; then
+    failed=$((failed + 1))
+  fi
+done
+
+echo ""
+if (( failed > 0 )); then
+  echo "FAILED: $failed test suite(s) failed"
+  exit 1
+else
+  echo "ALL TEST SUITES PASSED"
+fi
+"""
 
 # --- Core tasks ---
 

--- a/modules/claude-commands/fd-new.md
+++ b/modules/claude-commands/fd-new.md
@@ -59,6 +59,7 @@ Create a new Feature Design (FD) in the Forgia vault.
    - `priority`: if from issue — "high" if labels contain "bug", else "medium"; if from description — "medium"
    - `effort`: "medium" (default)
    - `impact`: "medium" (default)
+   - `author`: detect automatically — try `git config user.name`, fallback to `gh api user --jq '.login'`, fallback to empty
    - `assignee`: from issue assignee if available, or empty
    - `created`: today's date
    - `reviewed`: false

--- a/modules/vault-template/fd/_templates/fd-template.md
+++ b/modules/vault-template/fd/_templates/fd-template.md
@@ -5,6 +5,7 @@ status: planned
 priority: medium
 effort: medium
 impact: medium
+author: "{{AUTHOR}}"
 assignee: ""
 created: "{{DATE}}"
 reviewed: false

--- a/tests/e2e-multi-eng.sh
+++ b/tests/e2e-multi-eng.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Forgia E2E Tests — Multi-Engineer Workflow
+# Run from repo root: ./tests/e2e-multi-eng.sh
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORGIA="$ROOT_DIR/bin/forgia"
+TEST_DIR=$(mktemp -d)
+PASSED=0
+FAILED=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+cleanup() {
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+# --- Helpers ---
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$haystack" | grep -q "$needle"; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    expected to contain: %s\n" "$needle"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_file_exists() {
+  local desc="$1" file="$2"
+  TOTAL=$((TOTAL + 1))
+  if [[ -f "$file" ]]; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    file not found: %s\n" "$file"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_file_contains() {
+  local desc="$1" needle="$2" file="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ -f "$file" ]] && grep -q "$needle" "$file"; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    file: %s, expected to contain: %s\n" "$file" "$needle"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_file_not_contains() {
+  local desc="$1" needle="$2" file="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ -f "$file" ]] && ! grep -q "$needle" "$file"; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    file: %s, expected NOT to contain: %s\n" "$file" "$needle"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [[ "$expected" == "$actual" ]]; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    expected: %s\n" "$expected"
+    printf "    actual:   %s\n" "$actual"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# --- Tests ---
+
+echo "=== Forgia E2E Tests — Multi-Engineer ==="
+echo "  Test dir: $TEST_DIR"
+echo ""
+
+cd "$TEST_DIR"
+git init --initial-branch=main -q
+git config user.name "TestUser"
+git config user.email "test@example.com"
+
+# =====================================================
+echo "--- forgia init: .gitignore ---"
+# =====================================================
+
+"$FORGIA" init >/dev/null 2>&1
+
+assert_file_exists "creates .forgia/.gitignore" "$TEST_DIR/.forgia/.gitignore"
+
+gitignore_content=$(cat "$TEST_DIR/.forgia/.gitignore")
+assert_contains "gitignore excludes logs/" "logs/" "$gitignore_content"
+assert_contains "gitignore excludes run/" "run/" "$gitignore_content"
+assert_contains "gitignore excludes *.pid" '*.pid' "$gitignore_content"
+assert_contains "gitignore excludes .beads/" ".beads/" "$gitignore_content"
+
+echo ""
+
+# =====================================================
+echo "--- forgia init: .gitignore not overwritten ---"
+# =====================================================
+
+echo "# custom" > "$TEST_DIR/.forgia/.gitignore"
+"$FORGIA" init <<< "y" >/dev/null 2>&1
+
+custom_content=$(cat "$TEST_DIR/.forgia/.gitignore")
+assert_eq "gitignore not overwritten" "# custom" "$custom_content"
+
+echo ""
+
+# =====================================================
+echo "--- forgia init: CODEOWNERS (no .github/) ---"
+# =====================================================
+
+rm -rf .forgia
+"$FORGIA" init >/dev/null 2>&1
+
+TOTAL=$((TOTAL + 1))
+if [[ ! -f ".github/CODEOWNERS" ]]; then
+  printf "  ${GREEN}PASS${NC} %s\n" "no CODEOWNERS when .github/ missing"
+  PASSED=$((PASSED + 1))
+else
+  printf "  ${RED}FAIL${NC} %s\n" "no CODEOWNERS when .github/ missing"
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+
+# =====================================================
+echo "--- forgia init: CODEOWNERS (with .github/) ---"
+# =====================================================
+
+rm -rf .forgia
+mkdir -p .github
+"$FORGIA" init >/dev/null 2>&1
+
+assert_file_exists "creates CODEOWNERS" ".github/CODEOWNERS"
+
+co_content=$(cat ".github/CODEOWNERS")
+assert_contains "CODEOWNERS has constitution" "constitution.md" "$co_content"
+assert_contains "CODEOWNERS has guardrails" "guardrails/" "$co_content"
+assert_contains "CODEOWNERS has architecture" "architecture/" "$co_content"
+assert_contains "CODEOWNERS has fd/ open to all" '.forgia/fd/' "$co_content"
+assert_contains "CODEOWNERS uses git user" "TestUser" "$co_content"
+
+echo ""
+
+# =====================================================
+echo "--- forgia init: CODEOWNERS not overwritten ---"
+# =====================================================
+
+echo "# custom owners" > ".github/CODEOWNERS"
+rm -rf .forgia
+"$FORGIA" init >/dev/null 2>&1
+
+custom_co=$(cat ".github/CODEOWNERS")
+assert_eq "CODEOWNERS not overwritten" "# custom owners" "$custom_co"
+
+echo ""
+
+# =====================================================
+echo "--- FD template: author field ---"
+# =====================================================
+
+fd_template=$(cat "$TEST_DIR/.forgia/fd/_templates/fd-template.md")
+assert_contains "FD template has author field" "author:" "$fd_template"
+assert_contains "FD template has author placeholder" '{{AUTHOR}}' "$fd_template"
+
+echo ""
+
+# =====================================================
+echo "--- forgia status: shows author ---"
+# =====================================================
+
+cat > "$TEST_DIR/.forgia/fd/FD-001-test.md" <<'FD'
+---
+id: "FD-001"
+title: "Test Feature"
+status: planned
+author: "ferruvich"
+---
+FD
+
+output=$("$FORGIA" status 2>&1)
+assert_contains "status shows author" "ferruvich" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- forgia status: no author graceful ---"
+# =====================================================
+
+cat > "$TEST_DIR/.forgia/fd/FD-002-no-author.md" <<'FD'
+---
+id: "FD-002"
+title: "No Author Feature"
+status: planned
+---
+FD
+
+output=$("$FORGIA" status 2>&1)
+assert_contains "status shows FD without author" "FD-002" "$output"
+assert_contains "status shows title without author" "No Author Feature" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- .gitignore: logs excluded from git ---"
+# =====================================================
+
+mkdir -p "$TEST_DIR/.forgia/logs"
+echo "test log" > "$TEST_DIR/.forgia/logs/test.log"
+git add .forgia/ 2>/dev/null || true
+git_status=$(git status --short .forgia/logs/ 2>/dev/null)
+TOTAL=$((TOTAL + 1))
+# logs/ should not appear in git status (ignored)
+if [[ -z "$git_status" ]] || echo "$git_status" | grep -q '!!'; then
+  printf "  ${GREEN}PASS${NC} %s\n" "logs/ excluded from git tracking"
+  PASSED=$((PASSED + 1))
+else
+  printf "  ${RED}FAIL${NC} %s\n" "logs/ excluded from git tracking"
+  printf "    git status: %s\n" "$git_status"
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+
+# =====================================================
+# Summary
+# =====================================================
+
+echo "=== Results ==="
+echo ""
+printf "  Total:  %d\n" "$TOTAL"
+printf "  ${GREEN}Passed: %d${NC}\n" "$PASSED"
+if (( FAILED > 0 )); then
+  printf "  ${RED}Failed: %d${NC}\n" "$FAILED"
+else
+  printf "  Failed: %d\n" "$FAILED"
+fi
+echo ""
+
+if (( FAILED > 0 )); then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL TESTS PASSED"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

First step toward multi-engineer support. Makes `.forgia/` shareable via git with team conventions.

### Changes

- **`forgia init`**: generates `.forgia/.gitignore` (excludes `logs/`, `run/`, `.beads/`)
- **`forgia init`**: generates `.github/CODEOWNERS` template (if `.github/` exists) with git user as maintainer, `fd/` open to all
- **FD template**: added `author` field with `{{AUTHOR}}` placeholder
- **`/fd-new`**: auto-populates `author` from `git config user.name` or `gh api user`
- **`forgia status`**: shows `(author)` next to each FD
- Graceful handling when `author` field is missing (older FDs)

### Files changed

| File | Change |
|------|--------|
| `bin/forgia` | init: .gitignore + CODEOWNERS, status: show author |
| `modules/vault-template/fd/_templates/fd-template.md` | Added `author` field |
| `modules/claude-commands/fd-new.md` | Auto-populate author |
| `tests/e2e-multi-eng.sh` | 20 E2E tests |

### Test plan (20/20 passing)

- [x] `forgia init` creates `.forgia/.gitignore` with logs/, run/, *.pid, .beads/
- [x] `.gitignore` not overwritten on re-init
- [x] No CODEOWNERS when `.github/` doesn't exist
- [x] CODEOWNERS created with constitution, guardrails, architecture protected
- [x] CODEOWNERS uses git config user.name
- [x] CODEOWNERS not overwritten on re-init
- [x] FD template has `author` field with `{{AUTHOR}}` placeholder
- [x] `forgia status` shows author when present
- [x] `forgia status` handles FDs without author gracefully
- [x] `logs/` excluded from git tracking via .gitignore

Closes #30 (phase 1)