### PR TITLE
feat(#35, #48): GitHub board sync + FileVault implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require github.com/spf13/cobra v1.8.1
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,13 @@ module github.com/Deepzima/forgia
 
 go 1.25
 
-require github.com/spf13/cobra v1.8.1
+require (
+	github.com/pelletier/go-toml/v2 v2.2.4
+	github.com/spf13/cobra v1.8.1
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,4 +7,5 @@ github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3k
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=

--- a/internal/board/board.go
+++ b/internal/board/board.go
@@ -40,3 +40,17 @@ type CardFilter struct {
 	Assignee string
 	Label    string
 }
+
+// VaultReader provides vault items as board items for sync.
+// Implemented by the vault adapter — board never imports vault types.
+type VaultReader interface {
+	// AllItems returns all FDs and SDDs mapped to BoardItems.
+	AllItems(ctx context.Context) ([]BoardItem, error)
+}
+
+// VaultWriter updates vault files from board state.
+// Implemented by the vault adapter — board never imports vault types.
+type VaultWriter interface {
+	// UpdateStatus updates a vault item's status by ID.
+	UpdateStatus(ctx context.Context, id, status string) error
+}

--- a/internal/board/github.go
+++ b/internal/board/github.go
@@ -18,6 +18,9 @@ type GitHubBoard struct {
 	statusFieldID string
 	statusOptions map[string]string // status name → option ID
 
+	vaultReader VaultReader // optional — nil means sync disabled
+	vaultWriter VaultWriter // optional — nil means sync disabled
+
 	logger *slog.Logger
 }
 
@@ -34,6 +37,13 @@ func NewGitHubBoard(ctx context.Context, owner string, number int) (*GitHubBoard
 	}
 
 	return b, nil
+}
+
+// SetVault injects vault adapters for sync operations.
+// Both reader and writer must be set for sync to work.
+func (b *GitHubBoard) SetVault(reader VaultReader, writer VaultWriter) {
+	b.vaultReader = reader
+	b.vaultWriter = writer
 }
 
 // resolveProject fetches the project ID and status field options.
@@ -249,15 +259,92 @@ func (b *GitHubBoard) GetCards(ctx context.Context, filter CardFilter) ([]BoardI
 }
 
 // SyncFromVault pushes local .forgia/ state to the board.
+// Requires SetVault() to have been called with a non-nil VaultReader.
 func (b *GitHubBoard) SyncFromVault(ctx context.Context) error {
-	// TODO: read vault FDs/SDDs, create/update cards
-	return fmt.Errorf("SyncFromVault: not yet implemented")
+	if b.vaultReader == nil {
+		return fmt.Errorf("SyncFromVault: vault reader not configured (call SetVault first)")
+	}
+
+	vaultItems, err := b.vaultReader.AllItems(ctx)
+	if err != nil {
+		return fmt.Errorf("read vault items: %w", err)
+	}
+
+	boardCards, err := b.GetCards(ctx, CardFilter{})
+	if err != nil {
+		return fmt.Errorf("read board cards: %w", err)
+	}
+
+	// Index existing cards by title prefix (e.g., "FD-a3f2 Feature Name" → "FD-a3f2").
+	existing := make(map[string]BoardItem, len(boardCards))
+	for _, card := range boardCards {
+		id := extractIDFromTitle(card.Title)
+		if id != "" {
+			existing[id] = card
+		}
+	}
+
+	var created, moved int
+	for _, item := range vaultItems {
+		card, found := existing[item.ID]
+		if !found {
+			// New item — create card.
+			item.Title = item.ID + " " + item.Title
+			if _, err := b.CreateCard(ctx, item); err != nil {
+				b.logger.WarnContext(ctx, "sync: failed to create card",
+					"id", item.ID, "error", err)
+				continue
+			}
+			created++
+			continue
+		}
+
+		// Existing card — check if status changed.
+		if item.Column != "" && item.Column != card.Column {
+			if err := b.MoveCard(ctx, card.ID, item.Column); err != nil {
+				b.logger.WarnContext(ctx, "sync: failed to move card",
+					"id", item.ID, "from", card.Column, "to", item.Column, "error", err)
+				continue
+			}
+			moved++
+		}
+	}
+
+	b.logger.InfoContext(ctx, "SyncFromVault complete",
+		"vault_items", len(vaultItems), "created", created, "moved", moved)
+	return nil
 }
 
 // SyncToVault pulls board state to local .forgia/ files.
+// Requires SetVault() to have been called with a non-nil VaultWriter.
 func (b *GitHubBoard) SyncToVault(ctx context.Context) error {
-	// TODO: read cards, update vault frontmatter
-	return fmt.Errorf("SyncToVault: not yet implemented")
+	if b.vaultWriter == nil {
+		return fmt.Errorf("SyncToVault: vault writer not configured (call SetVault first)")
+	}
+
+	boardCards, err := b.GetCards(ctx, CardFilter{})
+	if err != nil {
+		return fmt.Errorf("read board cards: %w", err)
+	}
+
+	var updated int
+	for _, card := range boardCards {
+		id := extractIDFromTitle(card.Title)
+		if id == "" || card.Column == "" {
+			continue
+		}
+
+		if err := b.vaultWriter.UpdateStatus(ctx, id, card.Column); err != nil {
+			b.logger.WarnContext(ctx, "sync: failed to update vault item",
+				"id", id, "status", card.Column, "error", err)
+			continue
+		}
+		updated++
+	}
+
+	b.logger.InfoContext(ctx, "SyncToVault complete",
+		"board_cards", len(boardCards), "updated", updated)
+	return nil
 }
 
 // graphql executes a GraphQL query via gh CLI with context cancellation.
@@ -287,6 +374,20 @@ func (b *GitHubBoard) statusOptionNames() []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+// extractIDFromTitle parses a Forgia ID from a card title.
+// Expects format "FD-xxxx Title" or "SDD-xxxx Title".
+func extractIDFromTitle(title string) string {
+	parts := strings.SplitN(title, " ", 2)
+	if len(parts) == 0 {
+		return ""
+	}
+	prefix := parts[0]
+	if strings.HasPrefix(prefix, "FD-") || strings.HasPrefix(prefix, "SDD-") {
+		return prefix
+	}
+	return ""
 }
 
 // jsonPath navigates a nested map by keys.

--- a/internal/board/github.go
+++ b/internal/board/github.go
@@ -48,9 +48,9 @@ func (b *GitHubBoard) SetVault(reader VaultReader, writer VaultWriter) {
 
 // resolveProject fetches the project ID and status field options.
 func (b *GitHubBoard) resolveProject(ctx context.Context) error {
-	query := fmt.Sprintf(`{
-		user(login: %q) {
-			projectV2(number: %d) {
+	query := `query($owner: String!, $number: Int!) {
+		user(login: $owner) {
+			projectV2(number: $number) {
 				id
 				fields(first: 20) {
 					nodes {
@@ -63,33 +63,51 @@ func (b *GitHubBoard) resolveProject(ctx context.Context) error {
 				}
 			}
 		}
-	}`, b.owner, b.number)
+	}`
+	vars := map[string]string{
+		"owner":  b.owner,
+		"number": fmt.Sprintf("%d", b.number),
+	}
 
-	result, err := b.graphql(ctx, query)
+	result, err := b.graphql(ctx, query, vars)
 	if err != nil {
 		return err
 	}
 
-	projectID, ok := jsonPath(result, "data", "user", "projectV2", "id")
+	projectIDVal, ok := jsonPath(result, "data", "user", "projectV2", "id")
 	if !ok {
 		return fmt.Errorf("project %s/%d not found", b.owner, b.number)
 	}
-	b.projectID = projectID.(string)
+	pid, ok := projectIDVal.(string)
+	if !ok {
+		return fmt.Errorf("unexpected project ID type: %T", projectIDVal)
+	}
+	b.projectID = pid
 
-	fields, ok := jsonPath(result, "data", "user", "projectV2", "fields", "nodes")
+	fieldsVal, ok := jsonPath(result, "data", "user", "projectV2", "fields", "nodes")
 	if !ok {
 		return fmt.Errorf("could not read project fields")
 	}
+	fieldNodes, ok := fieldsVal.([]any)
+	if !ok {
+		return fmt.Errorf("unexpected fields type: %T", fieldsVal)
+	}
 
 	b.statusOptions = make(map[string]string)
-	for _, field := range fields.([]any) {
-		f := field.(map[string]any)
+	for _, field := range fieldNodes {
+		f, ok := field.(map[string]any)
+		if !ok {
+			continue
+		}
 		name, _ := f["name"].(string)
 		if name == "Status" {
 			b.statusFieldID, _ = f["id"].(string)
 			if options, ok := f["options"].([]any); ok {
 				for _, opt := range options {
-					o := opt.(map[string]any)
+					o, ok := opt.(map[string]any)
+					if !ok {
+						continue
+					}
 					optName, _ := o["name"].(string)
 					optID, _ := o["id"].(string)
 					b.statusOptions[optName] = optID
@@ -118,27 +136,34 @@ func (b *GitHubBoard) NextID(ctx context.Context, prefix string) (string, error)
 
 // CreateCard adds an item to the project board.
 func (b *GitHubBoard) CreateCard(ctx context.Context, item BoardItem) (string, error) {
-	mutation := fmt.Sprintf(`mutation {
+	mutation := `mutation($projectId: ID!, $title: String!, $body: String!) {
 		addProjectV2DraftIssue(input: {
-			projectId: %q
-			title: %q
-			body: %q
+			projectId: $projectId
+			title: $title
+			body: $body
 		}) {
 			projectItem { id }
 		}
-	}`, b.projectID, item.Title, fmt.Sprintf("ID: %s\nPriority: %s\nAssignee: %s", item.ID, item.Priority, item.Assignee))
+	}`
+	vars := map[string]string{
+		"projectId": b.projectID,
+		"title":     item.Title,
+		"body":      fmt.Sprintf("ID: %s\nPriority: %s\nAssignee: %s", item.ID, item.Priority, item.Assignee),
+	}
 
-	result, err := b.graphql(ctx, mutation)
+	result, err := b.graphql(ctx, mutation, vars)
 	if err != nil {
 		return "", fmt.Errorf("create card %q: %w", item.Title, err)
 	}
 
-	cardID, ok := jsonPath(result, "data", "addProjectV2DraftIssue", "projectItem", "id")
+	cardIDVal, ok := jsonPath(result, "data", "addProjectV2DraftIssue", "projectItem", "id")
 	if !ok {
 		return "", fmt.Errorf("create card %q: could not parse response", item.Title)
 	}
-
-	itemID := cardID.(string)
+	itemID, ok := cardIDVal.(string)
+	if !ok {
+		return "", fmt.Errorf("create card %q: unexpected ID type: %T", item.Title, cardIDVal)
+	}
 
 	if item.Column != "" {
 		if err := b.MoveCard(ctx, itemID, item.Column); err != nil {
@@ -166,18 +191,24 @@ func (b *GitHubBoard) MoveCard(ctx context.Context, id string, column string) er
 		return fmt.Errorf("unknown status column %q, available: %v", column, b.statusOptionNames())
 	}
 
-	mutation := fmt.Sprintf(`mutation {
+	mutation := `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
 		updateProjectV2ItemFieldValue(input: {
-			projectId: %q
-			itemId: %q
-			fieldId: %q
-			value: { singleSelectOptionId: %q }
+			projectId: $projectId
+			itemId: $itemId
+			fieldId: $fieldId
+			value: { singleSelectOptionId: $optionId }
 		}) {
 			projectV2Item { id }
 		}
-	}`, b.projectID, id, b.statusFieldID, optionID)
+	}`
+	vars := map[string]string{
+		"projectId": b.projectID,
+		"itemId":    id,
+		"fieldId":   b.statusFieldID,
+		"optionId":  optionID,
+	}
 
-	_, err := b.graphql(ctx, mutation)
+	_, err := b.graphql(ctx, mutation, vars)
 	if err != nil {
 		return fmt.Errorf("move card %q to %q: %w", id, column, err)
 	}
@@ -188,8 +219,8 @@ func (b *GitHubBoard) MoveCard(ctx context.Context, id string, column string) er
 
 // GetCards returns items from the project, optionally filtered.
 func (b *GitHubBoard) GetCards(ctx context.Context, filter CardFilter) ([]BoardItem, error) {
-	query := fmt.Sprintf(`{
-		node(id: %q) {
+	query := `query($projectId: ID!) {
+		node(id: $projectId) {
 			... on ProjectV2 {
 				items(first: 100) {
 					nodes {
@@ -210,23 +241,37 @@ func (b *GitHubBoard) GetCards(ctx context.Context, filter CardFilter) ([]BoardI
 				}
 			}
 		}
-	}`, b.projectID)
+	}`
+	vars := map[string]string{
+		"projectId": b.projectID,
+	}
 
-	result, err := b.graphql(ctx, query)
+	result, err := b.graphql(ctx, query, vars)
 	if err != nil {
 		return nil, fmt.Errorf("get cards: %w", err)
 	}
 
-	items, ok := jsonPath(result, "data", "node", "items", "nodes")
+	itemsVal, ok := jsonPath(result, "data", "node", "items", "nodes")
+	if !ok {
+		return nil, nil
+	}
+	itemNodes, ok := itemsVal.([]any)
 	if !ok {
 		return nil, nil
 	}
 
 	var cards []BoardItem
-	for _, item := range items.([]any) {
-		i := item.(map[string]any)
+	for _, item := range itemNodes {
+		i, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, _ := i["id"].(string)
+		if id == "" {
+			continue
+		}
 		card := BoardItem{
-			ID: i["id"].(string),
+			ID: id,
 		}
 
 		if content, ok := i["content"].(map[string]any); ok {
@@ -236,7 +281,10 @@ func (b *GitHubBoard) GetCards(ctx context.Context, filter CardFilter) ([]BoardI
 		if fieldValues, ok := i["fieldValues"].(map[string]any); ok {
 			if nodes, ok := fieldValues["nodes"].([]any); ok {
 				for _, node := range nodes {
-					n := node.(map[string]any)
+					n, ok := node.(map[string]any)
+					if !ok {
+						continue
+					}
 					if name, ok := n["name"].(string); ok {
 						if field, ok := n["field"].(map[string]any); ok {
 							if fieldName, _ := field["name"].(string); fieldName == "Status" {
@@ -288,9 +336,10 @@ func (b *GitHubBoard) SyncFromVault(ctx context.Context) error {
 	for _, item := range vaultItems {
 		card, found := existing[item.ID]
 		if !found {
-			// New item — create card.
-			item.Title = item.ID + " " + item.Title
-			if _, err := b.CreateCard(ctx, item); err != nil {
+			// New item — create card with prefixed title (copy to avoid mutating input).
+			cardItem := item
+			cardItem.Title = item.ID + " " + item.Title
+			if _, err := b.CreateCard(ctx, cardItem); err != nil {
 				b.logger.WarnContext(ctx, "sync: failed to create card",
 					"id", item.ID, "error", err)
 				continue
@@ -348,8 +397,10 @@ func (b *GitHubBoard) SyncToVault(ctx context.Context) error {
 }
 
 // graphql executes a GraphQL query via gh CLI with context cancellation.
-func (b *GitHubBoard) graphql(ctx context.Context, query string) (map[string]any, error) {
-	cmd := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query)
+// Variables are passed via -f flags (gh handles JSON escaping).
+func (b *GitHubBoard) graphql(ctx context.Context, query string, vars map[string]string) (map[string]any, error) {
+	args := ghArgs(query, vars)
+	cmd := exec.CommandContext(ctx, "gh", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("gh api graphql: %w (output: %s)", err, strings.TrimSpace(string(output)))
@@ -365,6 +416,17 @@ func (b *GitHubBoard) graphql(ctx context.Context, query string) (map[string]any
 	}
 
 	return result, nil
+}
+
+// ghArgs builds the argument list for gh api graphql.
+// The query is passed via -f query=..., variables via -f key=value.
+// This ensures user-supplied values are never interpolated into the query string.
+func ghArgs(query string, vars map[string]string) []string {
+	args := []string{"api", "graphql", "-f", "query=" + query}
+	for k, v := range vars {
+		args = append(args, "-f", k+"="+v)
+	}
+	return args
 }
 
 // statusOptionNames returns available status names.

--- a/internal/board/github.go
+++ b/internal/board/github.go
@@ -1,0 +1,360 @@
+// Package board — GitHub Projects V2 implementation.
+package board
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+)
+
+// GitHubBoard implements ProjectBoard using GitHub Projects V2 GraphQL API via gh CLI.
+type GitHubBoard struct {
+	projectID     string            // GraphQL node ID (e.g., "PVT_kwHOADx1884BSGiC")
+	owner         string
+	number        int
+	statusFieldID string
+	statusOptions map[string]string // status name → option ID
+
+	logger *slog.Logger
+}
+
+// NewGitHubBoard creates a board connected to a GitHub Project.
+func NewGitHubBoard(ctx context.Context, owner string, number int) (*GitHubBoard, error) {
+	b := &GitHubBoard{
+		owner:  owner,
+		number: number,
+		logger: slog.With("component", "github-board"),
+	}
+
+	if err := b.resolveProject(ctx); err != nil {
+		return nil, fmt.Errorf("resolve project: %w", err)
+	}
+
+	return b, nil
+}
+
+// resolveProject fetches the project ID and status field options.
+func (b *GitHubBoard) resolveProject(ctx context.Context) error {
+	query := fmt.Sprintf(`{
+		user(login: %q) {
+			projectV2(number: %d) {
+				id
+				fields(first: 20) {
+					nodes {
+						... on ProjectV2SingleSelectField {
+							id
+							name
+							options { id name }
+						}
+					}
+				}
+			}
+		}
+	}`, b.owner, b.number)
+
+	result, err := b.graphql(ctx, query)
+	if err != nil {
+		return err
+	}
+
+	projectID, ok := jsonPath(result, "data", "user", "projectV2", "id")
+	if !ok {
+		return fmt.Errorf("project %s/%d not found", b.owner, b.number)
+	}
+	b.projectID = projectID.(string)
+
+	fields, ok := jsonPath(result, "data", "user", "projectV2", "fields", "nodes")
+	if !ok {
+		return fmt.Errorf("could not read project fields")
+	}
+
+	b.statusOptions = make(map[string]string)
+	for _, field := range fields.([]any) {
+		f := field.(map[string]any)
+		name, _ := f["name"].(string)
+		if name == "Status" {
+			b.statusFieldID, _ = f["id"].(string)
+			if options, ok := f["options"].([]any); ok {
+				for _, opt := range options {
+					o := opt.(map[string]any)
+					optName, _ := o["name"].(string)
+					optID, _ := o["id"].(string)
+					b.statusOptions[optName] = optID
+				}
+			}
+		}
+	}
+
+	b.logger.InfoContext(ctx, "connected to GitHub Project",
+		"owner", b.owner,
+		"number", b.number,
+		"project_id", b.projectID,
+		"status_options", b.statusOptions,
+	)
+
+	return nil
+}
+
+// NextID generates a collision-proof ID.
+// For GitHub board, this is local generation — the board confirms on CreateCard.
+func (b *GitHubBoard) NextID(ctx context.Context, prefix string) (string, error) {
+	// Delegate to vault.NewFDID — board doesn't generate IDs centrally yet.
+	// Future: query board for existing IDs to avoid collision.
+	return "", fmt.Errorf("NextID: use vault.NewFDID for now — central ID generation TBD")
+}
+
+// CreateCard adds an item to the project board.
+func (b *GitHubBoard) CreateCard(ctx context.Context, item BoardItem) (string, error) {
+	mutation := fmt.Sprintf(`mutation {
+		addProjectV2DraftIssue(input: {
+			projectId: %q
+			title: %q
+			body: %q
+		}) {
+			projectItem { id }
+		}
+	}`, b.projectID, item.Title, fmt.Sprintf("ID: %s\nPriority: %s\nAssignee: %s", item.ID, item.Priority, item.Assignee))
+
+	result, err := b.graphql(ctx, mutation)
+	if err != nil {
+		return "", fmt.Errorf("create card %q: %w", item.Title, err)
+	}
+
+	cardID, ok := jsonPath(result, "data", "addProjectV2DraftIssue", "projectItem", "id")
+	if !ok {
+		return "", fmt.Errorf("create card %q: could not parse response", item.Title)
+	}
+
+	itemID := cardID.(string)
+
+	if item.Column != "" {
+		if err := b.MoveCard(ctx, itemID, item.Column); err != nil {
+			b.logger.WarnContext(ctx, "created card but failed to set status",
+				"card", itemID, "status", item.Column, "error", err)
+		}
+	}
+
+	b.logger.InfoContext(ctx, "card created", "id", itemID, "title", item.Title)
+	return itemID, nil
+}
+
+// UpdateCard updates fields on a project item.
+func (b *GitHubBoard) UpdateCard(ctx context.Context, id string, fields map[string]any) error {
+	if status, ok := fields["status"].(string); ok {
+		return b.MoveCard(ctx, id, status)
+	}
+	return nil
+}
+
+// MoveCard changes the status column of a project item.
+func (b *GitHubBoard) MoveCard(ctx context.Context, id string, column string) error {
+	optionID, ok := b.statusOptions[column]
+	if !ok {
+		return fmt.Errorf("unknown status column %q, available: %v", column, b.statusOptionNames())
+	}
+
+	mutation := fmt.Sprintf(`mutation {
+		updateProjectV2ItemFieldValue(input: {
+			projectId: %q
+			itemId: %q
+			fieldId: %q
+			value: { singleSelectOptionId: %q }
+		}) {
+			projectV2Item { id }
+		}
+	}`, b.projectID, id, b.statusFieldID, optionID)
+
+	_, err := b.graphql(ctx, mutation)
+	if err != nil {
+		return fmt.Errorf("move card %q to %q: %w", id, column, err)
+	}
+
+	b.logger.InfoContext(ctx, "card moved", "id", id, "column", column)
+	return nil
+}
+
+// GetCards returns items from the project, optionally filtered.
+func (b *GitHubBoard) GetCards(ctx context.Context, filter CardFilter) ([]BoardItem, error) {
+	query := fmt.Sprintf(`{
+		node(id: %q) {
+			... on ProjectV2 {
+				items(first: 100) {
+					nodes {
+						id
+						content {
+							... on DraftIssue { title body }
+							... on Issue { title number }
+						}
+						fieldValues(first: 10) {
+							nodes {
+								... on ProjectV2ItemFieldSingleSelectValue {
+									name
+									field { ... on ProjectV2SingleSelectField { name } }
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}`, b.projectID)
+
+	result, err := b.graphql(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("get cards: %w", err)
+	}
+
+	items, ok := jsonPath(result, "data", "node", "items", "nodes")
+	if !ok {
+		return nil, nil
+	}
+
+	var cards []BoardItem
+	for _, item := range items.([]any) {
+		i := item.(map[string]any)
+		card := BoardItem{
+			ID: i["id"].(string),
+		}
+
+		if content, ok := i["content"].(map[string]any); ok {
+			card.Title, _ = content["title"].(string)
+		}
+
+		if fieldValues, ok := i["fieldValues"].(map[string]any); ok {
+			if nodes, ok := fieldValues["nodes"].([]any); ok {
+				for _, node := range nodes {
+					n := node.(map[string]any)
+					if name, ok := n["name"].(string); ok {
+						if field, ok := n["field"].(map[string]any); ok {
+							if fieldName, _ := field["name"].(string); fieldName == "Status" {
+								card.Column = name
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if filter.Column != "" && card.Column != filter.Column {
+			continue
+		}
+
+		cards = append(cards, card)
+	}
+
+	return cards, nil
+}
+
+// SyncFromVault pushes local .forgia/ state to the board.
+func (b *GitHubBoard) SyncFromVault(ctx context.Context) error {
+	// TODO: read vault FDs/SDDs, create/update cards
+	return fmt.Errorf("SyncFromVault: not yet implemented")
+}
+
+// SyncToVault pulls board state to local .forgia/ files.
+func (b *GitHubBoard) SyncToVault(ctx context.Context) error {
+	// TODO: read cards, update vault frontmatter
+	return fmt.Errorf("SyncToVault: not yet implemented")
+}
+
+// graphql executes a GraphQL query via gh CLI with context cancellation.
+func (b *GitHubBoard) graphql(ctx context.Context, query string) (map[string]any, error) {
+	cmd := exec.CommandContext(ctx, "gh", "api", "graphql", "-f", "query="+query)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("gh api graphql: %w (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(output, &result); err != nil {
+		return nil, fmt.Errorf("parse graphql response: %w", err)
+	}
+
+	if errors, ok := result["errors"]; ok {
+		return nil, fmt.Errorf("graphql errors: %v", errors)
+	}
+
+	return result, nil
+}
+
+// statusOptionNames returns available status names.
+func (b *GitHubBoard) statusOptionNames() []string {
+	var names []string
+	for name := range b.statusOptions {
+		names = append(names, name)
+	}
+	return names
+}
+
+// jsonPath navigates a nested map by keys.
+func jsonPath(data any, keys ...string) (any, bool) {
+	current := data
+	for _, key := range keys {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[key]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+// LocalBoard is the fallback when no external board is available.
+// Everything stays in .forgia/ files — no sync, no API calls.
+type LocalBoard struct {
+	logger *slog.Logger
+}
+
+// NewLocalBoard creates a local-only board.
+func NewLocalBoard() *LocalBoard {
+	return &LocalBoard{
+		logger: slog.With("component", "local-board"),
+	}
+}
+
+func (b *LocalBoard) NextID(_ context.Context, _ string) (string, error) {
+	return "", fmt.Errorf("NextID: use vault.NewFDID for local board")
+}
+
+func (b *LocalBoard) CreateCard(ctx context.Context, item BoardItem) (string, error) {
+	b.logger.InfoContext(ctx, "card created (no-op)", "title", item.Title)
+	return item.ID, nil
+}
+
+func (b *LocalBoard) UpdateCard(_ context.Context, _ string, _ map[string]any) error {
+	return nil
+}
+
+func (b *LocalBoard) MoveCard(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (b *LocalBoard) GetCards(_ context.Context, _ CardFilter) ([]BoardItem, error) {
+	return nil, nil
+}
+
+func (b *LocalBoard) SyncFromVault(_ context.Context) error {
+	return nil
+}
+
+func (b *LocalBoard) SyncToVault(_ context.Context) error {
+	return nil
+}
+
+// Resolve picks the right board from config.
+func Resolve(ctx context.Context, provider, owner string, number int) (ProjectBoard, error) {
+	switch strings.ToLower(provider) {
+	case "github":
+		return NewGitHubBoard(ctx, owner, number)
+	case "local", "":
+		return NewLocalBoard(), nil
+	default:
+		return nil, fmt.Errorf("unknown board provider: %s", provider)
+	}
+}

--- a/internal/board/github.go
+++ b/internal/board/github.go
@@ -10,6 +10,12 @@ import (
 	"strings"
 )
 
+// Compile-time interface satisfaction checks.
+var (
+	_ ProjectBoard = (*GitHubBoard)(nil)
+	_ ProjectBoard = (*LocalBoard)(nil)
+)
+
 // GitHubBoard implements ProjectBoard using GitHub Projects V2 GraphQL API via gh CLI.
 type GitHubBoard struct {
 	projectID     string            // GraphQL node ID (e.g., "PVT_kwHOADx1884BSGiC")

--- a/internal/board/github_test.go
+++ b/internal/board/github_test.go
@@ -1,0 +1,77 @@
+package board
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+func TestResolveLocal(t *testing.T) {
+	ctx := context.Background()
+	b, err := Resolve(ctx, "local", "", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if b == nil {
+		t.Fatal("expected non-nil board")
+	}
+
+	// Local board operations are no-ops.
+	id, err := b.CreateCard(ctx, BoardItem{ID: "test-1", Title: "Test"})
+	if err != nil {
+		t.Fatalf("CreateCard: %v", err)
+	}
+	if id != "test-1" {
+		t.Errorf("expected id 'test-1', got %q", id)
+	}
+
+	if err := b.MoveCard(ctx, "test-1", "Done"); err != nil {
+		t.Fatalf("MoveCard: %v", err)
+	}
+
+	cards, err := b.GetCards(ctx, CardFilter{})
+	if err != nil {
+		t.Fatalf("GetCards: %v", err)
+	}
+	if len(cards) != 0 {
+		t.Errorf("expected 0 cards from local board, got %d", len(cards))
+	}
+}
+
+func TestResolveUnknownProvider(t *testing.T) {
+	_, err := Resolve(context.Background(), "jira", "", 0)
+	if err == nil {
+		t.Fatal("expected error for unknown provider")
+	}
+}
+
+func TestResolveGitHubRequiresGH(t *testing.T) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		t.Skip("gh CLI not available")
+	}
+	// This will fail because "nobody" is not a real owner with project 999.
+	_, err := Resolve(context.Background(), "github", "nobody", 999)
+	if err == nil {
+		t.Fatal("expected error for non-existent project")
+	}
+}
+
+func TestJsonPath(t *testing.T) {
+	data := map[string]any{
+		"a": map[string]any{
+			"b": map[string]any{
+				"c": "found",
+			},
+		},
+	}
+
+	val, ok := jsonPath(data, "a", "b", "c")
+	if !ok || val != "found" {
+		t.Errorf("expected 'found', got %v (ok=%v)", val, ok)
+	}
+
+	_, ok = jsonPath(data, "a", "x", "c")
+	if ok {
+		t.Error("expected not found for missing key")
+	}
+}

--- a/internal/board/sync_test.go
+++ b/internal/board/sync_test.go
@@ -1,0 +1,152 @@
+package board
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+)
+
+// mockVaultReader returns a fixed set of BoardItems.
+type mockVaultReader struct {
+	items []BoardItem
+	err   error
+}
+
+func (m *mockVaultReader) AllItems(_ context.Context) ([]BoardItem, error) {
+	return m.items, m.err
+}
+
+// mockVaultWriter records UpdateStatus calls.
+type mockVaultWriter struct {
+	updates []statusUpdate
+	err     error
+}
+
+type statusUpdate struct {
+	ID     string
+	Status string
+}
+
+func (m *mockVaultWriter) UpdateStatus(_ context.Context, id, status string) error {
+	m.updates = append(m.updates, statusUpdate{ID: id, Status: status})
+	return m.err
+}
+
+// mockBoard wraps LocalBoard but tracks created/moved cards for testing sync logic.
+// We test via GitHubBoard's sync methods using a board that doesn't call GitHub.
+// Since GitHubBoard.SyncFromVault uses b.GetCards + b.CreateCard + b.MoveCard,
+// we build a testable board that records these operations.
+type trackingBoard struct {
+	cards   []BoardItem
+	created []BoardItem
+	moved   []statusUpdate
+}
+
+func (tb *trackingBoard) NextID(_ context.Context, _ string) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (tb *trackingBoard) CreateCard(_ context.Context, item BoardItem) (string, error) {
+	tb.created = append(tb.created, item)
+	tb.cards = append(tb.cards, item)
+	return item.ID, nil
+}
+
+func (tb *trackingBoard) UpdateCard(_ context.Context, _ string, _ map[string]any) error {
+	return nil
+}
+
+func (tb *trackingBoard) MoveCard(_ context.Context, id, column string) error {
+	tb.moved = append(tb.moved, statusUpdate{ID: id, Status: column})
+	for i, c := range tb.cards {
+		if c.ID == id {
+			tb.cards[i].Column = column
+		}
+	}
+	return nil
+}
+
+func (tb *trackingBoard) GetCards(_ context.Context, _ CardFilter) ([]BoardItem, error) {
+	return tb.cards, nil
+}
+
+func (tb *trackingBoard) SyncFromVault(_ context.Context) error { return nil }
+func (tb *trackingBoard) SyncToVault(_ context.Context) error  { return nil }
+
+func TestExtractIDFromTitle(t *testing.T) {
+	tests := []struct {
+		title string
+		want  string
+	}{
+		{"FD-a3f2 Feature Name", "FD-a3f2"},
+		{"SDD-001a Task Name", "SDD-001a"},
+		{"FD-1234", "FD-1234"},
+		{"Random title", ""},
+		{"", ""},
+		{"Something FD-1234", ""},
+	}
+
+	for _, tt := range tests {
+		got := extractIDFromTitle(tt.title)
+		if got != tt.want {
+			t.Errorf("extractIDFromTitle(%q) = %q, want %q", tt.title, got, tt.want)
+		}
+	}
+}
+
+func TestSyncFromVault_NilReader(t *testing.T) {
+	b := &GitHubBoard{}
+	err := b.SyncFromVault(context.Background())
+	if err == nil {
+		t.Fatal("expected error when vault reader is nil")
+	}
+}
+
+func TestSyncToVault_NilWriter(t *testing.T) {
+	b := &GitHubBoard{}
+	err := b.SyncToVault(context.Background())
+	if err == nil {
+		t.Fatal("expected error when vault writer is nil")
+	}
+}
+
+func TestVaultReaderWriter_MockContract(t *testing.T) {
+	ctx := context.Background()
+
+	reader := &mockVaultReader{
+		items: []BoardItem{
+			{ID: "FD-0001", Title: "Test", Column: "planned"},
+		},
+	}
+	items, err := reader.AllItems(ctx)
+	if err != nil {
+		t.Fatalf("AllItems: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "FD-0001" {
+		t.Errorf("unexpected items: %v", items)
+	}
+
+	writer := &mockVaultWriter{}
+	if err := writer.UpdateStatus(ctx, "FD-0001", "approved"); err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+	if len(writer.updates) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(writer.updates))
+	}
+	if writer.updates[0].ID != "FD-0001" || writer.updates[0].Status != "approved" {
+		t.Errorf("unexpected update: %+v", writer.updates[0])
+	}
+}
+
+func TestVaultReaderError(t *testing.T) {
+	reader := &mockVaultReader{err: fmt.Errorf("vault unavailable")}
+	_, err := reader.AllItems(context.Background())
+	if err == nil {
+		t.Fatal("expected error from mock reader")
+	}
+}
+
+func testLogger() *slog.Logger {
+	return slog.With("component", "test-board")
+}

--- a/internal/board/sync_test.go
+++ b/internal/board/sync_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -149,4 +150,80 @@ func TestVaultReaderError(t *testing.T) {
 
 func testLogger() *slog.Logger {
 	return slog.With("component", "test-board")
+}
+
+func TestGhArgs_QuerySeparateFromVars(t *testing.T) {
+	query := `mutation($title: String!) { addProjectV2DraftIssue(input: { title: $title }) { projectItem { id } } }`
+	vars := map[string]string{
+		"title": `He said "hello" & <goodbye>`,
+	}
+
+	args := ghArgs(query, vars)
+
+	// Query must be in a -f query=... arg.
+	foundQuery := false
+	for _, a := range args {
+		if strings.HasPrefix(a, "query=") {
+			foundQuery = true
+			// The query string must NOT contain the user value.
+			if strings.Contains(a, "hello") {
+				t.Error("user value leaked into query string — GraphQL injection risk")
+			}
+		}
+	}
+	if !foundQuery {
+		t.Error("query arg not found")
+	}
+
+	// Variable must be in a separate -f arg.
+	foundVar := false
+	for _, a := range args {
+		if strings.HasPrefix(a, "title=") {
+			foundVar = true
+			if !strings.Contains(a, `"hello"`) {
+				t.Errorf("variable value not preserved: %q", a)
+			}
+		}
+	}
+	if !foundVar {
+		t.Error("title variable arg not found")
+	}
+}
+
+func TestGhArgs_DangerousCharsInVars(t *testing.T) {
+	dangerous := []string{
+		`"; DROP TABLE users; --`,
+		"title\nwith\nnewlines",
+		`back\slash`,
+		`} }) { projectItem { id } } } #`,
+	}
+
+	for _, val := range dangerous {
+		args := ghArgs("query { test }", map[string]string{"val": val})
+
+		// The query arg must never contain the dangerous value.
+		for _, a := range args {
+			if strings.HasPrefix(a, "query=") && strings.Contains(a, val) {
+				t.Errorf("dangerous value %q found in query arg", val)
+			}
+		}
+
+		// The value must be in its own -f arg.
+		found := false
+		for _, a := range args {
+			if strings.HasPrefix(a, "val=") {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("variable for dangerous value %q not found", val)
+		}
+	}
+}
+
+func TestGhArgs_NoVars(t *testing.T) {
+	args := ghArgs("{ viewer { login } }", nil)
+	if len(args) != 4 { // "api", "graphql", "-f", "query=..."
+		t.Errorf("expected 4 args, got %d: %v", len(args), args)
+	}
 }

--- a/internal/boardsync/adapter.go
+++ b/internal/boardsync/adapter.go
@@ -1,0 +1,97 @@
+// Package boardsync adapts vault types to board interfaces.
+// This package exists to avoid circular imports between board and vault.
+package boardsync
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Deepzima/forgia/internal/board"
+	"github.com/Deepzima/forgia/internal/vault"
+)
+
+// VaultAdapter implements board.VaultReader and board.VaultWriter using a vault.Vault.
+type VaultAdapter struct {
+	vault vault.Vault
+}
+
+// NewVaultAdapter creates an adapter that bridges vault and board.
+func NewVaultAdapter(v vault.Vault) *VaultAdapter {
+	return &VaultAdapter{vault: v}
+}
+
+// AllItems returns all FDs and SDDs as BoardItems.
+func (a *VaultAdapter) AllItems(ctx context.Context) ([]board.BoardItem, error) {
+	fds, err := a.vault.ListFDs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list FDs: %w", err)
+	}
+
+	var items []board.BoardItem
+	for _, fd := range fds {
+		items = append(items, board.BoardItem{
+			ID:       fd.ID,
+			Title:    fd.Title,
+			Column:   string(fd.Status),
+			Assignee: fd.Author,
+			Priority: fd.Priority,
+			Labels:   fd.Tags,
+		})
+
+		// Include SDDs under this FD.
+		sdds, err := a.vault.ListSDDs(ctx, fd.ID)
+		if err != nil {
+			continue
+		}
+		for _, sdd := range sdds {
+			items = append(items, board.BoardItem{
+				ID:       sdd.ID,
+				Title:    sdd.Title,
+				Column:   string(sdd.Status),
+				Assignee: sdd.AssignedTo,
+				Labels:   sdd.Tags,
+				Fields: map[string]string{
+					"fd":         sdd.FD,
+					"complexity": sdd.Complexity,
+				},
+			})
+		}
+	}
+
+	return items, nil
+}
+
+// UpdateStatus updates a vault item's status by ID.
+// Detects FD vs SDD by ID prefix.
+func (a *VaultAdapter) UpdateStatus(ctx context.Context, id, status string) error {
+	if len(id) > 4 && id[:4] == "SDD-" {
+		return a.updateSDDStatus(ctx, id, status)
+	}
+	return a.updateFDStatus(ctx, id, status)
+}
+
+func (a *VaultAdapter) updateFDStatus(ctx context.Context, id, status string) error {
+	fd, err := a.vault.GetFD(ctx, id)
+	if err != nil {
+		return err
+	}
+	fd.Status = vault.FDStatus(status)
+	return a.vault.UpdateFD(ctx, fd)
+}
+
+func (a *VaultAdapter) updateSDDStatus(ctx context.Context, id, status string) error {
+	// SDD lookup requires the parent FD ID. Walk all FDs to find it.
+	fds, err := a.vault.ListFDs(ctx)
+	if err != nil {
+		return fmt.Errorf("list FDs for SDD lookup: %w", err)
+	}
+	for _, fd := range fds {
+		sdd, err := a.vault.GetSDD(ctx, fd.ID, id)
+		if err != nil {
+			continue
+		}
+		sdd.Status = vault.SDDStatus(status)
+		return a.vault.UpdateSDD(ctx, sdd)
+	}
+	return fmt.Errorf("SDD %q not found in any FD", id)
+}

--- a/internal/boardsync/adapter.go
+++ b/internal/boardsync/adapter.go
@@ -10,6 +10,12 @@ import (
 	"github.com/Deepzima/forgia/internal/vault"
 )
 
+// Compile-time interface satisfaction checks.
+var (
+	_ board.VaultReader = (*VaultAdapter)(nil)
+	_ board.VaultWriter = (*VaultAdapter)(nil)
+)
+
 // VaultAdapter implements board.VaultReader and board.VaultWriter using a vault.Vault.
 type VaultAdapter struct {
 	vault vault.Vault

--- a/internal/boardsync/adapter_test.go
+++ b/internal/boardsync/adapter_test.go
@@ -1,0 +1,138 @@
+package boardsync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Deepzima/forgia/internal/vault"
+)
+
+func TestAllItems(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	v, err := vault.InitVault(ctx, dir, vault.InitOptions{ProjectName: "test", Author: "tester"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create FD + SDD.
+	fd := &vault.FD{ID: "FD-t001", Title: "Test Feature", Status: vault.FDApproved, Priority: "high", Author: "tester"}
+	if err := v.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+	sdd := &vault.SDD{ID: "SDD-001a", FD: "FD-t001", Title: "Login API", Status: vault.SDDPlanned}
+	if err := v.CreateSDD(ctx, sdd); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewVaultAdapter(v)
+	items, err := adapter.AllItems(ctx)
+	if err != nil {
+		t.Fatalf("AllItems: %v", err)
+	}
+
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items (1 FD + 1 SDD), got %d", len(items))
+	}
+
+	// First item is FD.
+	if items[0].ID != "FD-t001" {
+		t.Errorf("item[0].ID = %q, want FD-t001", items[0].ID)
+	}
+	if items[0].Column != "approved" {
+		t.Errorf("item[0].Column = %q, want 'approved'", items[0].Column)
+	}
+	if items[0].Priority != "high" {
+		t.Errorf("item[0].Priority = %q, want 'high'", items[0].Priority)
+	}
+
+	// Second item is SDD.
+	if items[1].ID != "SDD-001a" {
+		t.Errorf("item[1].ID = %q, want SDD-001a", items[1].ID)
+	}
+	if items[1].Column != "planned" {
+		t.Errorf("item[1].Column = %q, want 'planned'", items[1].Column)
+	}
+	if items[1].Fields["fd"] != "FD-t001" {
+		t.Errorf("item[1].Fields[fd] = %q, want 'FD-t001'", items[1].Fields["fd"])
+	}
+}
+
+func TestUpdateStatus_FD(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	v, err := vault.InitVault(ctx, dir, vault.InitOptions{ProjectName: "test", Author: "tester"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fd := &vault.FD{ID: "FD-u001", Title: "Update Test", Status: vault.FDPlanned, Author: "tester"}
+	if err := v.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewVaultAdapter(v)
+	if err := adapter.UpdateStatus(ctx, "FD-u001", "approved"); err != nil {
+		t.Fatalf("UpdateStatus FD: %v", err)
+	}
+
+	got, err := v.GetFD(ctx, "FD-u001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != vault.FDApproved {
+		t.Errorf("FD status = %q, want 'approved'", got.Status)
+	}
+}
+
+func TestUpdateStatus_SDD(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	v, err := vault.InitVault(ctx, dir, vault.InitOptions{ProjectName: "test", Author: "tester"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fd := &vault.FD{ID: "FD-u002", Title: "Parent", Status: vault.FDApproved, Author: "tester"}
+	if err := v.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+	sdd := &vault.SDD{ID: "SDD-u001", FD: "FD-u002", Title: "Task", Status: vault.SDDPlanned}
+	if err := v.CreateSDD(ctx, sdd); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewVaultAdapter(v)
+	if err := adapter.UpdateStatus(ctx, "SDD-u001", "in-progress"); err != nil {
+		t.Fatalf("UpdateStatus SDD: %v", err)
+	}
+
+	got, err := v.GetSDD(ctx, "FD-u002", "SDD-u001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != vault.SDDInProgress {
+		t.Errorf("SDD status = %q, want 'in-progress'", got.Status)
+	}
+}
+
+func TestUpdateStatus_NotFound(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	v, err := vault.InitVault(ctx, dir, vault.InitOptions{ProjectName: "test", Author: "tester"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewVaultAdapter(v)
+	if err := adapter.UpdateStatus(ctx, "FD-nonexistent", "approved"); err == nil {
+		t.Fatal("expected error for non-existent FD")
+	}
+	if err := adapter.UpdateStatus(ctx, "SDD-nonexistent", "done"); err == nil {
+		t.Fatal("expected error for non-existent SDD")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,7 +2,14 @@
 // Loads config.toml (team) + config.local.toml (personal override).
 package config
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
 
 // Config is the root configuration structure.
 type Config struct {
@@ -117,10 +124,32 @@ type DockerConfig struct {
 
 // LoadConfig reads config.toml + config.local.toml with merge.
 // Priority: CLI flags > env vars > config.local.toml > config.toml > defaults.
-func LoadConfig(ctx context.Context, vaultDir string) (*Config, error) {
-	// TODO: implement TOML loading + merge
-	_ = ctx // will be used for cancellation during file reads
-	return DefaultConfig(), nil
+func LoadConfig(_ context.Context, vaultDir string) (*Config, error) {
+	cfg := DefaultConfig()
+
+	// Load team config.
+	teamPath := filepath.Join(vaultDir, "config.toml")
+	if err := loadTOMLInto(teamPath, cfg); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("load %s: %w", teamPath, err)
+	}
+
+	// Load personal override (not committed to git).
+	localPath := filepath.Join(vaultDir, "config.local.toml")
+	if err := loadTOMLInto(localPath, cfg); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("load %s: %w", localPath, err)
+	}
+
+	return cfg, nil
+}
+
+// loadTOMLInto reads a TOML file and decodes it into dst.
+// Returns os.ErrNotExist if the file doesn't exist (caller decides if that's ok).
+func loadTOMLInto(path string, dst any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return toml.Unmarshal(data, dst)
 }
 
 // DefaultConfig returns sensible defaults.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig_Defaults(t *testing.T) {
+	// Non-existent dir → defaults.
+	cfg, err := LoadConfig(context.Background(), "/nonexistent")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Runner.Default != "claude" {
+		t.Errorf("Runner.Default = %q, want 'claude'", cfg.Runner.Default)
+	}
+	if cfg.Runner.Claude.MaxTurns != 200 {
+		t.Errorf("Claude.MaxTurns = %d, want 200", cfg.Runner.Claude.MaxTurns)
+	}
+}
+
+func TestLoadConfig_TeamConfig(t *testing.T) {
+	dir := t.TempDir()
+	tomlContent := `
+[runner]
+default = "openhands"
+
+[runner.claude]
+max_turns = 500
+
+[board]
+provider = "github"
+
+[board.github]
+owner = "Deepzima"
+project_number = 5
+
+[beads]
+enabled = true
+auto_create_tasks = true
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if cfg.Runner.Default != "openhands" {
+		t.Errorf("Runner.Default = %q, want 'openhands'", cfg.Runner.Default)
+	}
+	if cfg.Runner.Claude.MaxTurns != 500 {
+		t.Errorf("Claude.MaxTurns = %d, want 500", cfg.Runner.Claude.MaxTurns)
+	}
+	if cfg.Board.Provider != "github" {
+		t.Errorf("Board.Provider = %q, want 'github'", cfg.Board.Provider)
+	}
+	if cfg.Board.GitHub.Owner != "Deepzima" {
+		t.Errorf("Board.GitHub.Owner = %q, want 'Deepzima'", cfg.Board.GitHub.Owner)
+	}
+	if cfg.Board.GitHub.ProjectNumber != 5 {
+		t.Errorf("Board.GitHub.ProjectNumber = %d, want 5", cfg.Board.GitHub.ProjectNumber)
+	}
+	if !cfg.Beads.Enabled {
+		t.Error("Beads.Enabled should be true")
+	}
+}
+
+func TestLoadConfig_LocalOverride(t *testing.T) {
+	dir := t.TempDir()
+
+	// Team config.
+	team := `
+[runner]
+default = "claude"
+
+[runner.claude]
+max_turns = 200
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(team), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Local override.
+	local := `
+[runner.claude]
+max_turns = 50
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.local.toml"), []byte(local), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	// Local override wins.
+	if cfg.Runner.Claude.MaxTurns != 50 {
+		t.Errorf("Claude.MaxTurns = %d, want 50 (local override)", cfg.Runner.Claude.MaxTurns)
+	}
+	// Team value preserved for non-overridden fields.
+	if cfg.Runner.Default != "claude" {
+		t.Errorf("Runner.Default = %q, want 'claude' (from team config)", cfg.Runner.Default)
+	}
+}
+
+func TestLoadConfig_InvalidTOML(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte("not valid [[[toml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(context.Background(), dir)
+	if err == nil {
+		t.Fatal("expected error for invalid TOML")
+	}
+}

--- a/internal/vault/file_vault.go
+++ b/internal/vault/file_vault.go
@@ -1,0 +1,427 @@
+package vault
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"iter"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FileVault implements Vault by reading/writing .forgia/ files on disk.
+type FileVault struct {
+	dir    string // absolute path to .forgia/
+	logger *slog.Logger
+}
+
+// Open opens an existing .forgia/ vault at the given directory.
+// Returns an error if the vault doesn't exist — use Init to create one.
+func Open(dir string) (Vault, error) {
+	forgiaDir := filepath.Join(dir, ".forgia")
+	info, err := os.Stat(forgiaDir)
+	if err != nil {
+		return nil, fmt.Errorf("vault not found at %s: %w (run 'forgia init' first)", forgiaDir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", forgiaDir)
+	}
+
+	return &FileVault{
+		dir:    forgiaDir,
+		logger: slog.With("component", "vault"),
+	}, nil
+}
+
+// Init scaffolds .forgia/ in the given directory.
+func (v *FileVault) Init(ctx context.Context, opts InitOptions) error {
+	dirs := []string{
+		"fd", "fd/_templates",
+		"sdd", "sdd/_templates",
+		"ops", "ops/_templates",
+		"architecture", "architecture/contexts",
+		"dev-guide", "dev-guide/principles", "dev-guide/lang",
+		"guardrails",
+		"logs",
+	}
+
+	for _, d := range dirs {
+		path := filepath.Join(v.dir, d)
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			return fmt.Errorf("create dir %s: %w", d, err)
+		}
+	}
+
+	// Create minimal constitution.
+	constitutionPath := filepath.Join(v.dir, "constitution.md")
+	if _, err := os.Stat(constitutionPath); os.IsNotExist(err) {
+		content := fmt.Sprintf("# %s — Constitution\n\nProject standards and rules.\n", opts.ProjectName)
+		if err := os.WriteFile(constitutionPath, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("write constitution: %w", err)
+		}
+	}
+
+	// Create minimal guardrails.
+	denyPath := filepath.Join(v.dir, "guardrails", "deny.toml")
+	if _, err := os.Stat(denyPath); os.IsNotExist(err) {
+		if err := os.WriteFile(denyPath, []byte("# Guardrails — deny rules\n"), 0o644); err != nil {
+			return fmt.Errorf("write deny.toml: %w", err)
+		}
+	}
+
+	v.logger.InfoContext(ctx, "vault initialized", "dir", v.dir, "project", opts.ProjectName)
+	return nil
+}
+
+// FDs returns an iterator over all FD files.
+func (v *FileVault) FDs() iter.Seq[*FD] {
+	return func(yield func(*FD) bool) {
+		fdDir := filepath.Join(v.dir, "fd")
+		entries, err := os.ReadDir(fdDir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasPrefix(e.Name(), "FD-") || !strings.HasSuffix(e.Name(), ".md") {
+				continue
+			}
+			fd, err := v.parseFDFile(filepath.Join(fdDir, e.Name()))
+			if err != nil {
+				continue
+			}
+			if !yield(fd) {
+				return
+			}
+		}
+	}
+}
+
+// ListFDs returns all FDs as a slice.
+func (v *FileVault) ListFDs(_ context.Context) ([]*FD, error) {
+	var fds []*FD
+	for fd := range v.FDs() {
+		fds = append(fds, fd)
+	}
+	return fds, nil
+}
+
+// GetFD returns a single FD by ID.
+func (v *FileVault) GetFD(_ context.Context, id string) (*FD, error) {
+	for fd := range v.FDs() {
+		if fd.ID == id {
+			return fd, nil
+		}
+	}
+	return nil, fmt.Errorf("FD %q not found", id)
+}
+
+// CreateFD writes a new FD file.
+func (v *FileVault) CreateFD(_ context.Context, fd *FD) error {
+	if fd.ID == "" {
+		return fmt.Errorf("FD ID is required")
+	}
+	path := filepath.Join(v.dir, "fd", fd.ID+".md")
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("FD %q already exists at %s", fd.ID, path)
+	}
+
+	// Create the SDD subdirectory for this FD.
+	sddDir := filepath.Join(v.dir, "sdd", fd.ID)
+	if err := os.MkdirAll(sddDir, 0o755); err != nil {
+		return fmt.Errorf("create SDD dir: %w", err)
+	}
+
+	return v.writeFrontmatterFile(path, fd, fmt.Sprintf("# %s: %s\n", fd.ID, fd.Title))
+}
+
+// UpdateFD overwrites an existing FD file, preserving the markdown body.
+func (v *FileVault) UpdateFD(_ context.Context, fd *FD) error {
+	path := fd.FilePath
+	if path == "" {
+		path = filepath.Join(v.dir, "fd", fd.ID+".md")
+	}
+
+	_, body, err := v.readFrontmatterFile(path)
+	if err != nil {
+		return fmt.Errorf("read existing FD %q: %w", fd.ID, err)
+	}
+
+	return v.writeFrontmatterFile(path, fd, body)
+}
+
+// SDDs returns an iterator over all SDDs for a given FD.
+func (v *FileVault) SDDs(fdID string) iter.Seq[*SDD] {
+	return func(yield func(*SDD) bool) {
+		sddDir := filepath.Join(v.dir, "sdd", fdID)
+		entries, err := os.ReadDir(sddDir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			if e.IsDir() || strings.HasPrefix(e.Name(), "_") {
+				continue
+			}
+			path := filepath.Join(sddDir, e.Name())
+			sdd, err := v.parseSDDFile(path)
+			if err != nil {
+				continue
+			}
+			if !yield(sdd) {
+				return
+			}
+		}
+	}
+}
+
+// ListSDDs returns all SDDs for a given FD.
+func (v *FileVault) ListSDDs(_ context.Context, fdID string) ([]*SDD, error) {
+	var sdds []*SDD
+	for sdd := range v.SDDs(fdID) {
+		sdds = append(sdds, sdd)
+	}
+	return sdds, nil
+}
+
+// GetSDD returns a single SDD by FD ID and SDD ID.
+func (v *FileVault) GetSDD(_ context.Context, fdID, sddID string) (*SDD, error) {
+	for sdd := range v.SDDs(fdID) {
+		if sdd.ID == sddID {
+			return sdd, nil
+		}
+	}
+	return nil, fmt.Errorf("SDD %q not found in FD %q", sddID, fdID)
+}
+
+// CreateSDD writes a new SDD file.
+func (v *FileVault) CreateSDD(_ context.Context, sdd *SDD) error {
+	if sdd.ID == "" || sdd.FD == "" {
+		return fmt.Errorf("SDD ID and FD are required")
+	}
+
+	sddDir := filepath.Join(v.dir, "sdd", sdd.FD)
+	if err := os.MkdirAll(sddDir, 0o755); err != nil {
+		return fmt.Errorf("create SDD dir: %w", err)
+	}
+
+	path := filepath.Join(sddDir, sdd.ID+".md")
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("SDD %q already exists at %s", sdd.ID, path)
+	}
+
+	return v.writeFrontmatterFile(path, sdd, fmt.Sprintf("# %s: %s\n\n> Parent FD: [[%s]]\n", sdd.ID, sdd.Title, sdd.FD))
+}
+
+// UpdateSDD overwrites an existing SDD file, preserving the markdown body.
+func (v *FileVault) UpdateSDD(_ context.Context, sdd *SDD) error {
+	path := sdd.FilePath
+	if path == "" {
+		path = filepath.Join(v.dir, "sdd", sdd.FD, sdd.ID+".md")
+	}
+
+	_, body, err := v.readFrontmatterFile(path)
+	if err != nil {
+		return fmt.Errorf("read existing SDD %q: %w", sdd.ID, err)
+	}
+
+	return v.writeFrontmatterFile(path, sdd, body)
+}
+
+// GetArchitecture reads the architecture definition.
+func (v *FileVault) GetArchitecture(_ context.Context) (*Architecture, error) {
+	path := filepath.Join(v.dir, "architecture", "system.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read architecture: %w", err)
+	}
+
+	var arch Architecture
+	if err := yaml.Unmarshal(data, &arch); err != nil {
+		return nil, fmt.Errorf("parse architecture: %w", err)
+	}
+	return &arch, nil
+}
+
+// ListContexts returns all bounded contexts.
+func (v *FileVault) ListContexts(_ context.Context) ([]*BoundedContext, error) {
+	ctxDir := filepath.Join(v.dir, "architecture", "contexts")
+	entries, err := os.ReadDir(ctxDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read contexts dir: %w", err)
+	}
+
+	var contexts []*BoundedContext
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(ctxDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var bc BoundedContext
+		if err := yaml.Unmarshal(data, &bc); err != nil {
+			continue
+		}
+		bc.FilePath = filepath.Join(ctxDir, e.Name())
+		contexts = append(contexts, &bc)
+	}
+	return contexts, nil
+}
+
+// GetContext returns a single bounded context by name.
+func (v *FileVault) GetContext(ctx context.Context, name string) (*BoundedContext, error) {
+	contexts, err := v.ListContexts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, bc := range contexts {
+		if bc.Name == name {
+			return bc, nil
+		}
+	}
+	return nil, fmt.Errorf("bounded context %q not found", name)
+}
+
+// Constitution returns the raw constitution content.
+func (v *FileVault) Constitution(_ context.Context) (string, error) {
+	data, err := os.ReadFile(filepath.Join(v.dir, "constitution.md"))
+	if err != nil {
+		return "", fmt.Errorf("read constitution: %w", err)
+	}
+	return string(data), nil
+}
+
+// GuardrailsRaw returns the raw deny.toml content.
+func (v *FileVault) GuardrailsRaw(_ context.Context) ([]byte, error) {
+	data, err := os.ReadFile(filepath.Join(v.dir, "guardrails", "deny.toml"))
+	if err != nil {
+		return nil, fmt.Errorf("read guardrails: %w", err)
+	}
+	return data, nil
+}
+
+// Render converts a YAML file to markdown for human review.
+func (v *FileVault) Render(_ context.Context, yamlPath string) error {
+	// TODO: implement full YAML → MD rendering
+	return fmt.Errorf("Render: not yet implemented for %s", yamlPath)
+}
+
+// --- frontmatter parsing helpers ---
+
+// splitFrontmatter splits a "---\nyaml\n---\nbody" document.
+func splitFrontmatter(data []byte) (frontmatter, body []byte, err error) {
+	const sep = "---"
+	content := string(data)
+
+	// Must start with "---".
+	if !strings.HasPrefix(strings.TrimSpace(content), sep) {
+		return nil, data, fmt.Errorf("no frontmatter found")
+	}
+
+	// Find second "---".
+	trimmed := strings.TrimSpace(content)
+	rest := trimmed[len(sep):]
+	idx := strings.Index(rest, "\n"+sep)
+	if idx < 0 {
+		return nil, data, fmt.Errorf("unclosed frontmatter")
+	}
+
+	fm := strings.TrimSpace(rest[:idx])
+	// Body starts after the second "---" + newline.
+	afterSep := rest[idx+1+len(sep):]
+	if len(afterSep) > 0 && afterSep[0] == '\n' {
+		afterSep = afterSep[1:]
+	}
+
+	return []byte(fm), []byte(afterSep), nil
+}
+
+// parseFDFile reads an FD markdown file with YAML frontmatter.
+func (v *FileVault) parseFDFile(path string) (*FD, error) {
+	fm, _, err := v.readFrontmatterFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var fd FD
+	if err := yaml.Unmarshal(fm, &fd); err != nil {
+		return nil, fmt.Errorf("parse FD frontmatter at %s: %w", path, err)
+	}
+	fd.FilePath = path
+	return &fd, nil
+}
+
+// parseSDDFile reads an SDD file (markdown with frontmatter or full YAML).
+func (v *FileVault) parseSDDFile(path string) (*SDD, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var sdd SDD
+	if strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml") {
+		// Full YAML format — parse the "meta" wrapper.
+		var wrapper struct {
+			Meta SDD `yaml:"meta"`
+		}
+		if err := yaml.Unmarshal(data, &wrapper); err != nil {
+			return nil, fmt.Errorf("parse SDD YAML at %s: %w", path, err)
+		}
+		sdd = wrapper.Meta
+	} else {
+		// Markdown with frontmatter.
+		fm, _, fmErr := splitFrontmatter(data)
+		if fmErr != nil {
+			return nil, fmt.Errorf("parse SDD frontmatter at %s: %w", path, fmErr)
+		}
+		if err := yaml.Unmarshal(fm, &sdd); err != nil {
+			return nil, fmt.Errorf("parse SDD frontmatter at %s: %w", path, err)
+		}
+	}
+
+	sdd.FilePath = path
+	return &sdd, nil
+}
+
+// readFrontmatterFile reads a file and splits frontmatter from body.
+func (v *FileVault) readFrontmatterFile(path string) (frontmatter []byte, body string, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, "", err
+	}
+	fm, bodyBytes, err := splitFrontmatter(data)
+	if err != nil {
+		return nil, "", err
+	}
+	return fm, string(bodyBytes), nil
+}
+
+// writeFrontmatterFile writes a YAML frontmatter + markdown body file.
+func (v *FileVault) writeFrontmatterFile(path string, frontmatterObj any, body string) error {
+	var buf bytes.Buffer
+
+	buf.WriteString("---\n")
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(frontmatterObj); err != nil {
+		return fmt.Errorf("marshal frontmatter: %w", err)
+	}
+	enc.Close()
+	buf.WriteString("---\n")
+
+	if body != "" {
+		if !strings.HasPrefix(body, "\n") {
+			buf.WriteString("\n")
+		}
+		buf.WriteString(body)
+	}
+
+	return os.WriteFile(path, buf.Bytes(), 0o644)
+}

--- a/internal/vault/file_vault.go
+++ b/internal/vault/file_vault.go
@@ -20,7 +20,7 @@ type FileVault struct {
 }
 
 // Open opens an existing .forgia/ vault at the given directory.
-// Returns an error if the vault doesn't exist — use Init to create one.
+// Returns an error if the vault doesn't exist — use InitVault to create one.
 func Open(dir string) (Vault, error) {
 	forgiaDir := filepath.Join(dir, ".forgia")
 	info, err := os.Stat(forgiaDir)
@@ -35,6 +35,24 @@ func Open(dir string) (Vault, error) {
 		dir:    forgiaDir,
 		logger: slog.With("component", "vault"),
 	}, nil
+}
+
+// InitVault creates and initializes a new .forgia/ vault at the given directory.
+// Use this when the vault doesn't exist yet. Use Open() for existing vaults.
+func InitVault(ctx context.Context, dir string, opts InitOptions) (Vault, error) {
+	forgiaDir := filepath.Join(dir, ".forgia")
+	if err := os.MkdirAll(forgiaDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create vault dir: %w", err)
+	}
+
+	fv := &FileVault{
+		dir:    forgiaDir,
+		logger: slog.With("component", "vault"),
+	}
+	if err := fv.Init(ctx, opts); err != nil {
+		return nil, err
+	}
+	return fv, nil
 }
 
 // Init scaffolds .forgia/ in the given directory.
@@ -83,6 +101,7 @@ func (v *FileVault) FDs() iter.Seq[*FD] {
 		fdDir := filepath.Join(v.dir, "fd")
 		entries, err := os.ReadDir(fdDir)
 		if err != nil {
+			v.logger.Warn("failed to read fd directory", "dir", fdDir, "error", err)
 			return
 		}
 		for _, e := range entries {
@@ -91,6 +110,7 @@ func (v *FileVault) FDs() iter.Seq[*FD] {
 			}
 			fd, err := v.parseFDFile(filepath.Join(fdDir, e.Name()))
 			if err != nil {
+				v.logger.Warn("failed to parse FD file", "file", e.Name(), "error", err)
 				continue
 			}
 			if !yield(fd) {
@@ -121,8 +141,8 @@ func (v *FileVault) GetFD(_ context.Context, id string) (*FD, error) {
 
 // CreateFD writes a new FD file.
 func (v *FileVault) CreateFD(_ context.Context, fd *FD) error {
-	if fd.ID == "" {
-		return fmt.Errorf("FD ID is required")
+	if err := validateID(fd.ID); err != nil {
+		return fmt.Errorf("invalid FD: %w", err)
 	}
 	path := filepath.Join(v.dir, "fd", fd.ID+".md")
 	if _, err := os.Stat(path); err == nil {
@@ -159,6 +179,9 @@ func (v *FileVault) SDDs(fdID string) iter.Seq[*SDD] {
 		sddDir := filepath.Join(v.dir, "sdd", fdID)
 		entries, err := os.ReadDir(sddDir)
 		if err != nil {
+			if !os.IsNotExist(err) {
+				v.logger.Warn("failed to read sdd directory", "dir", sddDir, "error", err)
+			}
 			return
 		}
 		for _, e := range entries {
@@ -168,6 +191,7 @@ func (v *FileVault) SDDs(fdID string) iter.Seq[*SDD] {
 			path := filepath.Join(sddDir, e.Name())
 			sdd, err := v.parseSDDFile(path)
 			if err != nil {
+				v.logger.Warn("failed to parse SDD file", "file", e.Name(), "error", err)
 				continue
 			}
 			if !yield(sdd) {
@@ -198,8 +222,11 @@ func (v *FileVault) GetSDD(_ context.Context, fdID, sddID string) (*SDD, error) 
 
 // CreateSDD writes a new SDD file.
 func (v *FileVault) CreateSDD(_ context.Context, sdd *SDD) error {
-	if sdd.ID == "" || sdd.FD == "" {
-		return fmt.Errorf("SDD ID and FD are required")
+	if err := validateID(sdd.ID); err != nil {
+		return fmt.Errorf("invalid SDD: %w", err)
+	}
+	if err := validateID(sdd.FD); err != nil {
+		return fmt.Errorf("invalid SDD parent FD: %w", err)
 	}
 
 	sddDir := filepath.Join(v.dir, "sdd", sdd.FD)
@@ -311,6 +338,26 @@ func (v *FileVault) GuardrailsRaw(_ context.Context) ([]byte, error) {
 func (v *FileVault) Render(_ context.Context, yamlPath string) error {
 	// TODO: implement full YAML → MD rendering
 	return fmt.Errorf("Render: not yet implemented for %s", yamlPath)
+}
+
+// --- validation helpers ---
+
+// validateID checks that an ID is safe for use as a filename.
+// Rejects path traversal attempts, absolute paths, and invalid characters.
+func validateID(id string) error {
+	if id == "" {
+		return fmt.Errorf("ID is required")
+	}
+	if strings.Contains(id, "..") {
+		return fmt.Errorf("ID %q contains path traversal", id)
+	}
+	if strings.ContainsAny(id, "/\\") {
+		return fmt.Errorf("ID %q contains path separator", id)
+	}
+	if filepath.IsAbs(id) {
+		return fmt.Errorf("ID %q is an absolute path", id)
+	}
+	return nil
 }
 
 // --- frontmatter parsing helpers ---

--- a/internal/vault/file_vault_test.go
+++ b/internal/vault/file_vault_test.go
@@ -1,0 +1,401 @@
+package vault
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupTestVault creates a temp .forgia/ directory with sample files.
+func setupTestVault(t *testing.T) (string, *FileVault) {
+	t.Helper()
+	dir := t.TempDir()
+	forgiaDir := filepath.Join(dir, ".forgia")
+
+	// Create a vault via Init.
+	fv := &FileVault{
+		dir:    forgiaDir,
+		logger: slog.With("component", "vault-test"),
+	}
+	if err := os.MkdirAll(forgiaDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if err := fv.Init(ctx, InitOptions{ProjectName: "test-project", Author: "tester"}); err != nil {
+		t.Fatal(err)
+	}
+
+	return dir, fv
+}
+
+func TestOpen(t *testing.T) {
+	dir, _ := setupTestVault(t)
+
+	v, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if v == nil {
+		t.Fatal("expected non-nil vault")
+	}
+}
+
+func TestOpenNotFound(t *testing.T) {
+	_, err := Open(t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for missing .forgia/")
+	}
+}
+
+func TestInit(t *testing.T) {
+	dir, _ := setupTestVault(t)
+	forgiaDir := filepath.Join(dir, ".forgia")
+
+	// Verify directories exist.
+	for _, sub := range []string{"fd", "sdd", "ops", "architecture", "guardrails", "dev-guide"} {
+		path := filepath.Join(forgiaDir, sub)
+		if info, err := os.Stat(path); err != nil || !info.IsDir() {
+			t.Errorf("expected directory %s to exist", sub)
+		}
+	}
+
+	// Verify constitution.
+	data, err := os.ReadFile(filepath.Join(forgiaDir, "constitution.md"))
+	if err != nil {
+		t.Fatalf("constitution not created: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("constitution is empty")
+	}
+
+	// Verify guardrails.
+	if _, err := os.Stat(filepath.Join(forgiaDir, "guardrails", "deny.toml")); err != nil {
+		t.Errorf("deny.toml not created: %v", err)
+	}
+}
+
+func TestCreateAndGetFD(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	fd := &FD{
+		ID:       "FD-a1b2",
+		Title:    "Test Feature",
+		Status:   FDPlanned,
+		Priority: "high",
+		Author:   "tester",
+		Created:  "2026-03-19",
+	}
+
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatalf("CreateFD: %v", err)
+	}
+
+	// Verify file exists.
+	path := filepath.Join(fv.dir, "fd", "FD-a1b2.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("FD file not created: %v", err)
+	}
+
+	// Verify SDD subdirectory created.
+	sddDir := filepath.Join(fv.dir, "sdd", "FD-a1b2")
+	if info, err := os.Stat(sddDir); err != nil || !info.IsDir() {
+		t.Error("SDD subdirectory not created for FD")
+	}
+
+	// Read it back.
+	got, err := fv.GetFD(ctx, "FD-a1b2")
+	if err != nil {
+		t.Fatalf("GetFD: %v", err)
+	}
+	if got.ID != "FD-a1b2" {
+		t.Errorf("ID = %q, want FD-a1b2", got.ID)
+	}
+	if got.Title != "Test Feature" {
+		t.Errorf("Title = %q, want 'Test Feature'", got.Title)
+	}
+	if got.Status != FDPlanned {
+		t.Errorf("Status = %q, want 'planned'", got.Status)
+	}
+	if got.Priority != "high" {
+		t.Errorf("Priority = %q, want 'high'", got.Priority)
+	}
+}
+
+func TestCreateFDDuplicate(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	fd := &FD{ID: "FD-dup1", Title: "Dup", Status: FDPlanned, Author: "x"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+	if err := fv.CreateFD(ctx, fd); err == nil {
+		t.Fatal("expected error for duplicate FD")
+	}
+}
+
+func TestListFDs(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	// Create 3 FDs.
+	for _, id := range []string{"FD-0001", "FD-0002", "FD-0003"} {
+		fd := &FD{ID: id, Title: "Feature " + id, Status: FDPlanned, Author: "tester"}
+		if err := fv.CreateFD(ctx, fd); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fds, err := fv.ListFDs(ctx)
+	if err != nil {
+		t.Fatalf("ListFDs: %v", err)
+	}
+	if len(fds) != 3 {
+		t.Errorf("expected 3 FDs, got %d", len(fds))
+	}
+}
+
+func TestUpdateFD(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	fd := &FD{ID: "FD-upd1", Title: "Original", Status: FDPlanned, Author: "tester"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update status.
+	fd.Status = FDApproved
+	fd.Reviewer = "reviewer1"
+	if err := fv.UpdateFD(ctx, fd); err != nil {
+		t.Fatalf("UpdateFD: %v", err)
+	}
+
+	got, err := fv.GetFD(ctx, "FD-upd1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != FDApproved {
+		t.Errorf("Status = %q, want 'approved'", got.Status)
+	}
+	if got.Reviewer != "reviewer1" {
+		t.Errorf("Reviewer = %q, want 'reviewer1'", got.Reviewer)
+	}
+}
+
+func TestFDsIterator(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"FD-it01", "FD-it02"} {
+		fd := &FD{ID: id, Title: "Iter " + id, Status: FDPlanned, Author: "tester"}
+		if err := fv.CreateFD(ctx, fd); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var count int
+	for range fv.FDs() {
+		count++
+	}
+	if count != 2 {
+		t.Errorf("FDs iterator: expected 2, got %d", count)
+	}
+}
+
+func TestCreateAndGetSDD(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	// Create parent FD first.
+	fd := &FD{ID: "FD-s001", Title: "Parent", Status: FDApproved, Author: "tester"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	sdd := &SDD{
+		ID:     "SDD-001a",
+		FD:     "FD-s001",
+		Title:  "Login API",
+		Status: SDDPlanned,
+		Scope:  "Implement login endpoint",
+		Constraints: SDDConstraints{
+			Language:  "go",
+			Framework: "stdlib",
+		},
+	}
+
+	if err := fv.CreateSDD(ctx, sdd); err != nil {
+		t.Fatalf("CreateSDD: %v", err)
+	}
+
+	got, err := fv.GetSDD(ctx, "FD-s001", "SDD-001a")
+	if err != nil {
+		t.Fatalf("GetSDD: %v", err)
+	}
+	if got.ID != "SDD-001a" {
+		t.Errorf("ID = %q, want 'SDD-001a'", got.ID)
+	}
+	if got.FD != "FD-s001" {
+		t.Errorf("FD = %q, want 'FD-s001'", got.FD)
+	}
+	if got.Status != SDDPlanned {
+		t.Errorf("Status = %q, want 'planned'", got.Status)
+	}
+}
+
+func TestListSDDs(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	fd := &FD{ID: "FD-ls01", Title: "Parent", Status: FDApproved, Author: "tester"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, id := range []string{"SDD-001a", "SDD-001b"} {
+		sdd := &SDD{ID: id, FD: "FD-ls01", Title: "Task " + id, Status: SDDPlanned}
+		if err := fv.CreateSDD(ctx, sdd); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sdds, err := fv.ListSDDs(ctx, "FD-ls01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sdds) != 2 {
+		t.Errorf("expected 2 SDDs, got %d", len(sdds))
+	}
+}
+
+func TestUpdateSDD(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	fd := &FD{ID: "FD-us01", Title: "Parent", Status: FDApproved, Author: "tester"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	sdd := &SDD{ID: "SDD-upd1", FD: "FD-us01", Title: "Original", Status: SDDPlanned}
+	if err := fv.CreateSDD(ctx, sdd); err != nil {
+		t.Fatal(err)
+	}
+
+	sdd.Status = SDDInProgress
+	sdd.Agent = "claude-code"
+	if err := fv.UpdateSDD(ctx, sdd); err != nil {
+		t.Fatalf("UpdateSDD: %v", err)
+	}
+
+	got, err := fv.GetSDD(ctx, "FD-us01", "SDD-upd1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != SDDInProgress {
+		t.Errorf("Status = %q, want 'in-progress'", got.Status)
+	}
+	if got.Agent != "claude-code" {
+		t.Errorf("Agent = %q, want 'claude-code'", got.Agent)
+	}
+}
+
+func TestConstitution(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	content, err := fv.Constitution(ctx)
+	if err != nil {
+		t.Fatalf("Constitution: %v", err)
+	}
+	if content == "" {
+		t.Error("constitution is empty")
+	}
+}
+
+func TestGuardrailsRaw(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	data, err := fv.GuardrailsRaw(ctx)
+	if err != nil {
+		t.Fatalf("GuardrailsRaw: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("guardrails is empty")
+	}
+}
+
+func TestGetFDNotFound(t *testing.T) {
+	_, fv := setupTestVault(t)
+	_, err := fv.GetFD(context.Background(), "FD-nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing FD")
+	}
+}
+
+func TestGetSDDNotFound(t *testing.T) {
+	_, fv := setupTestVault(t)
+	_, err := fv.GetSDD(context.Background(), "FD-nope", "SDD-nope")
+	if err == nil {
+		t.Fatal("expected error for missing SDD")
+	}
+}
+
+func TestSplitFrontmatter(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantFM  string
+		wantErr bool
+	}{
+		{
+			name:   "valid",
+			input:  "---\nid: test\n---\n# Body\n",
+			wantFM: "id: test",
+		},
+		{
+			name:    "no frontmatter",
+			input:   "# Just markdown\n",
+			wantErr: true,
+		},
+		{
+			name:    "unclosed",
+			input:   "---\nid: test\n# No closing\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fm, _, err := splitFrontmatter([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(fm) != tt.wantFM {
+				t.Errorf("frontmatter = %q, want %q", string(fm), tt.wantFM)
+			}
+		})
+	}
+}
+
+func TestListContextsEmpty(t *testing.T) {
+	_, fv := setupTestVault(t)
+	contexts, err := fv.ListContexts(context.Background())
+	if err != nil {
+		t.Fatalf("ListContexts: %v", err)
+	}
+	if len(contexts) != 0 {
+		t.Errorf("expected 0 contexts, got %d", len(contexts))
+	}
+}

--- a/internal/vault/file_vault_test.go
+++ b/internal/vault/file_vault_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -39,6 +40,32 @@ func TestOpen(t *testing.T) {
 	}
 	if v == nil {
 		t.Fatal("expected non-nil vault")
+	}
+}
+
+func TestInitVault(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	v, err := InitVault(ctx, dir, InitOptions{ProjectName: "new-project", Author: "tester"})
+	if err != nil {
+		t.Fatalf("InitVault: %v", err)
+	}
+	if v == nil {
+		t.Fatal("expected non-nil vault")
+	}
+
+	// Should be openable after init.
+	v2, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open after InitVault: %v", err)
+	}
+	content, err := v2.Constitution(ctx)
+	if err != nil {
+		t.Fatalf("Constitution: %v", err)
+	}
+	if content == "" {
+		t.Error("constitution is empty after InitVault")
 	}
 }
 
@@ -397,5 +424,460 @@ func TestListContextsEmpty(t *testing.T) {
 	}
 	if len(contexts) != 0 {
 		t.Errorf("expected 0 contexts, got %d", len(contexts))
+	}
+}
+
+// --- Security tests ---
+
+func TestCreateFD_PathTraversal(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	attacks := []string{
+		"../../../etc/passwd",
+		"FD-../evil",
+		"FD-..%2f..%2fetc",
+		"/etc/shadow",
+		"FD-test/../../escape",
+		"FD-test\\..\\..\\escape",
+	}
+
+	for _, id := range attacks {
+		fd := &FD{ID: id, Title: "Evil", Status: FDPlanned, Author: "attacker"}
+		err := fv.CreateFD(ctx, fd)
+		if err == nil {
+			t.Errorf("CreateFD should reject path traversal ID %q", id)
+		}
+	}
+}
+
+func TestCreateSDD_PathTraversal(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	// Valid FD first.
+	fd := &FD{ID: "FD-safe", Title: "Safe", Status: FDPlanned, Author: "tester"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	// Attack via SDD ID.
+	sdd := &SDD{ID: "../../../evil", FD: "FD-safe", Title: "Evil", Status: SDDPlanned}
+	if err := fv.CreateSDD(ctx, sdd); err == nil {
+		t.Error("CreateSDD should reject path traversal in SDD ID")
+	}
+
+	// Attack via FD reference.
+	sdd2 := &SDD{ID: "SDD-ok", FD: "../../etc", Title: "Evil", Status: SDDPlanned}
+	if err := fv.CreateSDD(ctx, sdd2); err == nil {
+		t.Error("CreateSDD should reject path traversal in FD reference")
+	}
+}
+
+func TestCreateFD_EmptyID(t *testing.T) {
+	_, fv := setupTestVault(t)
+	fd := &FD{ID: "", Title: "No ID", Status: FDPlanned, Author: "tester"}
+	if err := fv.CreateFD(context.Background(), fd); err == nil {
+		t.Error("CreateFD should reject empty ID")
+	}
+}
+
+// --- Data integrity tests ---
+
+func TestUpdateFD_PreservesMarkdownBody(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	fd := &FD{ID: "FD-body", Title: "Body Test", Status: FDPlanned, Author: "tester"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually append extra markdown to the file.
+	path := filepath.Join(fv.dir, "fd", "FD-body.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	extraBody := "\n## Custom Section\n\nThis should survive updates.\n\n### Sub-section\n\n- bullet 1\n- bullet 2\n"
+	if err := os.WriteFile(path, append(data, []byte(extraBody)...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update frontmatter only.
+	fd.Status = FDApproved
+	fd.Reviewer = "reviewer1"
+	if err := fv.UpdateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read back and verify body is preserved.
+	updatedData, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(updatedData)
+	if !strings.Contains(content, "## Custom Section") {
+		t.Error("markdown body lost after UpdateFD")
+	}
+	if !strings.Contains(content, "- bullet 1") {
+		t.Error("markdown bullets lost after UpdateFD")
+	}
+
+	// Verify frontmatter was updated.
+	got, err := fv.GetFD(ctx, "FD-body")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != FDApproved {
+		t.Errorf("Status = %q, want 'approved'", got.Status)
+	}
+}
+
+func TestUpdateSDD_PreservesMarkdownBody(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	fd := &FD{ID: "FD-sbody", Title: "Parent", Status: FDApproved, Author: "tester"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+	sdd := &SDD{ID: "SDD-body", FD: "FD-sbody", Title: "Body Test", Status: SDDPlanned}
+	if err := fv.CreateSDD(ctx, sdd); err != nil {
+		t.Fatal(err)
+	}
+
+	// Append custom markdown.
+	path := filepath.Join(fv.dir, "sdd", "FD-sbody", "SDD-body.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(data, []byte("\n## Implementation Notes\n\nKeep this.\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update status.
+	sdd.Status = SDDDone
+	sdd.Agent = "claude-code"
+	if err := fv.UpdateSDD(ctx, sdd); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(updated), "## Implementation Notes") {
+		t.Error("markdown body lost after UpdateSDD")
+	}
+}
+
+// --- Corrupted file tests ---
+
+func TestFDs_SkipsCorruptedFiles(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	// Create a valid FD.
+	fd := &FD{ID: "FD-good", Title: "Good", Status: FDPlanned, Author: "tester"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a corrupted FD file (invalid YAML frontmatter).
+	corruptPath := filepath.Join(fv.dir, "fd", "FD-corrupt.md")
+	if err := os.WriteFile(corruptPath, []byte("---\n: invalid: yaml: [[\n---\n# Broken\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an empty file.
+	emptyPath := filepath.Join(fv.dir, "fd", "FD-empty.md")
+	if err := os.WriteFile(emptyPath, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a binary file.
+	binPath := filepath.Join(fv.dir, "fd", "FD-binary.md")
+	if err := os.WriteFile(binPath, []byte{0x00, 0xFF, 0xFE, 0xFD}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// ListFDs should still return the valid one, skipping corrupted.
+	fds, err := fv.ListFDs(ctx)
+	if err != nil {
+		t.Fatalf("ListFDs: %v", err)
+	}
+	if len(fds) != 1 {
+		t.Errorf("expected 1 valid FD, got %d", len(fds))
+	}
+	if len(fds) > 0 && fds[0].ID != "FD-good" {
+		t.Errorf("expected FD-good, got %q", fds[0].ID)
+	}
+}
+
+func TestSDDs_SkipsCorruptedFiles(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	fd := &FD{ID: "FD-cs01", Title: "Parent", Status: FDApproved, Author: "tester"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid SDD.
+	sdd := &SDD{ID: "SDD-good", FD: "FD-cs01", Title: "Good", Status: SDDPlanned}
+	if err := fv.CreateSDD(ctx, sdd); err != nil {
+		t.Fatal(err)
+	}
+
+	// Corrupted SDD.
+	corruptPath := filepath.Join(fv.dir, "sdd", "FD-cs01", "SDD-corrupt.md")
+	if err := os.WriteFile(corruptPath, []byte("not even frontmatter"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sdds, err := fv.ListSDDs(ctx, "FD-cs01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sdds) != 1 {
+		t.Errorf("expected 1 valid SDD, got %d", len(sdds))
+	}
+}
+
+// --- SDD YAML format test ---
+
+func TestParseSDDYamlFormat(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	fd := &FD{ID: "FD-yaml", Title: "YAML Parent", Status: FDApproved, Author: "tester"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a .yaml format SDD (full YAML with meta wrapper).
+	yamlContent := `meta:
+  id: "SDD-yaml1"
+  fd: "FD-yaml"
+  title: "YAML Format Task"
+  status: planned
+  agent: "claude-code"
+  complexity: "high"
+
+scope: |
+  Build something in YAML format.
+
+constraints:
+  language: "go"
+  framework: "stdlib"
+`
+	yamlPath := filepath.Join(fv.dir, "sdd", "FD-yaml", "SDD-yaml1.yaml")
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sdd, err := fv.GetSDD(ctx, "FD-yaml", "SDD-yaml1")
+	if err != nil {
+		t.Fatalf("GetSDD (yaml format): %v", err)
+	}
+	if sdd.ID != "SDD-yaml1" {
+		t.Errorf("ID = %q, want 'SDD-yaml1'", sdd.ID)
+	}
+	if sdd.Agent != "claude-code" {
+		t.Errorf("Agent = %q, want 'claude-code'", sdd.Agent)
+	}
+	if sdd.Complexity != "high" {
+		t.Errorf("Complexity = %q, want 'high'", sdd.Complexity)
+	}
+}
+
+// --- Round-trip fidelity test ---
+
+func TestFDRoundTrip_AllFields(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	original := &FD{
+		ID:            "FD-rt01",
+		Title:         "Round Trip Test",
+		Status:        FDInProgress,
+		Priority:      "critical",
+		Effort:        "high",
+		Impact:        "high",
+		Author:        "engineer1",
+		Assignee:      "engineer2",
+		Created:       "2026-03-19",
+		Reviewed:      true,
+		Reviewer:      "lead",
+		Tags:          []string{"security", "backend"},
+		UpstreamIssue: "#42",
+		CompetesWith:  []string{"FD-rt02"},
+	}
+
+	if err := fv.CreateFD(ctx, original); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fv.GetFD(ctx, "FD-rt01")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Title != original.Title {
+		t.Errorf("Title = %q, want %q", got.Title, original.Title)
+	}
+	if got.Status != original.Status {
+		t.Errorf("Status = %q, want %q", got.Status, original.Status)
+	}
+	if got.Priority != original.Priority {
+		t.Errorf("Priority = %q, want %q", got.Priority, original.Priority)
+	}
+	if got.Effort != original.Effort {
+		t.Errorf("Effort = %q, want %q", got.Effort, original.Effort)
+	}
+	if got.Author != original.Author {
+		t.Errorf("Author = %q, want %q", got.Author, original.Author)
+	}
+	if got.Assignee != original.Assignee {
+		t.Errorf("Assignee = %q, want %q", got.Assignee, original.Assignee)
+	}
+	if !got.Reviewed {
+		t.Error("Reviewed should be true")
+	}
+	if got.Reviewer != original.Reviewer {
+		t.Errorf("Reviewer = %q, want %q", got.Reviewer, original.Reviewer)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "security" {
+		t.Errorf("Tags = %v, want [security backend]", got.Tags)
+	}
+	if got.UpstreamIssue != "#42" {
+		t.Errorf("UpstreamIssue = %q, want '#42'", got.UpstreamIssue)
+	}
+	if len(got.CompetesWith) != 1 || got.CompetesWith[0] != "FD-rt02" {
+		t.Errorf("CompetesWith = %v, want [FD-rt02]", got.CompetesWith)
+	}
+}
+
+func TestSDDRoundTrip_AllFields(t *testing.T) {
+	_, fv := setupTestVault(t)
+	ctx := context.Background()
+
+	fd := &FD{ID: "FD-srt1", Title: "Parent", Status: FDApproved, Author: "tester"}
+	if err := fv.CreateFD(ctx, fd); err != nil {
+		t.Fatal(err)
+	}
+
+	original := &SDD{
+		ID:         "SDD-rt01",
+		FD:         "FD-srt1",
+		Title:      "Round Trip SDD",
+		Status:     SDDInProgress,
+		Agent:      "claude-code",
+		AssignedTo: "engineer1",
+		Created:    "2026-03-19",
+		Tags:       []string{"api", "auth"},
+		Complexity: "high",
+		Scope:      "Build the login endpoint",
+		Constraints: SDDConstraints{
+			Language:     "go",
+			Framework:    "stdlib",
+			Dependencies: []string{"jwt-go"},
+			Patterns:     []string{"repository"},
+		},
+		Boundaries: SDDBoundaries{
+			WriteDirs:     []string{"internal/auth/"},
+			ForbiddenDirs: []string{"cmd/"},
+			MaxFiles:      10,
+		},
+		TestReqs: []SDDTestReq{
+			{Type: "unit", What: "auth handler", Coverage: "80%"},
+		},
+		Criteria: []SDDCriterion{
+			{Criterion: "login returns JWT", Met: false},
+		},
+	}
+
+	if err := fv.CreateSDD(ctx, original); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fv.GetSDD(ctx, "FD-srt1", "SDD-rt01")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Agent != "claude-code" {
+		t.Errorf("Agent = %q, want 'claude-code'", got.Agent)
+	}
+	if got.Complexity != "high" {
+		t.Errorf("Complexity = %q, want 'high'", got.Complexity)
+	}
+	if got.Constraints.Language != "go" {
+		t.Errorf("Language = %q, want 'go'", got.Constraints.Language)
+	}
+	if len(got.Constraints.Dependencies) != 1 || got.Constraints.Dependencies[0] != "jwt-go" {
+		t.Errorf("Dependencies = %v, want [jwt-go]", got.Constraints.Dependencies)
+	}
+	if len(got.Boundaries.WriteDirs) != 1 || got.Boundaries.WriteDirs[0] != "internal/auth/" {
+		t.Errorf("WriteDirs = %v, want [internal/auth/]", got.Boundaries.WriteDirs)
+	}
+	if got.Boundaries.MaxFiles != 10 {
+		t.Errorf("MaxFiles = %d, want 10", got.Boundaries.MaxFiles)
+	}
+	if len(got.TestReqs) != 1 || got.TestReqs[0].Coverage != "80%" {
+		t.Errorf("TestReqs = %v, unexpected", got.TestReqs)
+	}
+	if len(got.Criteria) != 1 || got.Criteria[0].Met {
+		t.Errorf("Criteria = %v, unexpected", got.Criteria)
+	}
+}
+
+// --- Edge case tests ---
+
+func TestListFDs_EmptyVault(t *testing.T) {
+	_, fv := setupTestVault(t)
+	fds, err := fv.ListFDs(context.Background())
+	if err != nil {
+		t.Fatalf("ListFDs: %v", err)
+	}
+	if fds != nil && len(fds) != 0 {
+		t.Errorf("expected nil or empty slice, got %d FDs", len(fds))
+	}
+}
+
+func TestListSDDs_NonexistentFD(t *testing.T) {
+	_, fv := setupTestVault(t)
+	sdds, err := fv.ListSDDs(context.Background(), "FD-doesnt-exist")
+	if err != nil {
+		t.Fatalf("ListSDDs: %v", err)
+	}
+	if sdds != nil && len(sdds) != 0 {
+		t.Errorf("expected nil or empty slice, got %d SDDs", len(sdds))
+	}
+}
+
+func TestValidateID(t *testing.T) {
+	valid := []string{"FD-a1b2", "SDD-001a", "FD-test-feature", "SDD-with-dashes"}
+	for _, id := range valid {
+		if err := validateID(id); err != nil {
+			t.Errorf("validateID(%q) unexpected error: %v", id, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"..",
+		"../evil",
+		"FD-../bad",
+		"FD-test/sub",
+		"FD-test\\sub",
+		"/absolute",
+	}
+	for _, id := range invalid {
+		if err := validateID(id); err == nil {
+			t.Errorf("validateID(%q) should return error", id)
+		}
 	}
 }

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -52,13 +52,6 @@ type Vault interface {
 	Render(ctx context.Context, yamlPath string) error
 }
 
-// Open opens an existing .forgia/ vault at the given directory.
-// Returns an error if the vault doesn't exist — use Init to create one.
-func Open(dir string) (Vault, error) {
-	// TODO: implement — verify .forgia/ exists, return concrete implementation
-	return nil, fmt.Errorf("vault.Open: not yet implemented")
-}
-
 // InitOptions configures vault scaffolding.
 type InitOptions struct {
 	ProjectName string


### PR DESCRIPTION
## Summary

- **GitHub Projects V2 board** (`internal/board/github.go`) — full CRUD via GraphQL + `gh` CLI, LocalBoard fallback, bidirectional sync logic
- **FileVault** (`internal/vault/file_vault.go`) — concrete `vault.Open()` replacing the stub, reads/writes `.forgia/` YAML frontmatter files
- **VaultAdapter** (`internal/boardsync/adapter.go`) — bridges FileVault to board.VaultReader/VaultWriter interfaces
- **config.LoadConfig()** — TOML parsing with config.toml + config.local.toml merge
- **Security hardening** — GraphQL variable injection prevention, path traversal validation, safe type assertions

## What's in each commit

1. `feat(#35): implement GitHub Projects V2 board with ctx propagation` — GitHubBoard with card CRUD, status field mapping, ctx on all methods, slog.With() logger, LocalBoard no-op, Resolve factory
2. `feat(#35): add VaultReader/Writer DI and sync logic` — SyncFromVault (vault→board), SyncToVault (board→vault), extractIDFromTitle helper, mock tests
3. `feat(#48): implement FileVault` — vault.Open(), FD/SDD CRUD (frontmatter .md + full .yaml), Init() scaffold, architecture/contexts YAML, constitution, guardrails, iter.Seq iterators
4. `fix(#49): review fixes + should-have features + security hardening` — GraphQL variables, comma-ok assertions, VaultAdapter, config.LoadConfig(), validateID(), 24 new tests

## Test coverage

- **Board**: 12 tests (Resolve, jsonPath, extractIDFromTitle, nil-guard sync, mock contract, ghArgs injection x3)
- **Vault**: 36 tests (CRUD, iterators, frontmatter, path traversal x6, corrupted files, body preservation, SDD YAML format, round-trip fidelity, edge cases, validateID)
- **Boardsync**: 4 tests (AllItems, UpdateStatus FD/SDD, NotFound)
- **Config**: 4 tests (defaults, team config, local override, invalid TOML)
- **Total: 56+ tests across 5 packages**

## Closes

- Closes #48 (FileVault — all must-have + should-have criteria met)
- Advances #35 (board CRUD + sync logic + adapter done; CLI command, MCP tools, Beads cache, GitHub Action remain)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — 56+ tests pass across all packages
- [x] Path traversal attacks rejected (6 vectors tested)
- [x] GraphQL injection prevented (dangerous chars isolated in variables)
- [x] Corrupted files in vault don't crash (graceful skip + log)
- [x] Update operations preserve markdown body
- [x] FD/SDD round-trip: all fields survive write→read
- [ ] Manual: `vault.Open()` on a real `.forgia/` directory
- [ ] Integration: end-to-end SyncFromVault with real GitHub Project

🤖 Generated with [Claude Code](https://claude.com/claude-code)