### PR TITLE
feat(#41): define Go interfaces for all internal packages

### DIFF
--- a/docs/functional-architecture.md
+++ b/docs/functional-architecture.md
@@ -154,6 +154,10 @@ stateDiagram-v2
 │   ├── lang/                        ← per-language conventions (auto-detected)
 │   └── *.md                         ← coding, commit, review conventions
 │
+├── learnings/                       ← feedback from closed FDs (committed)
+│   ├── FD-<hash>.yaml               ← failure modes, successful patterns, suggestions
+│   └── ...
+│
 ├── logs/                            ← gitignored
 │   ├── exec-<sdd>-<timestamp>.json  ← execution reports
 │   └── exec-<sdd>-<timestamp>.log   ← execution logs
@@ -443,7 +447,175 @@ Everything else is autonomous.
 | GitHub Action | On schedule or on issue label `forgia:fd` | CI-driven |
 | MCP tool | Another agent calls `forgia_next_fd()` | Agent-to-agent orchestration |
 
-## 9. Project Board Sync
+## 9. Feedback Loop — From Code Back to Architecture
+
+The critical missing piece: after code is produced, lessons learned must flow **back** to DDD documents, influencing future FDs. Without this, the architecture diverges from reality.
+
+### The Gap (today)
+
+```
+DDD → FD → SDD → Code → Work Log → STOP
+                                     ↑ feedback dies here
+```
+
+### The Complete Loop
+
+```mermaid
+flowchart TD
+    SDD_Done["SDD Done\n(Work Log filled)"] --> Verify["/fd-verify\n(all SDDs pass)"]
+
+    Verify --> Close["/fd-close FD-a3f2"]
+
+    Close --> Feedback["/fd-feedback FD-a3f2\n(NEW SKILL)"]
+
+    Feedback --> C1["Update contexts/\n(actual interfaces\nvs planned)"]
+    Feedback --> C2["Update architecture/\n(new containers,\nrevised quality attrs)"]
+    Feedback --> C3["Update glossary\n(new terms introduced)"]
+    Feedback --> C4["Write learning record\n(.forgia/learnings/\nfailure modes, patterns)"]
+
+    C1 & C2 & C3 & C4 --> Review["/arch-review\n(coherence check\nafter updates)"]
+
+    Review --> NextFD["Next FD proposal\n(gate reads updated\narchitecture + learnings)"]
+
+    style Feedback fill:#fff3cd,stroke:#ffc107
+    style C4 fill:#f3e5f5,stroke:#9c27b0
+    style Review fill:#f8d7da,stroke:#dc3545
+```
+
+### What `/fd-feedback` does
+
+New skill that runs after `/fd-close`. Reads all Work Logs of the closed FD and routes feedback to the right documents:
+
+| Work Log content | Routes to | Example |
+|-----------------|-----------|---------|
+| Interface was different than planned | `contexts/<name>.yaml` interfaces section | "CheckRisk takes position + account, not just position" |
+| New container/service introduced | `architecture/containers.yaml` | "Added Redis cache for session state" |
+| Technology decision changed | `architecture/technology-decisions.yaml` | "Switched from gRPC to HTTP for internal — simpler debugging" |
+| Latency/performance measured | `architecture/quality-attributes.yaml` | "Actual p99: 85ms (planned: 100ms) — margin OK" |
+| New term introduced | `architecture/glossary.yaml` | "BridgeTimeout: max wait for MT5 bridge response" |
+| Failure mode discovered | `.forgia/learnings/<fd-id>.yaml` (NEW) | "gRPC streaming caused memory leak under load" |
+| Pattern that worked well | `.forgia/learnings/<fd-id>.yaml` | "Builder pattern for config was clean and testable" |
+| Suggestion for future FDs | `.forgia/learnings/<fd-id>.yaml` | "Add integration test template to SDD for DB-dependent features" |
+
+### Learnings directory (new)
+
+```
+.forgia/
+  learnings/                        ← NEW: persisted knowledge from execution
+    FD-a3f2.yaml                    ← learnings from FD-a3f2
+    FD-b7c1.yaml                    ← learnings from FD-b7c1
+```
+
+```yaml
+# .forgia/learnings/FD-a3f2.yaml
+fd: FD-a3f2
+title: "Scaffold ZeroClaw + Tauri"
+closed: "2026-03-20"
+
+failure_modes:
+  - pattern: "gRPC streaming"
+    context: "Internal service communication"
+    outcome: "Memory leak under sustained load"
+    recommendation: "Use HTTP for internal, gRPC only for external"
+
+successful_patterns:
+  - pattern: "Builder pattern for config"
+    context: "Multi-field struct initialization"
+    outcome: "Clean, testable, extensible"
+
+suggestions:
+  - "Add DB integration test template to SDD for features with persistence"
+  - "Include load test acceptance criterion for any streaming interface"
+
+interface_corrections:
+  - context: "trading-engine"
+    interface: "CheckRisk"
+    planned: "check_risk(position) → approved/rejected"
+    actual: "check_risk(position, account) → RiskResult{approved, reason, limits}"
+
+new_terms:
+  - term: "BridgeTimeout"
+    meaning: "Max wait for MT5 bridge response before circuit breaker trips"
+```
+
+### How the Gate Intelligente uses learnings
+
+When a new FD is proposed, the gate reads `.forgia/learnings/` (Tier 3 Cold Memory):
+
+```mermaid
+flowchart LR
+    NewFD["Proposed FD-c4d5\nuses gRPC streaming"] --> Gate["Gate Intelligente"]
+
+    Gate --> ReadLearnings["Read learnings/FD-a3f2.yaml"]
+
+    ReadLearnings --> Match["MATCH: failure_mode\n'gRPC streaming → memory leak'"]
+
+    Match --> Block["STOP: FD-a3f2 found that gRPC streaming\ncauses memory leaks. Consider HTTP instead.\nSee: .forgia/learnings/FD-a3f2.yaml"]
+
+    style Block fill:#f8d7da,stroke:#dc3545
+    style Match fill:#fff3cd,stroke:#ffc107
+```
+
+### Complete lifecycle with feedback
+
+```mermaid
+stateDiagram-v2
+    [*] --> Architecture: /arch-init
+
+    Architecture --> FD: /fd-new
+    FD --> SDD: /fd-sdd (after /fd-review)
+    SDD --> Code: forgia exec/watch/batch
+    Code --> Verify: /fd-verify
+    Verify --> Close: /fd-close
+
+    Close --> FeedbackSkill: /fd-feedback (NEW)
+
+    state "Feedback Routing" as FeedbackSkill {
+        [*] --> ReadWorkLogs: Read all SDD Work Logs
+        ReadWorkLogs --> RouteContexts: Update contexts/ (interfaces)
+        ReadWorkLogs --> RouteArch: Update architecture/ (containers, QA)
+        ReadWorkLogs --> RouteLearnings: Write learnings/ (failure modes, patterns)
+        RouteContexts --> ArchReview
+        RouteArch --> ArchReview
+        RouteLearnings --> ArchReview
+        ArchReview: /arch-review (coherence)
+    }
+
+    FeedbackSkill --> Architecture: updated DDD docs
+    Architecture --> FD: next FD (informed by learnings)
+```
+
+### Skill definition
+
+```
+/fd-feedback FD-a3f2
+```
+
+| Attribute | Value |
+|-----------|-------|
+| Category | `architecture` |
+| Mode | `both` (slash command + MCP tool `forgia_fd_feedback`) |
+| Triggers | After `/fd-close` (can be called manually or auto-triggered) |
+| Reads | All SDD Work Logs for the closed FD |
+| Writes | `contexts/`, `architecture/`, `learnings/` |
+| Then runs | `/arch-review` to verify coherence |
+
+### Auto-trigger on `/fd-close`
+
+`/fd-close` should call `/fd-feedback` automatically:
+
+```
+/fd-close FD-a3f2
+  1. Archive FD with retrospective
+  2. → /fd-feedback FD-a3f2 (auto-triggered)
+       a. Read Work Logs
+       b. Route to contexts/architecture/learnings
+       c. Run /arch-review
+  3. Update board card → "Closed"
+  4. Done
+```
+
+## 10. Project Board Sync
 
 ```mermaid
 sequenceDiagram
@@ -558,6 +730,7 @@ skill.Registry
 | `/fd-sdd` | fd | both | #35 |
 | `/fd-verify` | fd | both | #17 |
 | `/fd-close` | fd | both | #29 |
+| `/fd-feedback` | architecture | both | #27 (feedback loop) |
 | `/fd-status` | fd | both | — |
 | `/arch-init` | architecture | both | #27 |
 | `/arch-review` | architecture | both | #27 |

--- a/docs/functional-architecture.md
+++ b/docs/functional-architecture.md
@@ -503,57 +503,92 @@ sequenceDiagram
     Forgia->>Board: update card with FD-c4d5 ID
 ```
 
-## 10. Skill Integration
+## 10. Skill System
 
-Skills are Claude Code slash commands that interact with the vault through the Go binary:
+A skill is any capability Forgia exposes — to humans (slash commands), to agents (MCP tools), or both. Three types:
 
 ```mermaid
-flowchart LR
-    subgraph skills ["Slash Commands"]
-        FDNew["/fd-new"]
-        FDDeep["/fd-deep"]
-        FDReview["/fd-review"]
-        FDSDD["/fd-sdd"]
-        FDVerify["/fd-verify"]
-        FDClose["/fd-close"]
-        ArchInit["/arch-init"]
-        ArchReview["/arch-review"]
-        ArchUpdate["/arch-update"]
-        Threat["/fd-threat-model"]
-        DryRun["/sdd-dry-run"]
+flowchart TD
+    subgraph types ["Skill Types"]
+        SC["SlashCommand\n(/fd-new, /fd-review)\nUser invokes explicitly"]
+        MT["MCPTool\n(forgia_blast_radius)\nAgent invokes directly"]
+        Both["Both\n(/arch-review + forgia_arch_review)\nSame Go logic, two entry points"]
     end
 
-    subgraph modes ["How they work"]
-        Direct["Direct: Claude reads .forgia/\nand executes instructions\n(current — slash command .md files)"]
-        MCP_Mode["MCP: Claude calls forgia tools\n(future — Go binary handles logic)"]
+    subgraph impl ["Implementation"]
+        Native["Native Skill\nGo logic in internal/"]
+        Composite["Composite Skill\nWraps external MCP provider\n+ adds Forgia logic"]
     end
 
-    skills --> Direct
-    skills -.->|"post Go rewrite"| MCP_Mode
+    SC --> Native
+    MT --> Native
+    MT --> Composite
+    Both --> Native
 
-    style skills fill:#fff3cd,stroke:#ffc107
-    style MCP_Mode fill:#d4edda,stroke:#28a745
+    subgraph providers ["Composite sources"]
+        CM["codebase-memory-mcp\nsearch_graph, detect_changes,\ntrace_call_path, get_architecture"]
+    end
+
+    Composite --> providers
+
+    style SC fill:#fff3cd,stroke:#ffc107
+    style MT fill:#cce5ff,stroke:#0d6efd
+    style Both fill:#d4edda,stroke:#28a745
+    style Composite fill:#f3e5f5,stroke:#9c27b0
 ```
 
-**Current (bash era)**: Skills are `.md` files with instructions. Claude reads them and executes using its own tools (Read, Write, Bash).
+### Skill Registry
 
-**Future (Go era)**: Skills call MCP tools (`forgia_fd_new`, `forgia_arch_review`). Logic is in Go, Claude just orchestrates.
+All skills register in a central `skill.Registry`. The MCP server and slash command installer both read from it:
 
-### Skill → Feature mapping
+```
+skill.Registry
+  ├── SlashCommands() → list of .md files to install
+  ├── MCPTools()      → list of MCP tool definitions to advertise
+  └── Get(name)       → execute skill logic
+```
 
-| Skill | Feature Issues | MCP Tool (future) |
-|-------|---------------|-------------------|
-| `/fd-new` | #30 (multi-eng), #29 (competitive) | `forgia_fd_new` |
-| `/fd-deep` | — (exists, 4 parallel agents) | `forgia_fd_deep` |
-| `/fd-review` | #18 (compliance scoring) | `forgia_fd_review` |
-| `/fd-sdd` | #35 (board sync) | `forgia_fd_sdd` |
-| `/fd-verify` | #17 (post-exec scan) | `forgia_fd_verify` |
-| `/fd-close` | #29 (reject) | `forgia_fd_close` |
-| `/arch-init` | #27 (DDD), #36 (codebase-memory) | `forgia_arch_init` |
-| `/arch-review` | #22, #36 | `forgia_arch_review` |
-| `/arch-update` | #27 | `forgia_arch_update` |
-| `/fd-threat-model` | #21 | `forgia_threat_model` |
-| `/sdd-dry-run` | #23, #36 | `forgia_dry_run` |
+### Slash Command Skills (user-facing)
+
+| Skill | Category | Mode | Issue |
+|-------|----------|------|-------|
+| `/fd-new` | fd | both | #29, #30 |
+| `/fd-deep` | fd | slash_command | — |
+| `/fd-review` | fd | both | #18 |
+| `/fd-sdd` | fd | both | #35 |
+| `/fd-verify` | fd | both | #17 |
+| `/fd-close` | fd | both | #29 |
+| `/fd-status` | fd | both | — |
+| `/arch-init` | architecture | both | #27 |
+| `/arch-review` | architecture | both | #27 |
+| `/arch-update` | architecture | both | #27 |
+| `/fd-threat-model` | design | both | #21 |
+| `/fd-arch-review` | design | both | #22 |
+| `/sdd-dry-run` | design | both | #23 |
+
+### Composite Skills (codebase-memory-mcp derived)
+
+These wrap external MCP provider tools with Forgia logic (guardrails check, context enrichment):
+
+| Skill | Provider Tool | Forgia adds | Used by |
+|-------|--------------|-------------|---------|
+| `forgia_search_code` | `search_graph` | Guardrails filter on results | Agent search |
+| `forgia_blast_radius` | `detect_changes` | Cross-check with bounded contexts | Gate intelligente |
+| `forgia_trace_calls` | `trace_call_path` | Validate context interface contracts | `/arch-review` |
+| `forgia_architecture` | `get_architecture` | Merge with existing architecture/ | `/arch-init` |
+| `forgia_dead_code` | `search_graph(dead_code)` | Filter by SDD scope | Cleanup |
+| `forgia_reindex` | `index_repository` | Trigger after exec | Post-exec |
+
+### Skill evolution
+
+```
+Today (bash):       .md file → Claude interprets → Read/Write/Bash
+Transition:         .md file → Claude calls forgia CLI → Go logic
+Future (MCP):       .md thin wrapper → forgia_tool() MCP call → Go logic
+                    Agent can also call MCP tool directly (no .md needed)
+```
+
+Slash commands stay for **explicit UX** and **context savings**. MCP tools exist for **agent-to-agent** calls.
 
 ## 11. Configuration Hierarchy
 

--- a/docs/go-architecture.md
+++ b/docs/go-architecture.md
@@ -1,0 +1,421 @@
+# Go Architecture — Explicit Component Design & Evolutionary Pattern
+
+> Architecture of the Forgia Go binary: how packages compose, how they evolve
+> from CLI to library to MCP server, and the dependency rules that keep it clean.
+
+## 1. The Three Faces of Forgia
+
+The same Go codebase serves three consumers. The `internal/` packages are the shared foundation:
+
+```mermaid
+flowchart TD
+    subgraph consumers ["Three Consumers"]
+        CLI["CLI\n(cobra commands)\nforgia init, status, exec"]
+        MCP["MCP Server\n(JSON-RPC over stdio)\nforgia mcp"]
+        Lib["Library\n(Go import)\nimport internal/vault"]
+    end
+
+    subgraph core ["internal/ (shared foundation)"]
+        Vault["vault/"]
+        Config["config/"]
+        Runner["runner/"]
+        Guard["guardrails/"]
+        SkillPkg["skill/"]
+        Board["board/"]
+        MCPPkg["mcp/"]
+        Process["process/"]
+        Beads["beads/"]
+        SCM["scm/"]
+    end
+
+    CLI --> core
+    MCP --> core
+    Lib --> core
+
+    style CLI fill:#fff3cd,stroke:#ffc107
+    style MCP fill:#d4edda,stroke:#28a745
+    style Lib fill:#cce5ff,stroke:#0d6efd
+    style core fill:#f0f0f0,stroke:#999
+```
+
+### CLI (oggi e sempre)
+
+```
+cmd/forgia/main.go → cmd/forgia/cmd/root.go → internal/*
+```
+
+User at the terminal. Cobra commands call internal packages. Input: flags + args. Output: stdout + exit code.
+
+### MCP Server (futuro prossimo)
+
+```
+cmd/forgia/cmd/mcp.go → internal/mcp/server.go → internal/*
+```
+
+Claude Code (o qualsiasi MCP client) si connette via stdio. Input: JSON-RPC tool calls. Output: JSON-RPC results. Stessi package interni del CLI.
+
+### Library (per tool esterni)
+
+```go
+import "github.com/Deepzima/forgia/internal/vault"
+
+v, _ := vault.Open(".")
+for fd := range v.FDs() {
+    fmt.Println(fd.ID, fd.Status)
+}
+```
+
+Any Go program can import the internal packages. Useful for CI, custom tools, integrations.
+
+## 2. Package Dependency Graph
+
+```mermaid
+flowchart TD
+    subgraph leaf ["Leaf packages (zero internal deps)"]
+        Config["config/"]
+        Guard["guardrails/"]
+        Board["board/"]
+        SCM["scm/"]
+        Process["process/"]
+        Beads["beads/"]
+    end
+
+    subgraph mid ["Mid-level (1 internal dep)"]
+        Vault["vault/\n(imports: nothing)"]
+        MCPPkg["mcp/\n(imports: nothing)"]
+        Runner["runner/\n(imports: vault)"]
+        SkillPkg["skill/\n(imports: mcp)"]
+    end
+
+    subgraph top ["Top-level (composition)"]
+        CMD["cmd/forgia/cmd/\n(imports: everything)"]
+    end
+
+    Runner -->|"uses vault.SDD"| Vault
+    SkillPkg -->|"uses mcp.ToolDefinition"| MCPPkg
+    CMD --> Runner
+    CMD --> Vault
+    CMD --> Config
+    CMD --> Guard
+    CMD --> SkillPkg
+    CMD --> MCPPkg
+    CMD --> Board
+    CMD --> SCM
+    CMD --> Process
+    CMD --> Beads
+
+    style leaf fill:#d4edda,stroke:#28a745
+    style mid fill:#fff3cd,stroke:#ffc107
+    style top fill:#f8d7da,stroke:#dc3545
+```
+
+### Dependency Rules
+
+1. **Leaf packages** import only stdlib — no internal deps
+2. **Mid-level packages** import at most 1 other internal package, never upward
+3. **`cmd/`** is the only package that composes everything — it's the wiring layer
+4. **No circular deps** — if A imports B, B never imports A
+5. **Interfaces defined where consumed** — runner defines what it needs from vault, not the other way around
+
+### Cross-package data flow
+
+```
+vault.GuardrailsRaw() → []byte → guardrails.Parse() → *Guardrails
+```
+
+Packages communicate via **data**, not imports. Vault returns raw bytes, guardrails parses them. No cross-dependency.
+
+## 3. Evolutionary Pattern
+
+Ogni package evolve attraverso 3 fasi:
+
+```mermaid
+flowchart LR
+    Phase1["Phase 1: Types\n(interfaces + structs)\nCompiles, no logic"]
+    Phase2["Phase 2: CLI\n(implementation)\nCobra commands work"]
+    Phase3["Phase 3: MCP\n(tool exposure)\nAgents can call it"]
+
+    Phase1 --> Phase2 --> Phase3
+
+    style Phase1 fill:#cce5ff,stroke:#0d6efd
+    style Phase2 fill:#fff3cd,stroke:#ffc107
+    style Phase3 fill:#d4edda,stroke:#28a745
+```
+
+### Stato attuale per package
+
+| Package | Phase 1 (Types) | Phase 2 (CLI) | Phase 3 (MCP) |
+|---------|:-:|:-:|:-:|
+| vault/ | ✅ | — | — |
+| config/ | ✅ | — | — |
+| runner/ | ✅ | — | — |
+| guardrails/ | ✅ | — | — |
+| mcp/ | ✅ | — | — |
+| skill/ | ✅ | — | — |
+| board/ | ✅ | — | — |
+| scm/ | ✅ | — | — |
+| process/ | ✅ | — | — |
+| beads/ | ✅ | — | — |
+
+### Phase 1 → Phase 2 (CLI implementation)
+
+For each package, the implementation follows:
+
+```go
+// Phase 1: interface only (current)
+type Vault interface {
+    ListFDs(ctx context.Context) ([]*FD, error)
+}
+
+// Phase 2: concrete implementation
+type fsVault struct {
+    dir string
+}
+
+func Open(dir string) (Vault, error) {
+    return &fsVault{dir: dir}, nil
+}
+
+func (v *fsVault) ListFDs(ctx context.Context) ([]*FD, error) {
+    // actual file reading logic
+}
+```
+
+Il CLI command wires everything:
+
+```go
+// cmd/forgia/cmd/status.go
+func runStatus(cmd *cobra.Command, args []string) error {
+    ctx := cmd.Context()
+    cfg, _ := config.LoadConfig(ctx, ".forgia")
+    v, _ := vault.Open(".forgia")
+
+    for fd := range v.FDs() {
+        fmt.Printf("%-10s %-12s %s\n", fd.ID, fd.Status, fd.Title)
+    }
+    return nil
+}
+```
+
+### Phase 2 → Phase 3 (MCP exposure)
+
+Lo stesso codice viene esposto come MCP tool:
+
+```go
+// internal/mcp/server.go
+func (s *Server) registerVaultTools() {
+    s.tools["forgia_status"] = func(ctx context.Context, params map[string]any) (any, error) {
+        fds, _ := s.vault.ListFDs(ctx)
+        return fds, nil
+    }
+}
+```
+
+E come skill:
+
+```go
+// Skill registration at startup
+registry.Register(&nativeSkill{
+    name:     "fd-status",
+    category: skill.CategoryFD,
+    mode:     skill.ModeBoth,
+    slashCmd: "modules/claude-commands/fd-status.md",
+    mcpTool:  &mcp.ToolDefinition{Name: "status", Description: "Show FD dashboard"},
+    execute:  func(ctx, params) (any, error) {
+        return s.vault.ListFDs(ctx)
+    },
+})
+```
+
+## 4. Package Responsibility Matrix
+
+```mermaid
+flowchart TD
+    subgraph what ["WHAT (domain logic)"]
+        Vault["vault/\nFD, SDD, Architecture\nread/write .forgia/"]
+        Guard["guardrails/\nDeny patterns\npre/post scan"]
+        SkillPkg["skill/\nSkill registry\nnative + composite"]
+    end
+
+    subgraph how ["HOW (infrastructure)"]
+        Config["config/\nTOML loading\nmerge priority"]
+        Runner["runner/\nExecution backends\nclaude, openhands"]
+        Process["process/\nSubprocess lifecycle\nspawn, kill, signals"]
+        MCPPkg["mcp/\nToolProvider interface\nJSON-RPC server"]
+    end
+
+    subgraph where ["WHERE (external)"]
+        Board["board/\nGitHub/GitLab Projects\ncard sync"]
+        SCM["scm/\nGit operations\nPR, issues"]
+        Beads["beads/\nLocal cache\ndependency graph"]
+    end
+
+    style what fill:#fff3cd,stroke:#ffc107
+    style how fill:#cce5ff,stroke:#0d6efd
+    style where fill:#d4edda,stroke:#28a745
+```
+
+| Layer | Packages | Changes when |
+|-------|----------|-------------|
+| **WHAT** (domain) | vault, guardrails, skill | Business rules change (new FD fields, new skill categories) |
+| **HOW** (infra) | config, runner, process, mcp | Technical decisions change (new runner, new MCP protocol) |
+| **WHERE** (external) | board, scm, beads | Integrations change (new board provider, new SCM) |
+
+**Rule**: WHAT never imports WHERE. HOW bridges them. `cmd/` wires everything.
+
+## 5. Interface Segregation
+
+Each package exposes the smallest possible interface:
+
+```go
+// vault/ — espone Vault (grande) ma i consumer usano subset
+type Vault interface {
+    FDs() iter.Seq[*FD]
+    ListFDs(ctx context.Context) ([]*FD, error)
+    GetFD(ctx context.Context, id string) (*FD, error)
+    CreateFD(ctx context.Context, fd *FD) error
+    // ... 15+ metodi
+}
+
+// runner/ — consuma solo *vault.SDD, non tutto Vault
+type Runner interface {
+    Execute(ctx context.Context, sdd *vault.SDD, opts ExecOptions) (*ExecResult, error)
+}
+// runner non importa vault.Vault — importa solo vault.SDD (il tipo concreto)
+
+// board/ — non importa vault affatto
+type ProjectBoard interface {
+    CreateCard(ctx context.Context, item BoardItem) (string, error)
+}
+// board lavora con BoardItem (suo tipo) — il cmd/ converte FD → BoardItem
+```
+
+### Il wiring layer (cmd/)
+
+```go
+// cmd/forgia/cmd/exec.go
+func runExec(cmd *cobra.Command, args []string) error {
+    ctx := cmd.Context()
+
+    // Load all dependencies
+    v, _ := vault.Open(".forgia")
+    cfg, _ := config.LoadConfig(ctx, ".forgia")
+    r, _ := runner.Resolve(cfg.Runner.Default)
+
+    // Read SDD from vault
+    sdd, _ := v.GetSDD(ctx, fdID, sddID)
+
+    // Check guardrails
+    raw, _ := v.GuardrailsRaw(ctx)
+    g, _ := guardrails.Parse(raw)
+    if violations := g.CheckFiles(ctx, sdd.Boundaries.WriteDirs); len(violations) > 0 {
+        return fmt.Errorf("guardrails violated: %v", violations)
+    }
+
+    // Execute
+    result, _ := r.Execute(ctx, sdd, runner.ExecOptions{...})
+
+    // Sync to board (optional)
+    if b, err := board.Resolve(cfg); err == nil {
+        b.UpdateCard(ctx, sdd.FD, map[string]any{"status": "done"})
+    }
+
+    return nil
+}
+```
+
+`cmd/` is the only place where packages meet. No package knows about the others (except runner → vault.SDD).
+
+## 6. Testing Strategy per Fase
+
+### Phase 1 (Types — attuale)
+
+```go
+// Verifica che i tipi compilano e le costanti esistono
+func TestFDStatusConstants(t *testing.T) {
+    statuses := []FDStatus{FDPlanned, FDApproved, FDRejected}
+    for _, s := range statuses {
+        assert.NotEmpty(t, s)
+    }
+}
+```
+
+### Phase 2 (CLI — prossima)
+
+```go
+// Test con filesystem reale (t.TempDir)
+func TestVaultOpen(t *testing.T) {
+    dir := t.TempDir()
+    setupTestVault(t, dir)  // crea .forgia/ con file noti
+
+    v, err := vault.Open(dir)
+    assert.NoError(t, err)
+
+    fds, _ := v.ListFDs(context.Background())
+    assert.Len(t, fds, 2)
+}
+```
+
+### Phase 3 (MCP — futura)
+
+```go
+// Test MCP JSON-RPC
+func TestMCPStatus(t *testing.T) {
+    v := newTestVault(t)
+    srv := mcp.NewServer(v)
+
+    result, err := srv.HandleToolCall(context.Background(), mcp.ToolCall{
+        Name: "forgia_status",
+    })
+    assert.NoError(t, err)
+    assert.Contains(t, result, "fds")
+}
+```
+
+## 7. Adding a New Capability (Checklist)
+
+Quando aggiungi una nuova feature (es. `/arch-init`):
+
+### Step 1: Types (internal/)
+
+```
+[ ] Definisci tipi in vault/ se toccano .forgia/ (es. Architecture struct)
+[ ] Definisci interfaccia nel package consumer (es. skill.Skill)
+[ ] go build ./... passa
+[ ] Test per i nuovi tipi
+```
+
+### Step 2: CLI (cmd/)
+
+```
+[ ] Implementa la logica nel package (es. vault.fsVault.GetArchitecture)
+[ ] Crea il cobra command (cmd/forgia/cmd/arch_init.go)
+[ ] Wiring nel command: vault + config + guardrails
+[ ] go test ./... passa
+[ ] E2E test (bash o Go)
+```
+
+### Step 3: MCP (internal/mcp/)
+
+```
+[ ] Registra il tool nel MCP server
+[ ] Registra la skill nel skill.Registry (mode: Both)
+[ ] Aggiorna il .md slash command come thin wrapper
+[ ] Test MCP tool call
+```
+
+### Step 4: Docs
+
+```
+[ ] Aggiorna functional-architecture.md §10 (skill table)
+[ ] Aggiorna go-integration-guide.md se pattern nuovo
+[ ] Aggiorna go-architecture.md §3 (phase table)
+```
+
+## References
+
+- [go-integration-guide.md](go-integration-guide.md) — code patterns, process management
+- [functional-architecture.md](functional-architecture.md) — system design, data model
+- [Go Standard Project Layout](https://github.com/golang-standards/project-layout)
+- [Effective Go](https://go.dev/doc/effective_go)
+- [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments)

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -1,0 +1,98 @@
+// Package beads provides a resilient client for the Beads (bd) task tracker.
+// Beads is ALWAYS optional — Forgia works 100% without it.
+// When available, it provides fast local caching and dependency graph.
+package beads
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+var (
+	// ErrBeadsUnavailable means bd is not installed or circuit breaker is open.
+	ErrBeadsUnavailable = errors.New("beads unavailable")
+
+	// ErrBeadsTimeout means a bd command timed out.
+	ErrBeadsTimeout = errors.New("beads call timed out")
+)
+
+// Client wraps bd CLI with timeout and graceful fallback.
+type Client struct {
+	available bool
+	timeout   time.Duration
+}
+
+// NewClient creates a beads client, checking availability.
+func NewClient() *Client {
+	bc := &Client{timeout: 5 * time.Second}
+
+	if _, err := exec.LookPath("bd"); err != nil {
+		bc.available = false
+		return bc
+	}
+
+	if isCircuitBreakerOpen() {
+		slog.Warn("beads circuit breaker is open — using fallback",
+			"fix", "mise run bd:reset")
+		bc.available = false
+		return bc
+	}
+
+	bc.available = true
+	return bc
+}
+
+// Available returns true if beads is usable.
+func (bc *Client) Available() bool {
+	return bc.available
+}
+
+// Call executes a bd command with timeout and fallback.
+func (bc *Client) Call(ctx context.Context, args ...string) (string, error) {
+	if !bc.available {
+		return "", ErrBeadsUnavailable
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, bc.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bd", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			slog.Warn("beads call timed out", "args", args)
+			return "", ErrBeadsTimeout
+		}
+		return "", fmt.Errorf("bd %v: %w", args, err)
+	}
+
+	return string(output), nil
+}
+
+// isCircuitBreakerOpen checks /tmp/ for open circuit breaker files.
+func isCircuitBreakerOpen() bool {
+	patterns := []string{
+		"/tmp/beads-dolt-circuit-*.json",
+		"/private/tmp/beads-dolt-circuit-*.json",
+	}
+	for _, pattern := range patterns {
+		matches, _ := filepath.Glob(pattern)
+		for _, f := range matches {
+			data, err := os.ReadFile(f)
+			if err != nil {
+				continue
+			}
+			if strings.Contains(string(data), `"state":"open"`) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/board/board.go
+++ b/internal/board/board.go
@@ -1,0 +1,42 @@
+// Package board provides a generic project board interface
+// (GitHub Projects, GitLab Boards, local fallback).
+// The board is the central authority for FD/SDD IDs and status.
+package board
+
+import "context"
+
+// ProjectBoard abstracts project management backends.
+type ProjectBoard interface {
+	// NextID generates a collision-proof ID for a new FD.
+	// This is the PRIMARY source for IDs when online.
+	// Offline fallback: vault.NewFDID() generates locally.
+	NextID(ctx context.Context, prefix string) (string, error)
+
+	// Card CRUD.
+	CreateCard(ctx context.Context, item BoardItem) (string, error)
+	UpdateCard(ctx context.Context, id string, fields map[string]any) error
+	MoveCard(ctx context.Context, id string, column string) error
+	GetCards(ctx context.Context, filter CardFilter) ([]BoardItem, error)
+
+	// Sync between vault and board.
+	SyncFromVault(ctx context.Context) error // push local state → board
+	SyncToVault(ctx context.Context) error   // pull board state → local
+}
+
+// BoardItem represents a card on the project board.
+type BoardItem struct {
+	ID       string            `json:"id"`
+	Title    string            `json:"title"`
+	Column   string            `json:"column"`
+	Assignee string            `json:"assignee,omitempty"`
+	Priority string            `json:"priority,omitempty"`
+	Labels   []string          `json:"labels,omitempty"`
+	Fields   map[string]string `json:"fields,omitempty"` // custom fields (duration, tokens)
+}
+
+// CardFilter for querying cards.
+type CardFilter struct {
+	Column   string
+	Assignee string
+	Label    string
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,2 +1,147 @@
 // Package config handles Forgia configuration loading and management.
+// Loads config.toml (team) + config.local.toml (personal override).
 package config
+
+import "context"
+
+// Config is the root configuration structure.
+type Config struct {
+	Runner    RunnerConfig    `toml:"runner"`
+	Board     BoardConfig     `toml:"board"`
+	MCP       MCPConfig       `toml:"mcp"`
+	Beads     BeadsConfig     `toml:"beads"`
+	Watcher   WatcherConfig   `toml:"watcher"`
+	Knowledge KnowledgeConfig `toml:"knowledge"`
+	Docker    DockerConfig    `toml:"docker"`
+}
+
+// RunnerConfig selects and configures execution backends.
+type RunnerConfig struct {
+	Default     string             `toml:"default"` // claude, openhands
+	Parallel    bool               `toml:"parallel"`
+	MaxParallel int                `toml:"max_parallel"`
+	Claude      ClaudeRunnerConfig `toml:"claude"`
+	OpenHands   OpenHandsConfig    `toml:"openhands"`
+}
+
+// ClaudeRunnerConfig configures the Claude Code runner.
+type ClaudeRunnerConfig struct {
+	PermissionMode  string `toml:"permission_mode"` // default, auto, bypassPermissions
+	MaxTurns        int    `toml:"max_turns"`
+	Sandbox         string `toml:"sandbox"` // none, native, docker
+	UseRTK          bool   `toml:"use_rtk"`
+	RTKTrackSavings bool   `toml:"rtk_track_savings"`
+
+	// Agent Teams.
+	TeamEnabled      bool   `toml:"team_enabled"`
+	TeamLeadModel    string `toml:"team_lead_model"`
+	TeamDefaultModel string `toml:"team_default_model"`
+	TeamMaxTeammates int    `toml:"team_max_teammates"`
+	TeamSandbox      string `toml:"team_sandbox"`
+}
+
+// OpenHandsConfig configures the OpenHands runner.
+type OpenHandsConfig struct {
+	Image          string `toml:"image"`
+	Model          string `toml:"model"`
+	WorkspaceMount string `toml:"workspace_mount"`
+	MaxIterations  int    `toml:"max_iterations"`
+	UIPort         int    `toml:"ui_port"`
+}
+
+// BoardConfig selects the project board backend.
+type BoardConfig struct {
+	Provider string            `toml:"provider"` // github, gitlab, local
+	GitHub   GitHubBoardConfig `toml:"github"`
+	GitLab   GitLabBoardConfig `toml:"gitlab"`
+}
+
+// GitHubBoardConfig for GitHub Projects.
+type GitHubBoardConfig struct {
+	ProjectNumber int    `toml:"project_number"`
+	Owner         string `toml:"owner"`
+}
+
+// GitLabBoardConfig for GitLab Boards.
+type GitLabBoardConfig struct {
+	ProjectID int `toml:"project_id"`
+	BoardID   int `toml:"board_id"`
+}
+
+// MCPConfig configures MCP provider chaining.
+type MCPConfig struct {
+	Providers map[string]MCPProviderConfig `toml:"providers"`
+}
+
+// MCPProviderConfig defines an MCP subprocess provider.
+type MCPProviderConfig struct {
+	Command        string   `toml:"command"`
+	Args           []string `toml:"args"`
+	Lazy           bool     `toml:"lazy"`
+	RestartOnCrash bool     `toml:"restart_on_crash"`
+	HealthCheck    string   `toml:"health_check"`
+	ExposeTools    []string `toml:"expose_tools"`
+	Namespace      string   `toml:"namespace"`
+}
+
+// BeadsConfig for local cache integration.
+type BeadsConfig struct {
+	Enabled              bool `toml:"enabled"`
+	AutoCreateTasks      bool `toml:"auto_create_tasks"`
+	AutoCloseTasks       bool `toml:"auto_close_tasks"`
+	DependencyAwareBatch bool `toml:"dependency_aware_batch"`
+}
+
+// WatcherConfig for forgia watch.
+type WatcherConfig struct {
+	Enabled  bool   `toml:"enabled"`
+	Path     string `toml:"path"`
+	Debounce int    `toml:"debounce"` // seconds
+}
+
+// KnowledgeConfig for Tier 3 knowledge layer.
+type KnowledgeConfig struct {
+	Provider  string `toml:"provider"` // codebase-memory-mcp
+	AutoIndex bool   `toml:"auto_index"`
+	AutoSync  bool   `toml:"auto_sync"`
+}
+
+// DockerConfig for sandbox container management via Engine API.
+type DockerConfig struct {
+	Host           string   `toml:"host"` // unix:///var/run/docker.sock, tcp://, ssh://
+	SandboxImage   string   `toml:"sandbox_image"`
+	NetworkAllow   []string `toml:"sandbox_network_allow"`
+	WorkspaceMount string   `toml:"sandbox_workspace_mount"`
+	ExtraMounts    []string `toml:"sandbox_extra_mounts"`
+}
+
+// LoadConfig reads config.toml + config.local.toml with merge.
+// Priority: CLI flags > env vars > config.local.toml > config.toml > defaults.
+func LoadConfig(ctx context.Context, vaultDir string) (*Config, error) {
+	// TODO: implement TOML loading + merge
+	_ = ctx // will be used for cancellation during file reads
+	return DefaultConfig(), nil
+}
+
+// DefaultConfig returns sensible defaults.
+func DefaultConfig() *Config {
+	return &Config{
+		Runner: RunnerConfig{
+			Default:     "claude",
+			MaxParallel: 3,
+			Claude: ClaudeRunnerConfig{
+				PermissionMode:   "default",
+				MaxTurns:         200,
+				Sandbox:          "none",
+				TeamEnabled:      false,
+				TeamLeadModel:    "sonnet",
+				TeamDefaultModel: "sonnet",
+				TeamMaxTeammates: 5,
+			},
+		},
+		Watcher: WatcherConfig{
+			Path:     ".forgia/sdd",
+			Debounce: 5,
+		},
+	}
+}

--- a/internal/guardrails/guardrails.go
+++ b/internal/guardrails/guardrails.go
@@ -1,2 +1,49 @@
 // Package guardrails implements validation and safety checks for SDD execution.
+// Reads deny.toml and enforces read/execute/write deny patterns.
 package guardrails
+
+import "context"
+
+// Guardrails holds the deny lists from deny.toml.
+type Guardrails struct {
+	Read    DenyList `toml:"read"`
+	Execute DenyList `toml:"execute"`
+	Write   DenyList `toml:"write"`
+}
+
+// DenyList contains glob patterns that are denied.
+type DenyList struct {
+	Patterns []string `toml:"patterns"`
+}
+
+// Violation records a guardrail breach.
+type Violation struct {
+	Type    string // read, execute, write
+	Pattern string // the pattern that matched
+	Target  string // the file or command that violated
+}
+
+// CheckFiles returns violations for files that match [write] or [read] patterns.
+func (g *Guardrails) CheckFiles(ctx context.Context, files []string) []Violation {
+	// TODO: implement glob matching
+	return nil
+}
+
+// CheckCommand returns a violation if the command matches [execute] patterns.
+func (g *Guardrails) CheckCommand(ctx context.Context, cmd string) *Violation {
+	// TODO: implement pattern matching
+	return nil
+}
+
+// ScanForSecrets checks file contents for API key / credential patterns.
+func (g *Guardrails) ScanForSecrets(ctx context.Context, files []string) []Violation {
+	// TODO: implement regex scanning (AKIA, sk-ant-, ghp_, etc.)
+	return nil
+}
+
+// Parse reads deny.toml from raw bytes.
+// Vault provides the raw bytes via GuardrailsRaw(), this package parses them.
+func Parse(data []byte) (*Guardrails, error) {
+	// TODO: implement TOML parsing
+	return &Guardrails{}, nil
+}

--- a/internal/guardrails/guardrails.go
+++ b/internal/guardrails/guardrails.go
@@ -23,8 +23,9 @@ type Violation struct {
 	Target  string // the file or command that violated
 }
 
-// CheckFiles returns violations for files that match [write] or [read] patterns.
-func (g *Guardrails) CheckFiles(ctx context.Context, files []string) []Violation {
+// CheckFilePaths returns violations for file paths that match [write] or [read] glob patterns.
+// This checks paths only — use ScanForSecrets to check file contents.
+func (g *Guardrails) CheckFilePaths(ctx context.Context, paths []string) []Violation {
 	// TODO: implement glob matching
 	return nil
 }

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -1,2 +1,110 @@
 // Package mcp implements the Model Context Protocol integration.
+// Forgia acts as both MCP server (serving Claude) and MCP client (chaining to providers).
 package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// ToolProvider abstracts any external tool source (MCP server, API, in-process).
+type ToolProvider interface {
+	// Name returns the provider identifier.
+	Name() string
+
+	// Tools returns the tool definitions this provider exposes.
+	Tools() []ToolDefinition
+
+	// Call invokes a tool and returns the result.
+	Call(ctx context.Context, tool string, params map[string]any) (any, error)
+
+	// Start initializes the provider (spawn subprocess, connect API).
+	Start(ctx context.Context) error
+
+	// Stop gracefully shuts down the provider.
+	Stop() error
+
+	// Healthy returns true if the provider is ready.
+	Healthy() bool
+}
+
+// ToolDefinition describes a tool exposed by a provider.
+type ToolDefinition struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+	Namespace   string         `json:"-"` // prefix when re-exposed (e.g., "forgia_code_")
+}
+
+// ProviderRegistry manages multiple ToolProviders with namespace routing.
+// Thread-safe — MCP server handles concurrent tool calls.
+type ProviderRegistry struct {
+	providers map[string]ToolProvider
+	mu        sync.RWMutex
+}
+
+// NewProviderRegistry creates an empty registry.
+func NewProviderRegistry() *ProviderRegistry {
+	return &ProviderRegistry{
+		providers: make(map[string]ToolProvider),
+	}
+}
+
+// Register adds a provider to the registry.
+func (r *ProviderRegistry) Register(p ToolProvider) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.providers[p.Name()] = p
+}
+
+// AllTools returns merged tool list from all providers with namespace prefix.
+func (r *ProviderRegistry) AllTools() []ToolDefinition {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var tools []ToolDefinition
+	for _, p := range r.providers {
+		for _, t := range p.Tools() {
+			t.Name = "forgia_" + t.Namespace + "_" + t.Name
+			tools = append(tools, t)
+		}
+	}
+	return tools
+}
+
+// Call routes a namespaced tool call to the right provider.
+// Parses "forgia_code_search_graph" → provider="code", tool="search_graph".
+func (r *ProviderRegistry) Call(ctx context.Context, tool string, params map[string]any) (any, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	namespace, toolName, err := parseNamespacedTool(tool)
+	if err != nil {
+		return nil, err
+	}
+
+	p, ok := r.providers[namespace]
+	if !ok {
+		return nil, fmt.Errorf("unknown provider namespace: %s", namespace)
+	}
+
+	return p.Call(ctx, toolName, params)
+}
+
+// parseNamespacedTool splits "forgia_code_search_graph" → ("code", "search_graph").
+func parseNamespacedTool(tool string) (namespace, name string, err error) {
+	const prefix = "forgia_"
+	if !strings.HasPrefix(tool, prefix) {
+		return "", "", fmt.Errorf("tool %q missing forgia_ prefix", tool)
+	}
+
+	rest := strings.TrimPrefix(tool, prefix)
+	idx := strings.Index(rest, "_")
+	if idx < 0 {
+		return "", "", fmt.Errorf("tool %q missing namespace separator", tool)
+	}
+
+	return rest[:idx], rest[idx+1:], nil
+}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -67,7 +67,7 @@ func (r *ProviderRegistry) AllTools() []ToolDefinition {
 	var tools []ToolDefinition
 	for _, p := range r.providers {
 		for _, t := range p.Tools() {
-			t.Name = "forgia_" + t.Namespace + "_" + t.Name
+			t.Name = ToolName(t.Namespace, t.Name)
 			tools = append(tools, t)
 		}
 	}
@@ -91,6 +91,12 @@ func (r *ProviderRegistry) Call(ctx context.Context, tool string, params map[str
 	}
 
 	return p.Call(ctx, toolName, params)
+}
+
+// ToolName builds a namespaced tool name: ToolName("code", "search_graph") → "forgia_code_search_graph".
+// Single source of truth for the naming convention — used by ProviderRegistry and CompositeSkill.
+func ToolName(namespace, tool string) string {
+	return "forgia_" + namespace + "_" + tool
 }
 
 // parseNamespacedTool splits "forgia_code_search_graph" → ("code", "search_graph").

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -1,0 +1,61 @@
+package mcp
+
+import (
+	"testing"
+)
+
+func TestToolName(t *testing.T) {
+	tests := []struct {
+		namespace string
+		tool      string
+		want      string
+	}{
+		{"code", "search_graph", "forgia_code_search_graph"},
+		{"code", "detect_changes", "forgia_code_detect_changes"},
+		{"custom", "my_tool", "forgia_custom_my_tool"},
+	}
+
+	for _, tt := range tests {
+		got := ToolName(tt.namespace, tt.tool)
+		if got != tt.want {
+			t.Errorf("ToolName(%q, %q) = %q, want %q", tt.namespace, tt.tool, got, tt.want)
+		}
+	}
+}
+
+func TestParseNamespacedTool(t *testing.T) {
+	tests := []struct {
+		tool      string
+		wantNS    string
+		wantName  string
+		wantError bool
+	}{
+		{"forgia_code_search_graph", "code", "search_graph", false},
+		{"forgia_code_detect_changes", "code", "detect_changes", false},
+		{"forgia_custom_my_tool", "custom", "my_tool", false},
+		{"forgia_ns_a_b_c", "ns", "a_b_c", false},
+
+		// Error cases.
+		{"search_graph", "", "", true},           // missing forgia_ prefix
+		{"forgia_nounderscoreafter", "", "", true}, // no separator after namespace
+		{"", "", "", true},                        // empty
+		{"other_prefix_tool", "", "", true},       // wrong prefix
+	}
+
+	for _, tt := range tests {
+		ns, name, err := parseNamespacedTool(tt.tool)
+		if tt.wantError {
+			if err == nil {
+				t.Errorf("parseNamespacedTool(%q) expected error, got ns=%q name=%q", tt.tool, ns, name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseNamespacedTool(%q) unexpected error: %v", tt.tool, err)
+			continue
+		}
+		if ns != tt.wantNS || name != tt.wantName {
+			t.Errorf("parseNamespacedTool(%q) = (%q, %q), want (%q, %q)", tt.tool, ns, name, tt.wantNS, tt.wantName)
+		}
+	}
+}

--- a/internal/process/signals.go
+++ b/internal/process/signals.go
@@ -1,0 +1,53 @@
+package process
+
+import (
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// ShutdownManager coordinates graceful shutdown of all processes.
+type ShutdownManager struct {
+	processes []*Process
+	cleanups  []func()
+	mu        sync.Mutex
+}
+
+// NewShutdownManager creates a shutdown manager.
+func NewShutdownManager() *ShutdownManager {
+	return &ShutdownManager{}
+}
+
+// Register adds a process to be killed on shutdown.
+func (sm *ShutdownManager) Register(p *Process) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.processes = append(sm.processes, p)
+}
+
+// OnCleanup adds a cleanup function to run on shutdown.
+func (sm *ShutdownManager) OnCleanup(fn func()) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.cleanups = append(sm.cleanups, fn)
+}
+
+// ListenAndShutdown blocks until SIGINT or SIGTERM, then kills all processes.
+func (sm *ShutdownManager) ListenAndShutdown() {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	<-sigCh
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	for _, p := range sm.processes {
+		_ = p.Kill()
+	}
+
+	for _, fn := range sm.cleanups {
+		fn()
+	}
+}

--- a/internal/process/spawn.go
+++ b/internal/process/spawn.go
@@ -1,0 +1,92 @@
+// Package process manages subprocess spawning, monitoring, and lifecycle.
+// Used by runners (claude, docker) and MCP providers (subprocess).
+package process
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// Process represents a managed subprocess.
+// Exported fields (Name, Cmd, Stdout, Stderr) are read-only for callers.
+// Internal state (done, err, cancel) is accessed via methods (Done, Err, Kill).
+type Process struct {
+	Name   string
+	Cmd    *exec.Cmd
+	Stdout io.ReadCloser
+	Stderr io.ReadCloser
+
+	done   chan struct{} // closed when process exits (safe for multiple readers)
+	err    error         // exit error, valid after done is closed
+	cancel context.CancelFunc
+}
+
+// Spawn starts a subprocess with monitoring.
+// The ctx controls the subprocess lifetime — cancelling ctx kills the process.
+func Spawn(ctx context.Context, name string, args ...string) (*Process, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	cmd := exec.CommandContext(ctx, name, args...)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("stdout pipe %s: %w", name, err)
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("stderr pipe %s: %w", name, err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("spawn %s: %w", name, err)
+	}
+
+	p := &Process{
+		Name:   name,
+		Cmd:    cmd,
+		Stdout: stdout,
+		Stderr: stderr,
+		done:   make(chan struct{}),
+		cancel: cancel,
+	}
+
+	// Monitor in background — close channel on exit (safe for multiple readers).
+	go func() {
+		p.err = cmd.Wait()
+		close(p.done)
+	}()
+
+	return p, nil
+}
+
+// Kill sends SIGTERM, waits 5s, then SIGKILL.
+// Safe to call from multiple goroutines (done channel uses close pattern).
+func (p *Process) Kill() error {
+	if p.Cmd.Process == nil {
+		return nil
+	}
+	_ = p.Cmd.Process.Signal(syscall.SIGTERM)
+	select {
+	case <-p.done:
+		return p.err
+	case <-time.After(5 * time.Second):
+		return p.Cmd.Process.Kill()
+	}
+}
+
+// Done returns a channel that is closed when the process exits.
+func (p *Process) Done() <-chan struct{} {
+	return p.done
+}
+
+// Err returns the exit error. Only valid after Done() is closed.
+func (p *Process) Err() error {
+	return p.err
+}

--- a/internal/process/spawn.go
+++ b/internal/process/spawn.go
@@ -20,31 +20,26 @@ type Process struct {
 	Stdout io.ReadCloser
 	Stderr io.ReadCloser
 
-	done   chan struct{} // closed when process exits (safe for multiple readers)
-	err    error         // exit error, valid after done is closed
-	cancel context.CancelFunc
+	done chan struct{} // closed when process exits (safe for multiple readers)
+	err  error         // exit error, valid after done is closed
 }
 
 // Spawn starts a subprocess with monitoring.
 // The ctx controls the subprocess lifetime — cancelling ctx kills the process.
 func Spawn(ctx context.Context, name string, args ...string) (*Process, error) {
-	ctx, cancel := context.WithCancel(ctx)
 	cmd := exec.CommandContext(ctx, name, args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		cancel()
 		return nil, fmt.Errorf("stdout pipe %s: %w", name, err)
 	}
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		cancel()
 		return nil, fmt.Errorf("stderr pipe %s: %w", name, err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		cancel()
 		return nil, fmt.Errorf("spawn %s: %w", name, err)
 	}
 
@@ -54,7 +49,6 @@ func Spawn(ctx context.Context, name string, args ...string) (*Process, error) {
 		Stdout: stdout,
 		Stderr: stderr,
 		done:   make(chan struct{}),
-		cancel: cancel,
 	}
 
 	// Monitor in background — close channel on exit (safe for multiple readers).

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,2 +1,60 @@
-// Package runner manages SDD execution via different backends.
+// Package runner manages SDD execution via different backends
+// (Claude Code host, Claude Code sandbox, OpenHands, Agent Teams).
 package runner
+
+import (
+	"context"
+	"time"
+
+	"github.com/Deepzima/forgia/internal/vault"
+)
+
+// Runner executes an SDD and returns structured results.
+type Runner interface {
+	// Name returns the runner identifier (claude, openhands).
+	Name() string
+
+	// Execute runs an SDD and returns the result.
+	Execute(ctx context.Context, sdd *vault.SDD, opts ExecOptions) (*ExecResult, error)
+}
+
+// ExecOptions configures a single execution.
+type ExecOptions struct {
+	PermissionMode string // default, auto, bypassPermissions
+	Sandbox        string // none, native, docker
+	MaxTurns       int
+	UseRTK         bool
+	SystemContext   string // constitution + guardrails + principles
+	TaskPrompt     string // the SDD task
+
+	// Agent Teams.
+	UseTeam   bool
+	LeadModel string
+	Model     string // teammate model
+}
+
+// ExecResult records what happened during execution.
+type ExecResult struct {
+	SDD              string    `json:"sdd"`
+	FD               string    `json:"fd"`
+	Runner           string    `json:"runner"`
+	Started          time.Time `json:"started"`
+	Completed        time.Time `json:"completed"`
+	DurationSecs     int       `json:"duration_seconds"`
+	ExitCode         int       `json:"exit_code"`
+	Status           string    `json:"status"` // success, failed, timeout
+	FilesCreated     []string  `json:"files_created,omitempty"`
+	FilesModified    []string  `json:"files_modified,omitempty"`
+	Commits          []string  `json:"commits,omitempty"`
+	TokensRaw        int       `json:"tokens_raw,omitempty"`
+	TokensCompressed int       `json:"tokens_compressed,omitempty"`
+	TokensSaved      int       `json:"tokens_saved,omitempty"`
+	Model            string    `json:"model,omitempty"`
+	TeamRole         string    `json:"team_role,omitempty"` // lead, teammate
+}
+
+// Resolve picks the right runner from config.
+func Resolve(runnerName string) (Runner, error) {
+	// TODO: implement runner resolution
+	return nil, nil
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -4,6 +4,7 @@ package runner
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Deepzima/forgia/internal/vault"
@@ -56,5 +57,5 @@ type ExecResult struct {
 // Resolve picks the right runner from config.
 func Resolve(runnerName string) (Runner, error) {
 	// TODO: implement runner resolution
-	return nil, nil
+	return nil, fmt.Errorf("runner.Resolve(%q): not yet implemented", runnerName)
 }

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -2,7 +2,10 @@
 // (GitHub via gh CLI, GitLab via glab CLI).
 package scm
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // SCM abstracts source control operations.
 type SCM interface {
@@ -33,5 +36,5 @@ type Issue struct {
 // Resolve detects the SCM backend from the current git remote.
 func Resolve(ctx context.Context) (SCM, error) {
 	// TODO: detect github.com vs gitlab.com from git remote URL
-	return nil, nil
+	return nil, fmt.Errorf("scm.Resolve: not yet implemented")
 }

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -1,0 +1,37 @@
+// Package scm provides a generic source control management interface
+// (GitHub via gh CLI, GitLab via glab CLI).
+package scm
+
+import "context"
+
+// SCM abstracts source control operations.
+type SCM interface {
+	// CreatePR creates a pull/merge request. Returns the PR URL.
+	CreatePR(ctx context.Context, title, body, branch string) (string, error)
+
+	// GetIssue fetches an issue by number.
+	GetIssue(ctx context.Context, number int) (*Issue, error)
+
+	// PostComment adds a comment to an issue/PR.
+	PostComment(ctx context.Context, issueNumber int, body string) error
+
+	// ListLabels returns labels on an issue.
+	ListLabels(ctx context.Context, issueNumber int) ([]string, error)
+}
+
+// Issue represents a GitHub/GitLab issue.
+type Issue struct {
+	Number    int      `json:"number"`
+	Title     string   `json:"title"`
+	Body      string   `json:"body"`
+	Labels    []string `json:"labels"`
+	Assignee  string   `json:"assignee"`
+	Milestone string   `json:"milestone"`
+	State     string   `json:"state"`
+}
+
+// Resolve detects the SCM backend from the current git remote.
+func Resolve(ctx context.Context) (SCM, error) {
+	// TODO: detect github.com vs gitlab.com from git remote URL
+	return nil, nil
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -1,2 +1,193 @@
-// Package skill manages Claude Code slash command installation and lifecycle.
+// Package skill manages the unified skill system.
+//
+// A skill is any capability Forgia exposes — to humans (slash commands),
+// to agents (MCP tools), or both. Skills come in three types:
+//
+//   - SlashCommand: user types /fd-new → Claude reads .md, calls Go logic
+//   - MCPTool: agent calls forgia_blast_radius → Go logic directly
+//   - Both: /arch-review (human) and forgia_arch_review (agent) share the same Go logic
+//
+// Skills can be "native" (implemented in Go) or "composite" (wrapping an
+// external MCP provider like codebase-memory-mcp with added Forgia logic).
 package skill
+
+import (
+	"context"
+
+	"github.com/Deepzima/forgia/internal/mcp"
+)
+
+// Category groups skills by domain.
+type Category string
+
+const (
+	CategoryFD           Category = "fd"
+	CategorySDD          Category = "sdd"
+	CategoryArchitecture Category = "architecture"
+	CategoryDesign       Category = "design"
+	CategoryKnowledge    Category = "knowledge" // codebase-memory-mcp derived
+)
+
+// Mode describes how a skill is invoked.
+type Mode string
+
+const (
+	ModeSlashCommand Mode = "slash_command" // user types /fd-new
+	ModeMCPTool      Mode = "mcp_tool"     // agent calls forgia_fd_new
+	ModeBoth         Mode = "both"         // available as both
+)
+
+// Skill is a capability Forgia exposes.
+type Skill interface {
+	// Metadata.
+	Name() string            // "fd-new", "blast-radius"
+	Description() string     // human-readable description
+	Category() Category      // fd, sdd, architecture, design, knowledge
+	Mode() Mode              // slash_command, mcp_tool, both
+
+	// Slash command support (nil if Mode == MCPTool).
+	SlashCommandFile() string // relative path: "modules/claude-commands/fd-new.md"
+
+	// MCP tool support (nil if Mode == SlashCommand).
+	MCPToolDef() *mcp.ToolDefinition
+
+	// Execute runs the skill's Go logic.
+	Execute(ctx context.Context, params map[string]any) (any, error)
+}
+
+// CompositeSkill wraps an external MCP provider tool with Forgia logic.
+// Example: forgia_blast_radius = codebase-memory detect_changes + guardrails check.
+type CompositeSkill struct {
+	name        string
+	description string
+	category    Category
+	mode        Mode
+
+	// The underlying provider tool to call.
+	ProviderName string // "codebase-memory"
+	ProviderTool string // "detect_changes"
+
+	// Pre/post processing hooks.
+	PreProcess  func(ctx context.Context, params map[string]any) (map[string]any, error)
+	PostProcess func(ctx context.Context, result any) (any, error)
+
+	// Provider registry for calling the underlying tool.
+	registry *mcp.ProviderRegistry
+}
+
+// Name returns the skill name.
+func (s *CompositeSkill) Name() string { return s.name }
+
+// Description returns the skill description.
+func (s *CompositeSkill) Description() string { return s.description }
+
+// Category returns the skill category.
+func (s *CompositeSkill) Category() Category { return s.category }
+
+// Mode returns the skill invocation mode.
+func (s *CompositeSkill) Mode() Mode { return s.mode }
+
+// SlashCommandFile returns empty — composite skills are MCP-only.
+func (s *CompositeSkill) SlashCommandFile() string { return "" }
+
+// MCPToolDef returns the MCP tool definition.
+func (s *CompositeSkill) MCPToolDef() *mcp.ToolDefinition {
+	return &mcp.ToolDefinition{
+		Name:        s.name,
+		Description: s.description,
+		Namespace:   "forgia",
+	}
+}
+
+// Execute calls the underlying provider tool with pre/post processing.
+func (s *CompositeSkill) Execute(ctx context.Context, params map[string]any) (any, error) {
+	// Pre-process (e.g., add guardrails context, filter params).
+	if s.PreProcess != nil {
+		var err error
+		params, err = s.PreProcess(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Call underlying provider.
+	result, err := s.registry.Call(ctx, "forgia_"+s.ProviderName+"_"+s.ProviderTool, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Post-process (e.g., enrich with bounded context info, check guardrails).
+	if s.PostProcess != nil {
+		return s.PostProcess(ctx, result)
+	}
+
+	return result, nil
+}
+
+// Registry manages all registered skills.
+type Registry struct {
+	skills map[string]Skill
+}
+
+// NewRegistry creates an empty skill registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		skills: make(map[string]Skill),
+	}
+}
+
+// Register adds a skill to the registry.
+func (r *Registry) Register(s Skill) {
+	r.skills[s.Name()] = s
+}
+
+// Get returns a skill by name.
+func (r *Registry) Get(name string) (Skill, bool) {
+	s, ok := r.skills[name]
+	return s, ok
+}
+
+// ByCategory returns all skills in a category.
+func (r *Registry) ByCategory(cat Category) []Skill {
+	var result []Skill
+	for _, s := range r.skills {
+		if s.Category() == cat {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// SlashCommands returns all skills that have a slash command.
+func (r *Registry) SlashCommands() []Skill {
+	var result []Skill
+	for _, s := range r.skills {
+		if s.Mode() == ModeSlashCommand || s.Mode() == ModeBoth {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// MCPTools returns all skills that have an MCP tool.
+func (r *Registry) MCPTools() []Skill {
+	var result []Skill
+	for _, s := range r.skills {
+		if s.Mode() == ModeMCPTool || s.Mode() == ModeBoth {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// MCPToolDefs returns MCP tool definitions for all MCP-capable skills.
+// Used by the MCP server to advertise available tools.
+func (r *Registry) MCPToolDefs() []mcp.ToolDefinition {
+	var defs []mcp.ToolDefinition
+	for _, s := range r.MCPTools() {
+		if def := s.MCPToolDef(); def != nil {
+			defs = append(defs, *def)
+		}
+	}
+	return defs
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -91,11 +91,13 @@ func (s *CompositeSkill) Mode() Mode { return s.mode }
 func (s *CompositeSkill) SlashCommandFile() string { return "" }
 
 // MCPToolDef returns the MCP tool definition.
+// NOTE: Namespace is set to the skill name here (not "forgia") because this definition
+// is returned directly to the MCP client, NOT passed through ProviderRegistry.AllTools()
+// which would double-prefix it as "forgia_forgia_<tool>".
 func (s *CompositeSkill) MCPToolDef() *mcp.ToolDefinition {
 	return &mcp.ToolDefinition{
 		Name:        s.name,
 		Description: s.description,
-		Namespace:   "forgia",
 	}
 }
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -111,7 +111,7 @@ func (s *CompositeSkill) Execute(ctx context.Context, params map[string]any) (an
 	}
 
 	// Call underlying provider.
-	result, err := s.registry.Call(ctx, "forgia_"+s.ProviderName+"_"+s.ProviderTool, params)
+	result, err := s.registry.Call(ctx, mcp.ToolName(s.ProviderName, s.ProviderTool), params)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vault/architecture.go
+++ b/internal/vault/architecture.go
@@ -1,0 +1,111 @@
+package vault
+
+// Architecture represents the C4 Level 1-2 system design.
+type Architecture struct {
+	SystemContext       *SystemContext       `yaml:"system_context"`
+	Containers          *Containers          `yaml:"containers"`
+	TechnologyDecisions *TechnologyDecisions `yaml:"technology_decisions"`
+	QualityAttributes   *QualityAttributes   `yaml:"quality_attributes"`
+	Constraints         *ArchConstraints     `yaml:"constraints"`
+	Glossary            []GlossaryTerm       `yaml:"glossary,omitempty"`
+}
+
+// SystemContext is C4 Level 1 — the system in its environment.
+type SystemContext struct {
+	Name        string   `yaml:"name"`
+	Description string   `yaml:"description"`
+	Actors      []Actor  `yaml:"actors,omitempty"`
+	External    []string `yaml:"external_systems,omitempty"`
+	Boundaries  struct {
+		Inside  []string `yaml:"inside"`
+		Outside []string `yaml:"outside"`
+	} `yaml:"boundaries"`
+}
+
+// Actor is a user or external system that interacts with the platform.
+type Actor struct {
+	Name string `yaml:"name"`
+	Type string `yaml:"type"` // human, system, service
+	Role string `yaml:"role"`
+}
+
+// Containers is C4 Level 2 — services, apps, databases.
+type Containers struct {
+	Items []Container `yaml:"containers"`
+}
+
+// Container is a deployable unit (service, app, database).
+type Container struct {
+	Name       string `yaml:"name"`
+	Technology string `yaml:"technology"`
+	Purpose    string `yaml:"purpose"`
+	Context    string `yaml:"context,omitempty"` // maps to bounded context
+}
+
+// TechnologyDecisions is the ADR master — choices that apply everywhere.
+type TechnologyDecisions struct {
+	Decisions []TechDecision `yaml:"decisions"`
+}
+
+// TechDecision records a technology choice with rationale.
+type TechDecision struct {
+	Area      string `yaml:"area"`
+	Choice    string `yaml:"choice"`
+	Rationale string `yaml:"rationale"`
+	ADR       string `yaml:"adr,omitempty"` // link to ADR file
+}
+
+// QualityAttributes defines non-functional requirements.
+type QualityAttributes struct {
+	Latency      string `yaml:"latency,omitempty"`
+	Availability string `yaml:"availability,omitempty"`
+	Security     string `yaml:"security,omitempty"`
+	Scalability  string `yaml:"scalability,omitempty"`
+}
+
+// ArchConstraints captures budget, team, timeline.
+type ArchConstraints struct {
+	Budget   string   `yaml:"budget,omitempty"`
+	Team     string   `yaml:"team,omitempty"`
+	Timeline string   `yaml:"timeline,omitempty"`
+	Other    []string `yaml:"other,omitempty"`
+}
+
+// GlossaryTerm defines a ubiquitous language term (DDD).
+type GlossaryTerm struct {
+	Term    string `yaml:"term"`
+	Meaning string `yaml:"meaning"`
+}
+
+// BoundedContext represents a DDD bounded context.
+type BoundedContext struct {
+	Name             string              `yaml:"name"`
+	Description      string              `yaml:"description"`
+	Responsibilities []string            `yaml:"responsibilities,omitempty"`
+	Language         []GlossaryTerm      `yaml:"ubiquitous_language,omitempty"`
+	Interfaces       []ContextInterface  `yaml:"interfaces,omitempty"`
+	Dependencies     ContextDependencies `yaml:"dependencies"`
+	Status           ContextStatus       `yaml:"status"`
+
+	// Internal.
+	FilePath string `yaml:"-"`
+}
+
+// ContextInterface defines a contract between bounded contexts.
+type ContextInterface struct {
+	With     string `yaml:"with"`
+	Protocol string `yaml:"protocol"`
+	Contract string `yaml:"contract"`
+}
+
+// ContextDependencies lists what depends on what.
+type ContextDependencies struct {
+	DependsOn   []string `yaml:"depends_on,omitempty"`
+	DependedBy  []string `yaml:"depended_by,omitempty"`
+}
+
+// ContextStatus tracks implementation progress.
+type ContextStatus struct {
+	FDCreated   bool `yaml:"fd_created"`
+	FDCompleted bool `yaml:"fd_completed"`
+}

--- a/internal/vault/fd.go
+++ b/internal/vault/fd.go
@@ -1,0 +1,77 @@
+package vault
+
+import (
+	"log/slog"
+	"time"
+)
+
+// FDStatus represents the lifecycle state of a Feature Design.
+type FDStatus string
+
+const (
+	FDPlanned    FDStatus = "planned"
+	FDApproved   FDStatus = "approved"
+	FDInProgress FDStatus = "in-progress"
+	FDComplete   FDStatus = "complete"
+	FDClosed     FDStatus = "closed"
+	FDRejected   FDStatus = "rejected"
+	FDAbandoned  FDStatus = "abandoned"
+)
+
+// FD represents a Feature Design.
+type FD struct {
+	ID             string   `yaml:"id"`
+	Title          string   `yaml:"title"`
+	Status         FDStatus `yaml:"status"`
+	Priority       string   `yaml:"priority"`
+	Effort         string   `yaml:"effort"`
+	Impact         string   `yaml:"impact"`
+	Author         string   `yaml:"author"`
+	Assignee       string   `yaml:"assignee,omitempty"`
+	Created        string   `yaml:"created"`
+	Reviewed       bool     `yaml:"reviewed"`
+	Reviewer       string   `yaml:"reviewer,omitempty"`
+	Tags           []string `yaml:"tags,omitempty"`
+	UpstreamIssue  string   `yaml:"upstream_issue,omitempty"`
+	CompetesWith   []string `yaml:"competes_with,omitempty"`
+	RejectedReason string   `yaml:"rejected_reason,omitempty"`
+	SupersededBy   string   `yaml:"superseded_by,omitempty"`
+
+	// Internal — not serialized.
+	FilePath string `yaml:"-"`
+}
+
+// LogValue controls how FD appears in slog output.
+// Only metadata is logged — never content.
+func (fd FD) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("id", fd.ID),
+		slog.String("status", string(fd.Status)),
+		slog.String("author", fd.Author),
+	)
+}
+
+// ExecProfile describes how this FD should be executed by Agent Teams.
+type ExecProfile struct {
+	LeadModel       string            `yaml:"lead_model"`
+	DefaultModel    string            `yaml:"default_model"`
+	TeammateModels  map[string]string `yaml:"teammate_models,omitempty"` // SDD ID → model
+	MaxTeammates    int               `yaml:"max_teammates"`
+	Sandbox         string            `yaml:"sandbox"`
+	EstimatedTokens int               `yaml:"estimated_tokens,omitempty"`
+}
+
+// DesignedBy records who designed this FD.
+type DesignedBy struct {
+	Human string `yaml:"human"`
+	Model string `yaml:"model"` // e.g., "claude-opus"
+	Mode  string `yaml:"mode"`  // "host" or "sandbox"
+}
+
+// ExecutedBy records how this FD was executed.
+type ExecutedBy struct {
+	Method    string     `yaml:"method"` // "agent-team", "sequential", "manual"
+	LeadModel string    `yaml:"lead_model,omitempty"`
+	StartedAt time.Time `yaml:"started_at,omitempty"`
+	Duration  string    `yaml:"duration,omitempty"`
+}

--- a/internal/vault/fd.go
+++ b/internal/vault/fd.go
@@ -37,6 +37,11 @@ type FD struct {
 	RejectedReason string   `yaml:"rejected_reason,omitempty"`
 	SupersededBy   string   `yaml:"superseded_by,omitempty"`
 
+	// Execution tracking.
+	ExecProfile *ExecProfile `yaml:"exec_profile,omitempty"`
+	DesignedBy  *DesignedBy  `yaml:"designed_by,omitempty"`
+	ExecutedBy  *ExecutedBy  `yaml:"executed_by,omitempty"`
+
 	// Internal — not serialized.
 	FilePath string `yaml:"-"`
 }

--- a/internal/vault/sdd.go
+++ b/internal/vault/sdd.go
@@ -14,6 +14,7 @@ const (
 	SDDInProgress SDDStatus = "in-progress"
 	SDDDone       SDDStatus = "done"
 	SDDFailed     SDDStatus = "failed"
+	SDDCancelled  SDDStatus = "cancelled"
 )
 
 // SDD represents a Spec-Driven Development execution spec.
@@ -31,7 +32,7 @@ type SDD struct {
 	BdTaskID   string    `yaml:"bd_task_id,omitempty"`
 	Complexity string    `yaml:"complexity,omitempty"` // low, medium, high → model routing
 
-	Scope       string           `yaml:"scope"`
+	Scope       string           `yaml:"scope"` // Free-form markdown — not parsed, passed to agent as-is
 	Interfaces  []SDDInterface   `yaml:"interfaces,omitempty"`
 	Constraints SDDConstraints   `yaml:"constraints"`
 	Boundaries  SDDBoundaries    `yaml:"boundaries,omitempty"`

--- a/internal/vault/sdd.go
+++ b/internal/vault/sdd.go
@@ -1,0 +1,124 @@
+package vault
+
+import (
+	"log/slog"
+	"time"
+)
+
+// SDDStatus represents the lifecycle state of an SDD.
+type SDDStatus string
+
+const (
+	SDDPlanned    SDDStatus = "planned"
+	SDDValidated  SDDStatus = "validated"
+	SDDInProgress SDDStatus = "in-progress"
+	SDDDone       SDDStatus = "done"
+	SDDFailed     SDDStatus = "failed"
+)
+
+// SDD represents a Spec-Driven Development execution spec.
+type SDD struct {
+	ID         string    `yaml:"id"`
+	FD         string    `yaml:"fd"`
+	Title      string    `yaml:"title"`
+	Status     SDDStatus `yaml:"status"`
+	Agent      string    `yaml:"agent,omitempty"`
+	AssignedTo string    `yaml:"assigned_to,omitempty"`
+	Created    string    `yaml:"created"`
+	Started    string    `yaml:"started,omitempty"`
+	Completed  string    `yaml:"completed,omitempty"`
+	Tags       []string  `yaml:"tags,omitempty"`
+	BdTaskID   string    `yaml:"bd_task_id,omitempty"`
+	Complexity string    `yaml:"complexity,omitempty"` // low, medium, high → model routing
+
+	Scope       string           `yaml:"scope"`
+	Interfaces  []SDDInterface   `yaml:"interfaces,omitempty"`
+	Constraints SDDConstraints   `yaml:"constraints"`
+	Boundaries  SDDBoundaries    `yaml:"boundaries,omitempty"`
+	TestReqs    []SDDTestReq     `yaml:"test_requirements,omitempty"`
+	Criteria    []SDDCriterion   `yaml:"acceptance_criteria,omitempty"`
+	Context     []string         `yaml:"context,omitempty"`
+	WorkLog     *WorkLog         `yaml:"work_log,omitempty"`
+
+	// Internal.
+	FilePath string `yaml:"-"`
+}
+
+// SDDInterface defines an input/output contract.
+type SDDInterface struct {
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type"`
+	Description string `yaml:"description"`
+	Contract    string `yaml:"contract,omitempty"`
+}
+
+// SDDConstraints captures language, framework, patterns.
+type SDDConstraints struct {
+	Language     string   `yaml:"language"`
+	Framework    string   `yaml:"framework,omitempty"`
+	Dependencies []string `yaml:"dependencies,omitempty"`
+	Patterns     []string `yaml:"patterns,omitempty"`
+}
+
+// SDDBoundaries defines file ownership for Agent Teams.
+type SDDBoundaries struct {
+	WriteDirs    []string `yaml:"write_dirs,omitempty"`
+	ForbiddenDirs []string `yaml:"forbidden_dirs,omitempty"`
+	MaxFiles     int      `yaml:"max_files_created,omitempty"`
+	MaxFileSize  int      `yaml:"max_file_size_kb,omitempty"`
+	BannedImports []string `yaml:"banned_imports,omitempty"`
+}
+
+// SDDTestReq specifies a test requirement.
+type SDDTestReq struct {
+	Type     string `yaml:"type"`     // unit, integration, e2e
+	What     string `yaml:"what"`
+	Coverage string `yaml:"coverage,omitempty"`
+}
+
+// SDDCriterion is a single acceptance criterion.
+type SDDCriterion struct {
+	Criterion string `yaml:"criterion"`
+	Met       bool   `yaml:"met"`
+}
+
+// WorkLog records execution details (mandatory).
+type WorkLog struct {
+	Executor     string        `yaml:"executor"`
+	StartedAt    time.Time     `yaml:"started,omitempty"`
+	CompletedAt  time.Time     `yaml:"completed,omitempty"`
+	Duration     string        `yaml:"duration,omitempty"`
+	Decisions    []Decision    `yaml:"decisions,omitempty"`
+	Output       WorkLogOutput `yaml:"output"`
+	Retrospective Retrospective `yaml:"retrospective"`
+}
+
+// Decision records a choice made during execution.
+type Decision struct {
+	What string `yaml:"what"`
+	Why  string `yaml:"why"`
+}
+
+// WorkLogOutput records what was produced.
+type WorkLogOutput struct {
+	Commits      []string `yaml:"commits,omitempty"`
+	PR           string   `yaml:"pr,omitempty"`
+	FilesChanged []string `yaml:"files_changed,omitempty"`
+}
+
+// Retrospective records lessons learned.
+type Retrospective struct {
+	Worked      string `yaml:"worked,omitempty"`
+	DidntWork   string `yaml:"didnt_work,omitempty"`
+	Suggestions string `yaml:"suggestions,omitempty"`
+}
+
+// LogValue controls slog output for SDD.
+func (sdd SDD) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("id", sdd.ID),
+		slog.String("fd", sdd.FD),
+		slog.String("status", string(sdd.Status)),
+		slog.String("complexity", sdd.Complexity),
+	)
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -1,3 +1,64 @@
 // Package vault provides read/write access to the .forgia/ directory structure
-// (FDs, SDDs, constitution, guardrails, Work Logs).
+// (FDs, SDDs, architecture, contexts, constitution, guardrails, Work Logs).
 package vault
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"iter"
+	"time"
+)
+
+// Vault manages the .forgia/ directory structure.
+type Vault interface {
+	// Init scaffolds .forgia/ in the current project.
+	Init(ctx context.Context, opts InitOptions) error
+
+	// FD operations.
+	FDs() iter.Seq[*FD]
+	ListFDs(ctx context.Context) ([]*FD, error)
+	GetFD(ctx context.Context, id string) (*FD, error)
+	CreateFD(ctx context.Context, fd *FD) error
+	UpdateFD(ctx context.Context, fd *FD) error
+
+	// SDD operations.
+	SDDs(fdID string) iter.Seq[*SDD]
+	ListSDDs(ctx context.Context, fdID string) ([]*SDD, error)
+	GetSDD(ctx context.Context, fdID, sddID string) (*SDD, error)
+	CreateSDD(ctx context.Context, sdd *SDD) error
+	UpdateSDD(ctx context.Context, sdd *SDD) error
+
+	// Architecture (C4/DDD).
+	GetArchitecture(ctx context.Context) (*Architecture, error)
+	ListContexts(ctx context.Context) ([]*BoundedContext, error)
+	GetContext(ctx context.Context, name string) (*BoundedContext, error)
+
+	// Read-only access — returns raw content, caller parses.
+	Constitution(ctx context.Context) (string, error)
+	GuardrailsRaw(ctx context.Context) ([]byte, error)
+
+	// Render YAML → MD for human review.
+	Render(ctx context.Context, yamlPath string) error
+}
+
+// Open opens an existing .forgia/ vault at the given directory.
+// Returns an error if the vault doesn't exist — use Init to create one.
+func Open(dir string) (Vault, error) {
+	// TODO: implement — verify .forgia/ exists, return concrete implementation
+	return nil, fmt.Errorf("vault.Open: not yet implemented")
+}
+
+// InitOptions configures vault scaffolding.
+type InitOptions struct {
+	ProjectName string
+	Author      string
+}
+
+// NewFDID generates a collision-proof hash-based ID locally.
+// This is the FALLBACK for offline use. When a ProjectBoard is available,
+// use board.NextID() instead — the board is the central ID authority (#35).
+func NewFDID(title, author string) string {
+	h := sha256.Sum256([]byte(title + time.Now().String() + author))
+	return fmt.Sprintf("FD-%x", h[:2])
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -7,10 +7,20 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"iter"
+	"strconv"
+	"sync/atomic"
 	"time"
 )
 
+// idCounter ensures unique IDs even when called in the same nanosecond.
+var idCounter atomic.Uint64
+
 // Vault manages the .forgia/ directory structure.
+//
+// This interface is intentionally large (17 methods) because almost all callers
+// (CLI commands, MCP server) need both read and write access. Splitting into
+// VaultReader/VaultWriter is deferred until implementation reveals actual usage
+// patterns — then we refactor based on real data, not speculation.
 type Vault interface {
 	// Init scaffolds .forgia/ in the current project.
 	Init(ctx context.Context, opts InitOptions) error
@@ -59,6 +69,7 @@ type InitOptions struct {
 // This is the FALLBACK for offline use. When a ProjectBoard is available,
 // use board.NextID() instead — the board is the central ID authority (#35).
 func NewFDID(title, author string) string {
-	h := sha256.Sum256([]byte(title + time.Now().String() + author))
+	n := idCounter.Add(1)
+	h := sha256.Sum256([]byte(title + time.Now().String() + author + strconv.FormatUint(n, 10)))
 	return fmt.Sprintf("FD-%x", h[:2])
 }

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -37,7 +37,7 @@ func TestFDStatusConstants(t *testing.T) {
 
 func TestSDDStatusConstants(t *testing.T) {
 	statuses := []SDDStatus{
-		SDDPlanned, SDDValidated, SDDInProgress, SDDDone, SDDFailed,
+		SDDPlanned, SDDValidated, SDDInProgress, SDDDone, SDDFailed, SDDCancelled,
 	}
 	for _, s := range statuses {
 		if s == "" {

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -1,0 +1,47 @@
+package vault
+
+import (
+	"testing"
+)
+
+func TestNewFDID(t *testing.T) {
+	id := NewFDID("Test Feature", "testuser")
+	if len(id) != 7 { // "FD-" + 4 hex chars
+		t.Errorf("expected 7 char ID, got %d: %q", len(id), id)
+	}
+	if id[:3] != "FD-" {
+		t.Errorf("expected FD- prefix, got %q", id)
+	}
+}
+
+func TestNewFDIDUniqueness(t *testing.T) {
+	// Two calls with same input should produce different IDs (timestamp differs).
+	id1 := NewFDID("Same Title", "same-author")
+	id2 := NewFDID("Same Title", "same-author")
+	if id1 == id2 {
+		t.Errorf("expected unique IDs, both got %q", id1)
+	}
+}
+
+func TestFDStatusConstants(t *testing.T) {
+	statuses := []FDStatus{
+		FDPlanned, FDApproved, FDInProgress,
+		FDComplete, FDClosed, FDRejected, FDAbandoned,
+	}
+	for _, s := range statuses {
+		if s == "" {
+			t.Error("empty FD status constant")
+		}
+	}
+}
+
+func TestSDDStatusConstants(t *testing.T) {
+	statuses := []SDDStatus{
+		SDDPlanned, SDDValidated, SDDInProgress, SDDDone, SDDFailed,
+	}
+	for _, s := range statuses {
+		if s == "" {
+			t.Error("empty SDD status constant")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Defines interfaces and types for all 11 internal packages. No implementations — interfaces only. Enables parallel work: ferruvich ports commands, others build #35, #36, #27 on top of the same types.

Closes #41

## Packages (11)

| Package | What | Key types |
|---------|------|-----------|
| `vault/` | .forgia/ read/write | `Vault` interface, `FD`, `SDD`, `Architecture`, `BoundedContext` |
| `config/` | Config loading + merge | `Config`, `RunnerConfig`, `BoardConfig`, `MCPConfig` |
| `runner/` | SDD execution | `Runner` interface, `ExecResult`, `ExecOptions` |
| `guardrails/` | Security checks | `Guardrails`, `DenyList`, `Violation`, `Parse()` |
| `mcp/` | MCP provider chaining | `ToolProvider` interface, `ProviderRegistry` |
| `board/` | Project board sync | `ProjectBoard` interface, `BoardItem` |
| `scm/` | GitHub/GitLab | `SCM` interface, `Issue` |
| `process/` | Subprocess lifecycle | `Spawn()`, `Kill()`, `ShutdownManager` |
| `beads/` | Local cache (optional) | `Client`, circuit breaker detection |
| `skill/` | Slash commands | (stub — unchanged) |
| `vault/` tests | Type verification | `TestNewFDID`, status constants |

## Design decisions

- **No circular deps**: vault does NOT import guardrails. `vault.GuardrailsRaw()` returns `[]byte`, `guardrails.Parse()` parses it.
- **ctx everywhere**: all interface methods take `context.Context` (Go 1.25 rule).
- **iter.Seq**: `vault.FDs()` and `vault.SDDs()` return Go 1.25 iterators.
- **slog.LogValue**: FD and SDD implement LogValuer — only metadata logged, never content.
- **close(chan)**: Process.Kill() uses close pattern (safe for multiple readers).
- **ShutdownManager**: holds lock during iteration (race-safe).
- **Beads always optional**: `ErrBeadsUnavailable` fallback, circuit breaker check.
- **Agent Teams**: ExecProfile on FD, team fields on ExecOptions and ExecResult.

## Alignment

- [x] Aligned with `docs/go-integration-guide.md`
- [x] Aligned with `docs/functional-architecture.md`
- [x] Aligned with #41 comment (ctx, iterators, LogValuer, abandoned status, board, process, beads)
- [x] `go build ./...` passes
- [x] `go test ./...` passes

## Test plan

- [x] `go build ./...` — all packages compile
- [x] `go test ./...` — vault tests pass (NewFDID, status constants)
- [ ] @ferruvich review: interfaces match your implementation plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: ferruvich <ferruvich@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>