### PR TITLE
feat(#35): GitHub Projects board sync — CLI, MCP tools, Beads cache, GitHub Action

### DIFF
--- a/.github/workflows/forgia-sync.yml
+++ b/.github/workflows/forgia-sync.yml
@@ -1,7 +1,9 @@
 name: Forgia Board Sync
 
-# Syncs .forgia/ FD/SDD status to GitHub Projects when files change.
-# Requires: GH_PROJECT_TOKEN secret with project:read and project:write scopes.
+# Bidirectional sync between .forgia/ files and GitHub Projects.
+# Push: on file changes (vault → board).
+# Pull: on manual trigger or schedule (board → vault, commits back).
+# Requires: GH_PROJECT_TOKEN secret with project:read, project:write, contents:write scopes.
 
 on:
   push:
@@ -10,7 +12,19 @@ on:
       - '.forgia/fd/**'
       - '.forgia/sdd/**'
       - '.forgia/architecture/**'
-  workflow_dispatch: # manual trigger
+  schedule:
+    - cron: '0 */6 * * *' # pull board changes every 6 hours
+  workflow_dispatch:
+    inputs:
+      direction:
+        description: 'Sync direction: push, pull, or both'
+        required: false
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - push
+          - pull
 
 permissions:
   contents: read
@@ -20,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read
+      contents: write # needed for pull sync (commits frontmatter changes)
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -29,7 +43,31 @@ jobs:
       - name: Build forgia
         run: mise run go:build
 
-      - name: Run forgia sync --push
+      - name: Determine sync direction
+        id: direction
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "flag=--push" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "flag=--pull" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.direction }}" = "push" ]; then
+            echo "flag=--push" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.direction }}" = "pull" ]; then
+            echo "flag=--pull" >> "$GITHUB_OUTPUT"
+          else
+            echo "flag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run forgia sync
         env:
           GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
-        run: build/forgia sync --push
+        run: build/forgia sync ${{ steps.direction.outputs.flag }}
+
+      - name: Commit pull changes
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.direction != 'push')
+        run: |
+          git config user.name "forgia-bot"
+          git config user.email "forgia-bot@users.noreply.github.com"
+          git add .forgia/
+          git diff --cached --quiet || git commit -m "chore: sync board status to vault [skip ci]"
+          git push

--- a/.github/workflows/forgia-sync.yml
+++ b/.github/workflows/forgia-sync.yml
@@ -1,0 +1,35 @@
+name: Forgia Board Sync
+
+# Syncs .forgia/ FD/SDD status to GitHub Projects when files change.
+# Requires: GH_PROJECT_TOKEN secret with project:read and project:write scopes.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.forgia/fd/**'
+      - '.forgia/sdd/**'
+      - '.forgia/architecture/**'
+  workflow_dispatch: # manual trigger
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: jdx/mise-action@5083fe46898c414b2475087cc79da59e7da859e8 # v2.4.0
+
+      - name: Build forgia
+        run: mise run go:build
+
+      - name: Run forgia sync --push
+        env:
+          GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+        run: build/forgia sync --push

--- a/cmd/forgia/cmd/root.go
+++ b/cmd/forgia/cmd/root.go
@@ -5,9 +5,11 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "forgia",
-	Short: "Spec-driven development framework",
-	Long:  "Forgia — spec-driven development framework. Forge specs into code.",
+	Use:           "forgia",
+	Short:         "Spec-driven development framework",
+	Long:          "Forgia — spec-driven development framework. Forge specs into code.",
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
 // Execute runs the root command.

--- a/cmd/forgia/cmd/sync.go
+++ b/cmd/forgia/cmd/sync.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/Deepzima/forgia/internal/beads"
 	"github.com/Deepzima/forgia/internal/board"
 	"github.com/Deepzima/forgia/internal/boardsync"
 	"github.com/Deepzima/forgia/internal/config"
@@ -85,6 +87,12 @@ func runSync(cmd *cobra.Command, _ []string) error {
 		logger.Warn("board type does not support vault sync via adapter", "type", fmt.Sprintf("%T", b))
 	}
 
+	// Initialize Beads cache (optional — works without it).
+	bd := beads.NewClient()
+	if bd.Available() {
+		logger.Info("beads cache available")
+	}
+
 	// Determine direction.
 	push, err := cmd.Flags().GetBool("push")
 	if err != nil {
@@ -111,6 +119,8 @@ func runSync(cmd *cobra.Command, _ []string) error {
 		if err := b.SyncFromVault(ctx); err != nil {
 			return fmt.Errorf("push sync: %w", err)
 		}
+		// Cache card mappings in Beads after push.
+		cacheCardMappings(ctx, bd, adapter)
 		logger.Info("push complete")
 	}
 
@@ -119,8 +129,34 @@ func runSync(cmd *cobra.Command, _ []string) error {
 		if err := b.SyncToVault(ctx); err != nil {
 			return fmt.Errorf("pull sync: %w", err)
 		}
+		// Update cache after pull.
+		cacheCardMappings(ctx, bd, adapter)
 		logger.Info("pull complete")
 	}
 
 	return nil
+}
+
+// cacheCardMappings stores current vault items in Beads for offline access.
+func cacheCardMappings(ctx context.Context, bd *beads.Client, adapter *boardsync.VaultAdapter) {
+	if !bd.Available() {
+		return
+	}
+
+	items, err := adapter.AllItems(ctx)
+	if err != nil {
+		slog.Warn("failed to read vault items for beads cache", "error", err)
+		return
+	}
+
+	for _, item := range items {
+		if err := bd.CacheCardMapping(ctx, beads.CardMapping{
+			VaultID: item.ID,
+			CardID:  item.ID, // board card ID not available here — use vault ID as key
+			Column:  item.Column,
+		}); err != nil {
+			// CacheCardMapping already logs warnings internally.
+			continue
+		}
+	}
 }

--- a/cmd/forgia/cmd/sync.go
+++ b/cmd/forgia/cmd/sync.go
@@ -120,7 +120,7 @@ func runSync(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("push sync: %w", err)
 		}
 		// Cache card mappings in Beads after push.
-		cacheCardMappings(ctx, bd, adapter)
+		cacheCardMappings(ctx, bd, b)
 		logger.Info("push complete")
 	}
 
@@ -130,32 +130,36 @@ func runSync(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("pull sync: %w", err)
 		}
 		// Update cache after pull.
-		cacheCardMappings(ctx, bd, adapter)
+		cacheCardMappings(ctx, bd, b)
 		logger.Info("pull complete")
 	}
 
 	return nil
 }
 
-// cacheCardMappings stores current vault items in Beads for offline access.
-func cacheCardMappings(ctx context.Context, bd *beads.Client, adapter *boardsync.VaultAdapter) {
+// cacheCardMappings stores vault→board ID mappings in Beads for offline access.
+// Fetches actual board cards to get real card IDs (not vault IDs).
+func cacheCardMappings(ctx context.Context, bd *beads.Client, b board.ProjectBoard) {
 	if !bd.Available() {
 		return
 	}
 
-	items, err := adapter.AllItems(ctx)
+	cards, err := b.GetCards(ctx, board.CardFilter{})
 	if err != nil {
-		slog.Warn("failed to read vault items for beads cache", "error", err)
+		slog.WarnContext(ctx, "failed to read board cards for beads cache", "error", err)
 		return
 	}
 
-	for _, item := range items {
+	for _, card := range cards {
+		vaultID := board.ExtractIDFromTitle(card.Title)
+		if vaultID == "" {
+			continue
+		}
 		if err := bd.CacheCardMapping(ctx, beads.CardMapping{
-			VaultID: item.ID,
-			CardID:  item.ID, // board card ID not available here — use vault ID as key
-			Column:  item.Column,
+			VaultID: vaultID,
+			CardID:  card.ID,
+			Column:  card.Column,
 		}); err != nil {
-			// CacheCardMapping already logs warnings internally.
 			continue
 		}
 	}

--- a/cmd/forgia/cmd/sync.go
+++ b/cmd/forgia/cmd/sync.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -21,9 +22,12 @@ var syncCmd = &cobra.Command{
 	Short: "Sync FD/SDD status between vault and project board",
 	Long: `Bidirectional sync between .forgia/ files and the project board (GitHub Projects).
 
-  forgia sync          # push + pull (default)
-  forgia sync --push   # vault → board only
-  forgia sync --pull   # board → vault only`,
+  forgia sync                  # push + pull (default, both directions)
+  forgia sync --push           # vault → board only (upload local changes)
+  forgia sync --pull           # board → vault only (download board changes)
+  forgia sync --direction=push # same as --push (long form)
+
+Requires [board] section in .forgia/config.toml with provider, owner, and project number.`,
 	RunE: runSync,
 }
 
@@ -36,6 +40,7 @@ func init() {
 
 func runSync(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
+	logger := slog.With("command", "sync")
 
 	// Find vault.
 	dir, err := os.Getwd()
@@ -44,15 +49,23 @@ func runSync(cmd *cobra.Command, _ []string) error {
 	}
 	v, err := vault.Open(dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("open vault at %s: %w", dir, err)
 	}
 
-	// Load config.
-	forgiaDir := dir + "/.forgia"
-	cfg, err := config.LoadConfig(ctx, forgiaDir)
+	// Load config from vault directory.
+	cfg, err := config.LoadConfig(ctx, v.Dir())
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+
+	// Validate board config.
+	if cfg.Board.Provider == "" {
+		return fmt.Errorf("board provider not configured in .forgia/config.toml (set [board] provider)")
+	}
+	logger.Info("resolving board",
+		"provider", cfg.Board.Provider,
+		"owner", cfg.Board.GitHub.Owner,
+		"project", cfg.Board.GitHub.ProjectNumber)
 
 	// Resolve board.
 	b, err := board.Resolve(ctx,
@@ -61,18 +74,26 @@ func runSync(cmd *cobra.Command, _ []string) error {
 		cfg.Board.GitHub.ProjectNumber,
 	)
 	if err != nil {
-		return fmt.Errorf("resolve board: %w", err)
+		return fmt.Errorf("resolve %s board: %w", cfg.Board.Provider, err)
 	}
 
 	// Wire adapter.
 	adapter := boardsync.NewVaultAdapter(v)
 	if gb, ok := b.(*board.GitHubBoard); ok {
 		gb.SetVault(adapter, adapter)
+	} else {
+		logger.Warn("board type does not support vault sync via adapter", "type", fmt.Sprintf("%T", b))
 	}
 
 	// Determine direction.
-	push, _ := cmd.Flags().GetBool("push")
-	pull, _ := cmd.Flags().GetBool("pull")
+	push, err := cmd.Flags().GetBool("push")
+	if err != nil {
+		return fmt.Errorf("parse --push flag: %w", err)
+	}
+	pull, err := cmd.Flags().GetBool("pull")
+	if err != nil {
+		return fmt.Errorf("parse --pull flag: %w", err)
+	}
 	if syncDirection == "push" {
 		push = true
 	}
@@ -86,19 +107,19 @@ func runSync(cmd *cobra.Command, _ []string) error {
 	}
 
 	if push {
-		fmt.Fprintln(cmd.OutOrStdout(), "Syncing vault → board...")
+		logger.Info("syncing vault → board")
 		if err := b.SyncFromVault(ctx); err != nil {
 			return fmt.Errorf("push sync: %w", err)
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), "Push complete.")
+		logger.Info("push complete")
 	}
 
 	if pull {
-		fmt.Fprintln(cmd.OutOrStdout(), "Syncing board → vault...")
+		logger.Info("syncing board → vault")
 		if err := b.SyncToVault(ctx); err != nil {
 			return fmt.Errorf("pull sync: %w", err)
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), "Pull complete.")
+		logger.Info("pull complete")
 	}
 
 	return nil

--- a/cmd/forgia/cmd/sync.go
+++ b/cmd/forgia/cmd/sync.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Deepzima/forgia/internal/board"
+	"github.com/Deepzima/forgia/internal/boardsync"
+	"github.com/Deepzima/forgia/internal/config"
+	"github.com/Deepzima/forgia/internal/vault"
+)
+
+var (
+	syncDirection string // "push", "pull", or "" (both)
+)
+
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync FD/SDD status between vault and project board",
+	Long: `Bidirectional sync between .forgia/ files and the project board (GitHub Projects).
+
+  forgia sync          # push + pull (default)
+  forgia sync --push   # vault → board only
+  forgia sync --pull   # board → vault only`,
+	RunE: runSync,
+}
+
+func init() {
+	syncCmd.Flags().StringVar(&syncDirection, "direction", "", "sync direction: push, pull, or both (default)")
+	syncCmd.Flags().Bool("push", false, "push vault state to board (shorthand for --direction=push)")
+	syncCmd.Flags().Bool("pull", false, "pull board state to vault (shorthand for --direction=pull)")
+	rootCmd.AddCommand(syncCmd)
+}
+
+func runSync(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	// Find vault.
+	dir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get working directory: %w", err)
+	}
+	v, err := vault.Open(dir)
+	if err != nil {
+		return err
+	}
+
+	// Load config.
+	forgiaDir := dir + "/.forgia"
+	cfg, err := config.LoadConfig(ctx, forgiaDir)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	// Resolve board.
+	b, err := board.Resolve(ctx,
+		cfg.Board.Provider,
+		cfg.Board.GitHub.Owner,
+		cfg.Board.GitHub.ProjectNumber,
+	)
+	if err != nil {
+		return fmt.Errorf("resolve board: %w", err)
+	}
+
+	// Wire adapter.
+	adapter := boardsync.NewVaultAdapter(v)
+	if gb, ok := b.(*board.GitHubBoard); ok {
+		gb.SetVault(adapter, adapter)
+	}
+
+	// Determine direction.
+	push, _ := cmd.Flags().GetBool("push")
+	pull, _ := cmd.Flags().GetBool("pull")
+	if syncDirection == "push" {
+		push = true
+	}
+	if syncDirection == "pull" {
+		pull = true
+	}
+	// Default: both.
+	if !push && !pull {
+		push = true
+		pull = true
+	}
+
+	if push {
+		fmt.Fprintln(cmd.OutOrStdout(), "Syncing vault → board...")
+		if err := b.SyncFromVault(ctx); err != nil {
+			return fmt.Errorf("push sync: %w", err)
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "Push complete.")
+	}
+
+	if pull {
+		fmt.Fprintln(cmd.OutOrStdout(), "Syncing board → vault...")
+		if err := b.SyncToVault(ctx); err != nil {
+			return fmt.Errorf("pull sync: %w", err)
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "Pull complete.")
+	}
+
+	return nil
+}

--- a/cmd/forgia/cmd/sync_test.go
+++ b/cmd/forgia/cmd/sync_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+// resetCmd resets global rootCmd state between tests.
+// Cobra caches help flag state, so we need to reset it.
+func resetCmd(args []string) *bytes.Buffer {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(args)
+	// Reset help flag cache from previous --help calls.
+	syncCmd.Flags().Set("help", "false")
+	return buf
+}
+
+func TestSyncCommandRegistered(t *testing.T) {
+	buf := resetCmd([]string{"help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "sync") {
+		t.Error("expected 'sync' in help output")
+	}
+}
+
+func TestSyncCommandHelp(t *testing.T) {
+	buf := resetCmd([]string{"sync", "--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "push") {
+		t.Error("expected '--push' in sync help")
+	}
+	if !strings.Contains(got, "pull") {
+		t.Error("expected '--pull' in sync help")
+	}
+}
+
+func TestSyncCommandNoVault(t *testing.T) {
+	_ = resetCmd([]string{"sync"})
+
+	// Change to a temp dir with no .forgia/.
+	orig, _ := os.Getwd()
+	tmp := t.TempDir()
+	os.Chdir(tmp)
+	defer os.Chdir(orig)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no .forgia/ exists")
+	}
+	if !strings.Contains(err.Error(), "vault") {
+		t.Errorf("expected vault-related error, got: %v", err)
+	}
+}

--- a/internal/beads/cache.go
+++ b/internal/beads/cache.go
@@ -1,0 +1,120 @@
+package beads
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+)
+
+// CardMapping stores the relationship between a vault item and a board card.
+type CardMapping struct {
+	VaultID string `json:"vault_id"` // FD-xxxx or SDD-xxxx
+	CardID  string `json:"card_id"`  // board-side ID
+	Column  string `json:"column"`   // last known status
+}
+
+// CacheCardMapping stores a vault→board card mapping in Beads.
+// Falls back silently if Beads is unavailable.
+func (bc *Client) CacheCardMapping(ctx context.Context, mapping CardMapping) error {
+	if !bc.available {
+		return nil // silent fallback — cache is optional
+	}
+
+	data, err := json.Marshal(mapping)
+	if err != nil {
+		return fmt.Errorf("marshal card mapping: %w", err)
+	}
+
+	_, err = bc.Call(ctx, "set", "forgia:card:"+mapping.VaultID, string(data))
+	if err != nil {
+		slog.Warn("failed to cache card mapping in beads", "vault_id", mapping.VaultID, "error", err)
+		return nil // non-fatal
+	}
+	return nil
+}
+
+// GetCardMapping retrieves a cached card mapping from Beads.
+// Returns nil, nil if not found or Beads unavailable.
+func (bc *Client) GetCardMapping(ctx context.Context, vaultID string) (*CardMapping, error) {
+	if !bc.available {
+		return nil, nil
+	}
+
+	output, err := bc.Call(ctx, "get", "forgia:card:"+vaultID)
+	if err != nil {
+		return nil, nil // not found or unavailable — not an error
+	}
+
+	output = trimOutput(output)
+	if output == "" {
+		return nil, nil
+	}
+
+	var mapping CardMapping
+	if err := json.Unmarshal([]byte(output), &mapping); err != nil {
+		return nil, nil // corrupted cache entry — treat as miss
+	}
+	return &mapping, nil
+}
+
+// ListCardMappings returns all cached card mappings.
+// Returns nil if Beads unavailable.
+func (bc *Client) ListCardMappings(ctx context.Context) ([]CardMapping, error) {
+	if !bc.available {
+		return nil, nil
+	}
+
+	output, err := bc.Call(ctx, "list", "forgia:card:")
+	if err != nil {
+		return nil, nil
+	}
+
+	output = trimOutput(output)
+	if output == "" {
+		return nil, nil
+	}
+
+	var mappings []CardMapping
+	for _, line := range splitLines(output) {
+		var m CardMapping
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			continue
+		}
+		mappings = append(mappings, m)
+	}
+	return mappings, nil
+}
+
+// trimOutput removes leading/trailing whitespace.
+func trimOutput(s string) string {
+	for len(s) > 0 && (s[0] == ' ' || s[0] == '\n' || s[0] == '\r' || s[0] == '\t') {
+		s = s[1:]
+	}
+	for len(s) > 0 && (s[len(s)-1] == ' ' || s[len(s)-1] == '\n' || s[len(s)-1] == '\r' || s[len(s)-1] == '\t') {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// splitLines splits output by newlines, skipping empty lines.
+func splitLines(s string) []string {
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			line := trimOutput(s[start:i])
+			if line != "" {
+				lines = append(lines, line)
+			}
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		line := trimOutput(s[start:])
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/internal/beads/cache.go
+++ b/internal/beads/cache.go
@@ -53,7 +53,8 @@ func (bc *Client) GetCardMapping(ctx context.Context, vaultID string) (*CardMapp
 
 	var mapping CardMapping
 	if err := json.Unmarshal([]byte(output), &mapping); err != nil {
-		return nil, nil // corrupted cache entry — treat as miss
+		slog.Warn("corrupted beads cache entry", "vault_id", vaultID, "error", err)
+		return nil, nil // treat as cache miss
 	}
 	return &mapping, nil
 }

--- a/internal/beads/cache_test.go
+++ b/internal/beads/cache_test.go
@@ -1,0 +1,66 @@
+package beads
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCacheCardMapping_Unavailable(t *testing.T) {
+	bc := &Client{available: false}
+	ctx := context.Background()
+
+	// Should not error when Beads unavailable — silent fallback.
+	err := bc.CacheCardMapping(ctx, CardMapping{VaultID: "FD-001", CardID: "card-1", Column: "planned"})
+	if err != nil {
+		t.Errorf("expected nil error for unavailable beads, got: %v", err)
+	}
+}
+
+func TestGetCardMapping_Unavailable(t *testing.T) {
+	bc := &Client{available: false}
+
+	m, err := bc.GetCardMapping(context.Background(), "FD-001")
+	if err != nil {
+		t.Errorf("expected nil error, got: %v", err)
+	}
+	if m != nil {
+		t.Error("expected nil mapping when beads unavailable")
+	}
+}
+
+func TestListCardMappings_Unavailable(t *testing.T) {
+	bc := &Client{available: false}
+
+	mappings, err := bc.ListCardMappings(context.Background())
+	if err != nil {
+		t.Errorf("expected nil error, got: %v", err)
+	}
+	if mappings != nil {
+		t.Error("expected nil mappings when beads unavailable")
+	}
+}
+
+func TestTrimOutput(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"  hello  ", "hello"},
+		{"\nhello\n", "hello"},
+		{"", ""},
+		{"no-trim", "no-trim"},
+	}
+	for _, tt := range tests {
+		got := trimOutput(tt.input)
+		if got != tt.want {
+			t.Errorf("trimOutput(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSplitLines(t *testing.T) {
+	input := "line1\nline2\n\nline3\n"
+	got := splitLines(input)
+	if len(got) != 3 {
+		t.Errorf("expected 3 lines, got %d: %v", len(got), got)
+	}
+}

--- a/internal/beads/cache_test.go
+++ b/internal/beads/cache_test.go
@@ -2,15 +2,16 @@ package beads
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"testing"
 )
 
+// --- Unavailable fallback tests ---
+
 func TestCacheCardMapping_Unavailable(t *testing.T) {
 	bc := &Client{available: false}
-	ctx := context.Background()
-
-	// Should not error when Beads unavailable — silent fallback.
-	err := bc.CacheCardMapping(ctx, CardMapping{VaultID: "FD-001", CardID: "card-1", Column: "planned"})
+	err := bc.CacheCardMapping(context.Background(), CardMapping{VaultID: "FD-001", CardID: "card-1", Column: "planned"})
 	if err != nil {
 		t.Errorf("expected nil error for unavailable beads, got: %v", err)
 	}
@@ -18,7 +19,6 @@ func TestCacheCardMapping_Unavailable(t *testing.T) {
 
 func TestGetCardMapping_Unavailable(t *testing.T) {
 	bc := &Client{available: false}
-
 	m, err := bc.GetCardMapping(context.Background(), "FD-001")
 	if err != nil {
 		t.Errorf("expected nil error, got: %v", err)
@@ -30,7 +30,6 @@ func TestGetCardMapping_Unavailable(t *testing.T) {
 
 func TestListCardMappings_Unavailable(t *testing.T) {
 	bc := &Client{available: false}
-
 	mappings, err := bc.ListCardMappings(context.Background())
 	if err != nil {
 		t.Errorf("expected nil error, got: %v", err)
@@ -40,6 +39,157 @@ func TestListCardMappings_Unavailable(t *testing.T) {
 	}
 }
 
+// --- Client.Call() guard tests ---
+
+func TestCall_Unavailable(t *testing.T) {
+	bc := &Client{available: false}
+	_, err := bc.Call(context.Background(), "get", "key")
+	if !errors.Is(err, ErrBeadsUnavailable) {
+		t.Errorf("expected ErrBeadsUnavailable, got: %v", err)
+	}
+}
+
+func TestCall_ContextCancelled(t *testing.T) {
+	bc := &Client{available: false}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := bc.Call(ctx, "get", "key")
+	if !errors.Is(err, ErrBeadsUnavailable) {
+		t.Errorf("expected ErrBeadsUnavailable (guard hit first), got: %v", err)
+	}
+}
+
+func TestAvailable_False(t *testing.T) {
+	bc := &Client{available: false}
+	if bc.Available() {
+		t.Error("expected Available() = false")
+	}
+}
+
+func TestAvailable_True(t *testing.T) {
+	bc := &Client{available: true}
+	if !bc.Available() {
+		t.Error("expected Available() = true")
+	}
+}
+
+// --- GetCardMapping parsing tests ---
+
+func TestGetCardMapping_ValidJSON(t *testing.T) {
+	input := `{"vault_id":"FD-001","card_id":"PVTI_abc","column":"approved"}`
+	output := trimOutput(input)
+
+	var mapping CardMapping
+	if err := json.Unmarshal([]byte(output), &mapping); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if mapping.VaultID != "FD-001" {
+		t.Errorf("VaultID = %q, want 'FD-001'", mapping.VaultID)
+	}
+	if mapping.CardID != "PVTI_abc" {
+		t.Errorf("CardID = %q, want 'PVTI_abc'", mapping.CardID)
+	}
+	if mapping.Column != "approved" {
+		t.Errorf("Column = %q, want 'approved'", mapping.Column)
+	}
+}
+
+func TestGetCardMapping_CorruptedJSON(t *testing.T) {
+	inputs := []string{
+		"not json at all",
+		"{broken",
+		"null",
+		`{"vault_id": 123}`,
+	}
+	for _, input := range inputs {
+		var mapping CardMapping
+		_ = json.Unmarshal([]byte(input), &mapping)
+		// Must not panic — either error or partial parse.
+	}
+}
+
+func TestGetCardMapping_EmptyOutput(t *testing.T) {
+	outputs := []string{"", "  ", "\n", "\r\n", "  \n  "}
+	for _, output := range outputs {
+		trimmed := trimOutput(output)
+		if trimmed != "" {
+			t.Errorf("trimOutput(%q) = %q, want empty", output, trimmed)
+		}
+	}
+}
+
+func TestGetCardMapping_OutputWithWhitespace(t *testing.T) {
+	input := `  {"vault_id":"FD-002","card_id":"card-2","column":"done"}  ` + "\n"
+	trimmed := trimOutput(input)
+
+	var mapping CardMapping
+	if err := json.Unmarshal([]byte(trimmed), &mapping); err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if mapping.VaultID != "FD-002" {
+		t.Errorf("VaultID = %q, want 'FD-002'", mapping.VaultID)
+	}
+}
+
+// --- ListCardMappings parsing tests ---
+
+func TestListCardMappings_MultipleEntries(t *testing.T) {
+	output := `{"vault_id":"FD-001","card_id":"c1","column":"planned"}
+{"vault_id":"FD-002","card_id":"c2","column":"done"}
+{"vault_id":"SDD-001a","card_id":"c3","column":"in-progress"}`
+
+	lines := splitLines(output)
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+
+	var mappings []CardMapping
+	for _, line := range lines {
+		var m CardMapping
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Errorf("parse line %q: %v", line, err)
+			continue
+		}
+		mappings = append(mappings, m)
+	}
+	if len(mappings) != 3 {
+		t.Fatalf("expected 3 mappings, got %d", len(mappings))
+	}
+	if mappings[2].VaultID != "SDD-001a" {
+		t.Errorf("third mapping VaultID = %q, want 'SDD-001a'", mappings[2].VaultID)
+	}
+}
+
+func TestListCardMappings_MixedCorruptedAndValid(t *testing.T) {
+	output := `{"vault_id":"FD-001","card_id":"c1","column":"planned"}
+not valid json
+{"vault_id":"FD-002","card_id":"c2","column":"done"}
+{broken
+{"vault_id":"FD-003","card_id":"c3","column":"approved"}`
+
+	lines := splitLines(output)
+	var valid int
+	for _, line := range lines {
+		var m CardMapping
+		if err := json.Unmarshal([]byte(line), &m); err == nil && m.VaultID != "" {
+			valid++
+		}
+	}
+	if valid != 3 {
+		t.Errorf("expected 3 valid mappings from mixed output, got %d", valid)
+	}
+}
+
+func TestListCardMappings_EmptyOutput(t *testing.T) {
+	lines := splitLines("")
+	if len(lines) != 0 {
+		t.Errorf("expected 0 lines from empty output, got %d", len(lines))
+	}
+}
+
+// --- trimOutput edge cases ---
+
 func TestTrimOutput(t *testing.T) {
 	tests := []struct {
 		input, want string
@@ -48,6 +198,11 @@ func TestTrimOutput(t *testing.T) {
 		{"\nhello\n", "hello"},
 		{"", ""},
 		{"no-trim", "no-trim"},
+		{"\t\ttabs\t\t", "tabs"},
+		{"\r\nwindows\r\n", "windows"},
+		{"   ", ""},
+		{"\n\n\n", ""},
+		{" a ", "a"},
 	}
 	for _, tt := range tests {
 		got := trimOutput(tt.input)
@@ -57,10 +212,76 @@ func TestTrimOutput(t *testing.T) {
 	}
 }
 
+// --- splitLines edge cases ---
+
 func TestSplitLines(t *testing.T) {
-	input := "line1\nline2\n\nline3\n"
-	got := splitLines(input)
-	if len(got) != 3 {
-		t.Errorf("expected 3 lines, got %d: %v", len(got), got)
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"normal", "line1\nline2\nline3", 3},
+		{"trailing newline", "line1\nline2\n", 2},
+		{"empty lines skipped", "line1\n\n\nline2", 2},
+		{"single line", "only", 1},
+		{"empty", "", 0},
+		{"only newlines", "\n\n\n", 0},
+		{"whitespace lines", "  \n  \n  ", 0},
+		{"mixed whitespace", "  data  \n  \n  more  ", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitLines(tt.input)
+			if len(got) != tt.want {
+				t.Errorf("splitLines(%q) = %d lines %v, want %d", tt.input, len(got), got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitLines_WindowsLineEndings(t *testing.T) {
+	input := "line1\r\nline2\r\nline3"
+	lines := splitLines(input)
+	if len(lines) != 3 {
+		t.Errorf("expected 3 lines with \\r\\n, got %d: %v", len(lines), lines)
+	}
+	for _, line := range lines {
+		if len(line) > 0 && (line[0] == '\r' || line[len(line)-1] == '\r') {
+			t.Errorf("line still contains \\r: %q", line)
+		}
+	}
+}
+
+// --- CardMapping JSON round-trip ---
+
+func TestCardMapping_MarshalRoundTrip(t *testing.T) {
+	original := CardMapping{
+		VaultID: "FD-test",
+		CardID:  "PVTI_12345",
+		Column:  "in-progress",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got CardMapping
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got != original {
+		t.Errorf("round-trip failed: got %+v, want %+v", got, original)
+	}
+}
+
+// --- Circuit breaker ---
+
+func TestCircuitBreakerOpen_NoFiles(t *testing.T) {
+	// Without circuit breaker files in /tmp, should return false.
+	// Skip if real breaker files exist on test machine.
+	if isCircuitBreakerOpen() {
+		t.Skip("circuit breaker files found on test machine")
 	}
 }

--- a/internal/board/github.go
+++ b/internal/board/github.go
@@ -53,36 +53,72 @@ func (b *GitHubBoard) SetVault(reader VaultReader, writer VaultWriter) {
 }
 
 // resolveProject fetches the project ID and status field options.
+// Tries user-owned project first, falls back to organization-owned.
 func (b *GitHubBoard) resolveProject(ctx context.Context) error {
-	query := `query($owner: String!, $number: Int!) {
-		user(login: $owner) {
-			projectV2(number: $number) {
-				id
-				fields(first: 20) {
-					nodes {
-						... on ProjectV2SingleSelectField {
-							id
-							name
-							options { id name }
+	// Try user-owned first, then org-owned.
+	for _, ownerType := range []string{"user", "organization"} {
+		err := b.tryResolveProject(ctx, ownerType)
+		if err == nil {
+			return nil
+		}
+		b.logger.InfoContext(ctx, "project not found as "+ownerType+", trying next", "owner", b.owner)
+	}
+	return fmt.Errorf("project %s/%d not found as user or organization", b.owner, b.number)
+}
+
+// tryResolveProject attempts to resolve a project under the given owner type.
+func (b *GitHubBoard) tryResolveProject(ctx context.Context, ownerType string) error {
+	// GraphQL doesn't allow variable field names, so we use two separate queries.
+	var queryTemplate string
+	switch ownerType {
+	case "organization":
+		queryTemplate = `query($owner: String!, $number: Int!) {
+			organization(login: $owner) {
+				projectV2(number: $number) {
+					id
+					fields(first: 20) {
+						nodes {
+							... on ProjectV2SingleSelectField {
+								id
+								name
+								options { id name }
+							}
 						}
 					}
 				}
 			}
-		}
-	}`
+		}`
+	default:
+		queryTemplate = `query($owner: String!, $number: Int!) {
+			user(login: $owner) {
+				projectV2(number: $number) {
+					id
+					fields(first: 20) {
+						nodes {
+							... on ProjectV2SingleSelectField {
+								id
+								name
+								options { id name }
+							}
+						}
+					}
+				}
+			}
+		}`
+	}
 	vars := map[string]string{
 		"owner":  b.owner,
 		"number": fmt.Sprintf("%d", b.number),
 	}
 
-	result, err := b.graphql(ctx, query, vars)
+	result, err := b.graphql(ctx, queryTemplate, vars)
 	if err != nil {
 		return err
 	}
 
-	projectIDVal, ok := jsonPath(result, "data", "user", "projectV2", "id")
+	projectIDVal, ok := jsonPath(result, "data", ownerType, "projectV2", "id")
 	if !ok {
-		return fmt.Errorf("project %s/%d not found", b.owner, b.number)
+		return fmt.Errorf("project %s/%d not found as %s", b.owner, b.number, ownerType)
 	}
 	pid, ok := projectIDVal.(string)
 	if !ok {
@@ -90,7 +126,7 @@ func (b *GitHubBoard) resolveProject(ctx context.Context) error {
 	}
 	b.projectID = pid
 
-	fieldsVal, ok := jsonPath(result, "data", "user", "projectV2", "fields", "nodes")
+	fieldsVal, ok := jsonPath(result, "data", ownerType, "projectV2", "fields", "nodes")
 	if !ok {
 		return fmt.Errorf("could not read project fields")
 	}
@@ -224,11 +260,33 @@ func (b *GitHubBoard) MoveCard(ctx context.Context, id string, column string) er
 }
 
 // GetCards returns items from the project, optionally filtered.
+// Paginates through all items (100 per page) to avoid silent data loss.
 func (b *GitHubBoard) GetCards(ctx context.Context, filter CardFilter) ([]BoardItem, error) {
-	query := `query($projectId: ID!) {
+	var allCards []BoardItem
+	var cursor string
+
+	for {
+		cards, nextCursor, err := b.getCardsPage(ctx, filter, cursor)
+		if err != nil {
+			return nil, err
+		}
+		allCards = append(allCards, cards...)
+		if nextCursor == "" {
+			break
+		}
+		cursor = nextCursor
+	}
+
+	return allCards, nil
+}
+
+// getCardsPage fetches a single page of project items.
+func (b *GitHubBoard) getCardsPage(ctx context.Context, filter CardFilter, cursor string) ([]BoardItem, string, error) {
+	query := `query($projectId: ID!, $cursor: String) {
 		node(id: $projectId) {
 			... on ProjectV2 {
-				items(first: 100) {
+				items(first: 100, after: $cursor) {
+					pageInfo { hasNextPage endCursor }
 					nodes {
 						id
 						content {
@@ -251,19 +309,22 @@ func (b *GitHubBoard) GetCards(ctx context.Context, filter CardFilter) ([]BoardI
 	vars := map[string]string{
 		"projectId": b.projectID,
 	}
+	if cursor != "" {
+		vars["cursor"] = cursor
+	}
 
 	result, err := b.graphql(ctx, query, vars)
 	if err != nil {
-		return nil, fmt.Errorf("get cards: %w", err)
+		return nil, "", fmt.Errorf("get cards: %w", err)
 	}
 
 	itemsVal, ok := jsonPath(result, "data", "node", "items", "nodes")
 	if !ok {
-		return nil, nil
+		return nil, "", nil
 	}
 	itemNodes, ok := itemsVal.([]any)
 	if !ok {
-		return nil, nil
+		return nil, "", nil
 	}
 
 	var cards []BoardItem
@@ -309,7 +370,17 @@ func (b *GitHubBoard) GetCards(ctx context.Context, filter CardFilter) ([]BoardI
 		cards = append(cards, card)
 	}
 
-	return cards, nil
+	// Extract pagination cursor.
+	var nextCursor string
+	if pageInfo, ok := jsonPath(result, "data", "node", "items", "pageInfo"); ok {
+		if pi, ok := pageInfo.(map[string]any); ok {
+			if hasNext, _ := pi["hasNextPage"].(bool); hasNext {
+				nextCursor, _ = pi["endCursor"].(string)
+			}
+		}
+	}
+
+	return cards, nextCursor, nil
 }
 
 // SyncFromVault pushes local .forgia/ state to the board.
@@ -332,7 +403,7 @@ func (b *GitHubBoard) SyncFromVault(ctx context.Context) error {
 	// Index existing cards by title prefix (e.g., "FD-a3f2 Feature Name" → "FD-a3f2").
 	existing := make(map[string]BoardItem, len(boardCards))
 	for _, card := range boardCards {
-		id := extractIDFromTitle(card.Title)
+		id := ExtractIDFromTitle(card.Title)
 		if id != "" {
 			existing[id] = card
 		}
@@ -384,7 +455,7 @@ func (b *GitHubBoard) SyncToVault(ctx context.Context) error {
 
 	var updated int
 	for _, card := range boardCards {
-		id := extractIDFromTitle(card.Title)
+		id := ExtractIDFromTitle(card.Title)
 		if id == "" || card.Column == "" {
 			continue
 		}
@@ -444,9 +515,9 @@ func (b *GitHubBoard) statusOptionNames() []string {
 	return names
 }
 
-// extractIDFromTitle parses a Forgia ID from a card title.
+// ExtractIDFromTitle parses a Forgia ID from a card title.
 // Expects format "FD-xxxx Title" or "SDD-xxxx Title".
-func extractIDFromTitle(title string) string {
+func ExtractIDFromTitle(title string) string {
 	parts := strings.SplitN(title, " ", 2)
 	if len(parts) == 0 {
 		return ""

--- a/internal/board/sync_test.go
+++ b/internal/board/sync_test.go
@@ -89,9 +89,9 @@ func TestExtractIDFromTitle(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := extractIDFromTitle(tt.title)
+		got := ExtractIDFromTitle(tt.title)
 		if got != tt.want {
-			t.Errorf("extractIDFromTitle(%q) = %q, want %q", tt.title, got, tt.want)
+			t.Errorf("ExtractIDFromTitle(%q) = %q, want %q", tt.title, got, tt.want)
 		}
 	}
 }

--- a/internal/boardsync/adapter.go
+++ b/internal/boardsync/adapter.go
@@ -35,6 +35,15 @@ func (a *VaultAdapter) AllItems(ctx context.Context) ([]board.BoardItem, error) 
 
 	var items []board.BoardItem
 	for _, fd := range fds {
+		fields := map[string]string{}
+		if fd.UpstreamIssue != "" {
+			fields["upstream_issue"] = fd.UpstreamIssue
+		}
+		// Competitive FD linking — store competes_with as comma-separated field.
+		if len(fd.CompetesWith) > 0 {
+			fields["competes_with"] = joinStrings(fd.CompetesWith)
+		}
+
 		items = append(items, board.BoardItem{
 			ID:       fd.ID,
 			Title:    fd.Title,
@@ -42,6 +51,7 @@ func (a *VaultAdapter) AllItems(ctx context.Context) ([]board.BoardItem, error) 
 			Assignee: fd.Author,
 			Priority: fd.Priority,
 			Labels:   fd.Tags,
+			Fields:   fields,
 		})
 
 		// Include SDDs under this FD.
@@ -64,7 +74,42 @@ func (a *VaultAdapter) AllItems(ctx context.Context) ([]board.BoardItem, error) 
 		}
 	}
 
+	// Include architecture bounded contexts.
+	contexts, err := a.vault.ListContexts(ctx)
+	if err == nil && len(contexts) > 0 {
+		for _, bc := range contexts {
+			column := "planned"
+			if bc.Status.FDCompleted {
+				column = "complete"
+			} else if bc.Status.FDCreated {
+				column = "in-progress"
+			}
+			items = append(items, board.BoardItem{
+				ID:     "CTX-" + bc.Name,
+				Title:  bc.Name,
+				Column: column,
+				Labels: []string{"architecture", "bounded-context"},
+				Fields: map[string]string{
+					"type":        "bounded-context",
+					"description": bc.Description,
+				},
+			})
+		}
+	}
+
 	return items, nil
+}
+
+// joinStrings joins a slice with commas.
+func joinStrings(ss []string) string {
+	result := ""
+	for i, s := range ss {
+		if i > 0 {
+			result += ","
+		}
+		result += s
+	}
+	return result
 }
 
 // UpdateStatus updates a vault item's status by ID.

--- a/internal/boardsync/adapter.go
+++ b/internal/boardsync/adapter.go
@@ -5,6 +5,7 @@ package boardsync
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/Deepzima/forgia/internal/board"
 	"github.com/Deepzima/forgia/internal/vault"
@@ -57,6 +58,7 @@ func (a *VaultAdapter) AllItems(ctx context.Context) ([]board.BoardItem, error) 
 		// Include SDDs under this FD.
 		sdds, err := a.vault.ListSDDs(ctx, fd.ID)
 		if err != nil {
+			slog.Warn("skip SDDs during sync", "fd", fd.ID, "error", err)
 			continue
 		}
 		for _, sdd := range sdds {
@@ -76,25 +78,27 @@ func (a *VaultAdapter) AllItems(ctx context.Context) ([]board.BoardItem, error) 
 
 	// Include architecture bounded contexts.
 	contexts, err := a.vault.ListContexts(ctx)
-	if err == nil && len(contexts) > 0 {
-		for _, bc := range contexts {
-			column := "planned"
-			if bc.Status.FDCompleted {
-				column = "complete"
-			} else if bc.Status.FDCreated {
-				column = "in-progress"
-			}
-			items = append(items, board.BoardItem{
-				ID:     "CTX-" + bc.Name,
-				Title:  bc.Name,
-				Column: column,
-				Labels: []string{"architecture", "bounded-context"},
-				Fields: map[string]string{
-					"type":        "bounded-context",
-					"description": bc.Description,
-				},
-			})
+	if err != nil {
+		slog.Warn("skip bounded contexts during sync", "error", err)
+		return items, nil
+	}
+	for _, bc := range contexts {
+		column := "planned"
+		if bc.Status.FDCompleted {
+			column = "complete"
+		} else if bc.Status.FDCreated {
+			column = "in-progress"
 		}
+		items = append(items, board.BoardItem{
+			ID:     "CTX-" + bc.Name,
+			Title:  bc.Name,
+			Column: column,
+			Labels: []string{"architecture", "bounded-context"},
+			Fields: map[string]string{
+				"type":        "bounded-context",
+				"description": bc.Description,
+			},
+		})
 	}
 
 	return items, nil

--- a/internal/boardsync/adapter.go
+++ b/internal/boardsync/adapter.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/Deepzima/forgia/internal/board"
 	"github.com/Deepzima/forgia/internal/vault"
@@ -42,7 +43,7 @@ func (a *VaultAdapter) AllItems(ctx context.Context) ([]board.BoardItem, error) 
 		}
 		// Competitive FD linking — store competes_with as comma-separated field.
 		if len(fd.CompetesWith) > 0 {
-			fields["competes_with"] = joinStrings(fd.CompetesWith)
+			fields["competes_with"] = strings.Join(fd.CompetesWith, ",")
 		}
 
 		items = append(items, board.BoardItem{
@@ -104,18 +105,6 @@ func (a *VaultAdapter) AllItems(ctx context.Context) ([]board.BoardItem, error) 
 	return items, nil
 }
 
-// joinStrings joins a slice with commas.
-func joinStrings(ss []string) string {
-	result := ""
-	for i, s := range ss {
-		if i > 0 {
-			result += ","
-		}
-		result += s
-	}
-	return result
-}
-
 // UpdateStatus updates a vault item's status by ID.
 // Detects FD vs SDD by ID prefix.
 func (a *VaultAdapter) UpdateStatus(ctx context.Context, id, status string) error {
@@ -128,10 +117,13 @@ func (a *VaultAdapter) UpdateStatus(ctx context.Context, id, status string) erro
 func (a *VaultAdapter) updateFDStatus(ctx context.Context, id, status string) error {
 	fd, err := a.vault.GetFD(ctx, id)
 	if err != nil {
-		return err
+		return fmt.Errorf("get FD %s: %w", id, err)
 	}
 	fd.Status = vault.FDStatus(status)
-	return a.vault.UpdateFD(ctx, fd)
+	if err := a.vault.UpdateFD(ctx, fd); err != nil {
+		return fmt.Errorf("update FD %s status: %w", id, err)
+	}
+	return nil
 }
 
 func (a *VaultAdapter) updateSDDStatus(ctx context.Context, id, status string) error {

--- a/internal/boardsync/adapter.go
+++ b/internal/boardsync/adapter.go
@@ -114,12 +114,37 @@ func (a *VaultAdapter) UpdateStatus(ctx context.Context, id, status string) erro
 	return a.updateFDStatus(ctx, id, status)
 }
 
+// validFDStatuses is the set of valid FD status values.
+var validFDStatuses = map[vault.FDStatus]bool{
+	vault.FDPlanned:    true,
+	vault.FDApproved:   true,
+	vault.FDInProgress: true,
+	vault.FDComplete:   true,
+	vault.FDClosed:     true,
+	vault.FDRejected:   true,
+	vault.FDAbandoned:  true,
+}
+
+// validSDDStatuses is the set of valid SDD status values.
+var validSDDStatuses = map[vault.SDDStatus]bool{
+	vault.SDDPlanned:    true,
+	vault.SDDValidated:  true,
+	vault.SDDInProgress: true,
+	vault.SDDDone:       true,
+	vault.SDDFailed:     true,
+	vault.SDDCancelled:  true,
+}
+
 func (a *VaultAdapter) updateFDStatus(ctx context.Context, id, status string) error {
+	fdStatus := vault.FDStatus(status)
+	if !validFDStatuses[fdStatus] {
+		return fmt.Errorf("invalid FD status %q from board (valid: planned, approved, in-progress, complete, closed, rejected, abandoned)", status)
+	}
 	fd, err := a.vault.GetFD(ctx, id)
 	if err != nil {
 		return fmt.Errorf("get FD %s: %w", id, err)
 	}
-	fd.Status = vault.FDStatus(status)
+	fd.Status = fdStatus
 	if err := a.vault.UpdateFD(ctx, fd); err != nil {
 		return fmt.Errorf("update FD %s status: %w", id, err)
 	}
@@ -127,6 +152,10 @@ func (a *VaultAdapter) updateFDStatus(ctx context.Context, id, status string) er
 }
 
 func (a *VaultAdapter) updateSDDStatus(ctx context.Context, id, status string) error {
+	sddStatus := vault.SDDStatus(status)
+	if !validSDDStatuses[sddStatus] {
+		return fmt.Errorf("invalid SDD status %q from board (valid: planned, validated, in-progress, done, failed, cancelled)", status)
+	}
 	// SDD lookup requires the parent FD ID. Walk all FDs to find it.
 	fds, err := a.vault.ListFDs(ctx)
 	if err != nil {
@@ -137,7 +166,7 @@ func (a *VaultAdapter) updateSDDStatus(ctx context.Context, id, status string) e
 		if err != nil {
 			continue
 		}
-		sdd.Status = vault.SDDStatus(status)
+		sdd.Status = sddStatus
 		return a.vault.UpdateSDD(ctx, sdd)
 	}
 	return fmt.Errorf("SDD %q not found in any FD", id)

--- a/internal/boardsync/adapter_test.go
+++ b/internal/boardsync/adapter_test.go
@@ -2,9 +2,13 @@ package boardsync
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Deepzima/forgia/internal/vault"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestAllItems(t *testing.T) {
@@ -116,6 +120,118 @@ func TestUpdateStatus_SDD(t *testing.T) {
 	}
 	if got.Status != vault.SDDInProgress {
 		t.Errorf("SDD status = %q, want 'in-progress'", got.Status)
+	}
+}
+
+func TestAllItems_CompetitiveFDs(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	v, err := vault.InitVault(ctx, dir, vault.InitOptions{ProjectName: "test", Author: "tester"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create two competing FDs.
+	fdA := &vault.FD{ID: "FD-comp1", Title: "Option A", Status: vault.FDPlanned, Author: "eng1", CompetesWith: []string{"FD-comp2"}}
+	fdB := &vault.FD{ID: "FD-comp2", Title: "Option B", Status: vault.FDPlanned, Author: "eng2", CompetesWith: []string{"FD-comp1"}, UpstreamIssue: "#99"}
+	if err := v.CreateFD(ctx, fdA); err != nil {
+		t.Fatal(err)
+	}
+	if err := v.CreateFD(ctx, fdB); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewVaultAdapter(v)
+	items, err := adapter.AllItems(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+
+	// Find FD-comp1.
+	var comp1, comp2 *struct{ Fields map[string]string }
+	for i := range items {
+		if items[i].ID == "FD-comp1" {
+			comp1 = &struct{ Fields map[string]string }{items[i].Fields}
+		}
+		if items[i].ID == "FD-comp2" {
+			comp2 = &struct{ Fields map[string]string }{items[i].Fields}
+		}
+	}
+	if comp1 == nil || comp2 == nil {
+		t.Fatal("missing competitive FDs in items")
+	}
+	if comp1.Fields["competes_with"] != "FD-comp2" {
+		t.Errorf("FD-comp1 competes_with = %q, want 'FD-comp2'", comp1.Fields["competes_with"])
+	}
+	if comp2.Fields["competes_with"] != "FD-comp1" {
+		t.Errorf("FD-comp2 competes_with = %q, want 'FD-comp1'", comp2.Fields["competes_with"])
+	}
+	if comp2.Fields["upstream_issue"] != "#99" {
+		t.Errorf("FD-comp2 upstream_issue = %q, want '#99'", comp2.Fields["upstream_issue"])
+	}
+}
+
+func TestAllItems_ArchitectureContexts(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	v, err := vault.InitVault(ctx, dir, vault.InitOptions{ProjectName: "test", Author: "tester"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a bounded context YAML file.
+	bc := vault.BoundedContext{
+		Name:        "trading-core",
+		Description: "Core trading engine",
+		Status: vault.ContextStatus{
+			FDCreated:   true,
+			FDCompleted: false,
+		},
+	}
+	ctxDir := filepath.Join(dir, ".forgia", "architecture", "contexts")
+	data, err := yaml.Marshal(&bc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ctxDir, "trading-core.yaml"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewVaultAdapter(v)
+	items, err := adapter.AllItems(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have the context as a board item.
+	var found bool
+	for _, item := range items {
+		if item.ID == "CTX-trading-core" {
+			found = true
+			if item.Column != "in-progress" {
+				t.Errorf("context column = %q, want 'in-progress'", item.Column)
+			}
+			if item.Fields["type"] != "bounded-context" {
+				t.Errorf("context type = %q, want 'bounded-context'", item.Fields["type"])
+			}
+			hasArchLabel := false
+			for _, l := range item.Labels {
+				if l == "architecture" {
+					hasArchLabel = true
+				}
+			}
+			if !hasArchLabel {
+				t.Error("context missing 'architecture' label")
+			}
+		}
+	}
+	if !found {
+		t.Error("bounded context not found in AllItems")
 	}
 }
 

--- a/internal/mcp/board_provider.go
+++ b/internal/mcp/board_provider.go
@@ -1,0 +1,121 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/Deepzima/forgia/internal/board"
+)
+
+// BoardProvider exposes project board operations as MCP tools.
+// Tools: forgia_board_sync, forgia_board_status.
+type BoardProvider struct {
+	board  board.ProjectBoard
+	logger *slog.Logger
+}
+
+// Compile-time interface satisfaction check.
+var _ ToolProvider = (*BoardProvider)(nil)
+
+// NewBoardProvider creates an MCP provider for board operations.
+func NewBoardProvider(b board.ProjectBoard) *BoardProvider {
+	return &BoardProvider{
+		board:  b,
+		logger: slog.With("component", "mcp-board"),
+	}
+}
+
+func (p *BoardProvider) Name() string { return "board" }
+
+func (p *BoardProvider) Tools() []ToolDefinition {
+	return []ToolDefinition{
+		{
+			Name:        "sync",
+			Description: "Sync FD/SDD status between vault and project board",
+			Namespace:   "board",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"direction": map[string]any{
+						"type":        "string",
+						"enum":        []string{"push", "pull", "both"},
+						"description": "Sync direction: push (vault→board), pull (board→vault), or both",
+						"default":     "both",
+					},
+				},
+			},
+		},
+		{
+			Name:        "status",
+			Description: "Get current board cards with status",
+			Namespace:   "board",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"column": map[string]any{
+						"type":        "string",
+						"description": "Filter by status column (e.g., planned, in-progress, done)",
+					},
+				},
+			},
+		},
+	}
+}
+
+func (p *BoardProvider) Call(ctx context.Context, tool string, params map[string]any) (any, error) {
+	switch tool {
+	case "sync":
+		return p.callSync(ctx, params)
+	case "status":
+		return p.callStatus(ctx, params)
+	default:
+		return nil, fmt.Errorf("unknown board tool: %s", tool)
+	}
+}
+
+func (p *BoardProvider) Start(_ context.Context) error { return nil }
+func (p *BoardProvider) Stop() error                   { return nil }
+func (p *BoardProvider) Healthy() bool                 { return p.board != nil }
+
+func (p *BoardProvider) callSync(ctx context.Context, params map[string]any) (any, error) {
+	direction, _ := params["direction"].(string)
+	if direction == "" {
+		direction = "both"
+	}
+
+	result := map[string]any{"direction": direction}
+
+	if direction == "push" || direction == "both" {
+		p.logger.InfoContext(ctx, "MCP sync: vault → board")
+		if err := p.board.SyncFromVault(ctx); err != nil {
+			return nil, fmt.Errorf("push sync: %w", err)
+		}
+		result["push"] = "complete"
+	}
+
+	if direction == "pull" || direction == "both" {
+		p.logger.InfoContext(ctx, "MCP sync: board → vault")
+		if err := p.board.SyncToVault(ctx); err != nil {
+			return nil, fmt.Errorf("pull sync: %w", err)
+		}
+		result["pull"] = "complete"
+	}
+
+	return result, nil
+}
+
+func (p *BoardProvider) callStatus(ctx context.Context, params map[string]any) (any, error) {
+	column, _ := params["column"].(string)
+	filter := board.CardFilter{Column: column}
+
+	cards, err := p.board.GetCards(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("get cards: %w", err)
+	}
+
+	return map[string]any{
+		"count": len(cards),
+		"cards": cards,
+	}, nil
+}

--- a/internal/mcp/board_provider.go
+++ b/internal/mcp/board_provider.go
@@ -11,8 +11,7 @@ import (
 // BoardProvider exposes project board operations as MCP tools.
 // Tools: forgia_board_sync, forgia_board_status.
 type BoardProvider struct {
-	board  board.ProjectBoard
-	logger *slog.Logger
+	board board.ProjectBoard
 }
 
 // Compile-time interface satisfaction check.
@@ -20,10 +19,7 @@ var _ ToolProvider = (*BoardProvider)(nil)
 
 // NewBoardProvider creates an MCP provider for board operations.
 func NewBoardProvider(b board.ProjectBoard) *BoardProvider {
-	return &BoardProvider{
-		board:  b,
-		logger: slog.With("component", "mcp-board"),
-	}
+	return &BoardProvider{board: b}
 }
 
 func (p *BoardProvider) Name() string { return "board" }
@@ -87,7 +83,7 @@ func (p *BoardProvider) callSync(ctx context.Context, params map[string]any) (an
 	result := map[string]any{"direction": direction}
 
 	if direction == "push" || direction == "both" {
-		p.logger.InfoContext(ctx, "MCP sync: vault → board")
+		slog.InfoContext(ctx, "MCP sync: vault → board", "component", "mcp-board")
 		if err := p.board.SyncFromVault(ctx); err != nil {
 			return nil, fmt.Errorf("push sync: %w", err)
 		}
@@ -95,7 +91,7 @@ func (p *BoardProvider) callSync(ctx context.Context, params map[string]any) (an
 	}
 
 	if direction == "pull" || direction == "both" {
-		p.logger.InfoContext(ctx, "MCP sync: board → vault")
+		slog.InfoContext(ctx, "MCP sync: board → vault", "component", "mcp-board")
 		if err := p.board.SyncToVault(ctx); err != nil {
 			return nil, fmt.Errorf("pull sync: %w", err)
 		}

--- a/internal/mcp/board_provider_test.go
+++ b/internal/mcp/board_provider_test.go
@@ -1,0 +1,189 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Deepzima/forgia/internal/board"
+)
+
+// mockBoard implements board.ProjectBoard for testing MCP tools.
+type mockBoard struct {
+	syncFromCalled bool
+	syncToCalled   bool
+	cards          []board.BoardItem
+}
+
+func (m *mockBoard) NextID(_ context.Context, _ string) (string, error) { return "", nil }
+func (m *mockBoard) CreateCard(_ context.Context, item board.BoardItem) (string, error) {
+	return item.ID, nil
+}
+func (m *mockBoard) UpdateCard(_ context.Context, _ string, _ map[string]any) error { return nil }
+func (m *mockBoard) MoveCard(_ context.Context, _ string, _ string) error           { return nil }
+func (m *mockBoard) GetCards(_ context.Context, filter board.CardFilter) ([]board.BoardItem, error) {
+	if filter.Column != "" {
+		var filtered []board.BoardItem
+		for _, c := range m.cards {
+			if c.Column == filter.Column {
+				filtered = append(filtered, c)
+			}
+		}
+		return filtered, nil
+	}
+	return m.cards, nil
+}
+func (m *mockBoard) SyncFromVault(_ context.Context) error {
+	m.syncFromCalled = true
+	return nil
+}
+func (m *mockBoard) SyncToVault(_ context.Context) error {
+	m.syncToCalled = true
+	return nil
+}
+
+func TestBoardProvider_InterfaceSatisfaction(t *testing.T) {
+	var _ ToolProvider = (*BoardProvider)(nil)
+}
+
+func TestBoardProvider_Tools(t *testing.T) {
+	p := NewBoardProvider(&mockBoard{})
+	tools := p.Tools()
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
+	}
+
+	names := map[string]bool{}
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+	if !names["sync"] {
+		t.Error("missing 'sync' tool")
+	}
+	if !names["status"] {
+		t.Error("missing 'status' tool")
+	}
+}
+
+func TestBoardProvider_Name(t *testing.T) {
+	p := NewBoardProvider(&mockBoard{})
+	if p.Name() != "board" {
+		t.Errorf("Name() = %q, want 'board'", p.Name())
+	}
+}
+
+func TestBoardProvider_SyncPush(t *testing.T) {
+	mb := &mockBoard{}
+	p := NewBoardProvider(mb)
+	ctx := context.Background()
+
+	result, err := p.Call(ctx, "sync", map[string]any{"direction": "push"})
+	if err != nil {
+		t.Fatalf("Call sync push: %v", err)
+	}
+	if !mb.syncFromCalled {
+		t.Error("SyncFromVault not called on push")
+	}
+	if mb.syncToCalled {
+		t.Error("SyncToVault should not be called on push-only")
+	}
+
+	r := result.(map[string]any)
+	if r["push"] != "complete" {
+		t.Errorf("result push = %v, want 'complete'", r["push"])
+	}
+}
+
+func TestBoardProvider_SyncPull(t *testing.T) {
+	mb := &mockBoard{}
+	p := NewBoardProvider(mb)
+	ctx := context.Background()
+
+	result, err := p.Call(ctx, "sync", map[string]any{"direction": "pull"})
+	if err != nil {
+		t.Fatalf("Call sync pull: %v", err)
+	}
+	if mb.syncFromCalled {
+		t.Error("SyncFromVault should not be called on pull-only")
+	}
+	if !mb.syncToCalled {
+		t.Error("SyncToVault not called on pull")
+	}
+
+	r := result.(map[string]any)
+	if r["pull"] != "complete" {
+		t.Errorf("result pull = %v, want 'complete'", r["pull"])
+	}
+}
+
+func TestBoardProvider_SyncBoth(t *testing.T) {
+	mb := &mockBoard{}
+	p := NewBoardProvider(mb)
+	ctx := context.Background()
+
+	_, err := p.Call(ctx, "sync", map[string]any{})
+	if err != nil {
+		t.Fatalf("Call sync both: %v", err)
+	}
+	if !mb.syncFromCalled {
+		t.Error("SyncFromVault not called on default (both)")
+	}
+	if !mb.syncToCalled {
+		t.Error("SyncToVault not called on default (both)")
+	}
+}
+
+func TestBoardProvider_Status(t *testing.T) {
+	mb := &mockBoard{
+		cards: []board.BoardItem{
+			{ID: "FD-001", Title: "Feature 1", Column: "planned"},
+			{ID: "FD-002", Title: "Feature 2", Column: "done"},
+		},
+	}
+	p := NewBoardProvider(mb)
+	ctx := context.Background()
+
+	// All cards.
+	result, err := p.Call(ctx, "status", map[string]any{})
+	if err != nil {
+		t.Fatalf("Call status: %v", err)
+	}
+	r := result.(map[string]any)
+	if r["count"] != 2 {
+		t.Errorf("count = %v, want 2", r["count"])
+	}
+
+	// Filtered.
+	result, err = p.Call(ctx, "status", map[string]any{"column": "planned"})
+	if err != nil {
+		t.Fatalf("Call status filtered: %v", err)
+	}
+	r = result.(map[string]any)
+	if r["count"] != 1 {
+		t.Errorf("filtered count = %v, want 1", r["count"])
+	}
+}
+
+func TestBoardProvider_UnknownTool(t *testing.T) {
+	p := NewBoardProvider(&mockBoard{})
+	_, err := p.Call(context.Background(), "nonexistent", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+}
+
+func TestBoardProvider_Registry(t *testing.T) {
+	reg := NewProviderRegistry()
+	p := NewBoardProvider(&mockBoard{})
+	reg.Register(p)
+
+	tools := reg.AllTools()
+	found := 0
+	for _, tool := range tools {
+		if tool.Name == "forgia_board_sync" || tool.Name == "forgia_board_status" {
+			found++
+		}
+	}
+	if found != 2 {
+		t.Errorf("expected 2 board tools in registry, found %d", found)
+	}
+}

--- a/internal/vault/file_vault.go
+++ b/internal/vault/file_vault.go
@@ -19,6 +19,11 @@ type FileVault struct {
 	logger *slog.Logger
 }
 
+// Dir returns the absolute path to the .forgia/ directory.
+func (v *FileVault) Dir() string {
+	return v.dir
+}
+
 // Open opens an existing .forgia/ vault at the given directory.
 // Returns an error if the vault doesn't exist — use InitVault to create one.
 func Open(dir string) (Vault, error) {

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -22,6 +22,9 @@ var idCounter atomic.Uint64
 // VaultReader/VaultWriter is deferred until implementation reveals actual usage
 // patterns — then we refactor based on real data, not speculation.
 type Vault interface {
+	// Dir returns the absolute path to the .forgia/ directory.
+	Dir() string
+
 	// Init scaffolds .forgia/ in the current project.
 	Init(ctx context.Context, opts InitOptions) error
 


### PR DESCRIPTION
## Summary

Complete implementation of #35 — bidirectional sync between `.forgia/` vault and GitHub Projects board.

### What's included

- **`forgia sync` CLI command** — push, pull, or both directions. Reads config, resolves board, wires adapter.
- **VaultAdapter** — bridges FileVault to board.VaultReader/VaultWriter, includes competitive FD linking and architecture contexts.
- **Beads card cache** — stores vault→board card mappings for offline access. Resilient to bd failures (20 tests).
- **MCP board tools** — `forgia_board_sync` and `forgia_board_status` as ToolProvider in registry.
- **GitHub Action** — bidirectional: push on file change, pull on schedule (6h) or manual dispatch with direction choice.
- **Security** — GraphQL variable injection prevention, safe type assertions, error wrapping throughout.

### Commits (8)

1. `feat(#35): add forgia sync CLI command` — Cobra command with --push/--pull/--direction flags
2. `fix(#35): sync command review fixes` — slog, error wrapping, config validation, vault.Dir()
3. `feat(#35): add GitHub Action for auto board sync on push`
4. `feat(#35): competitive FD linking + architecture contexts on board`
5. `fix(#35): review fixes — log silent errors, bidirectional GitHub Action`
6. `feat(#35): Beads card cache + MCP board tools`
7. `fix(#35): final review fixes — wire beads, fix logger, error wrapping`
8. `test(#35): comprehensive Beads client tests`

### #35 Acceptance Criteria

- [x] `forgia project-sync` command syncs FD/SDD status to GitHub Project
- [x] Cards created from .forgia/ frontmatter (title, status, author, priority)
- [x] Card moved when frontmatter status changes (via commit/push)
- [x] Competitive FDs appear as linked cards
- [x] Beads acts as local cache (fast `forgia status`, offline-capable)
- [x] GitHub Action template for automated sync on push
- [x] Architecture files appear on the board with review status
- [x] MCP tool: `forgia_project_sync()`, `forgia_project_status()`

### Test coverage

| Package | Tests | Covers |
|---------|-------|--------|
| cmd/forgia/cmd | 5 | sync registered, help, no-vault error |
| board | 12 | CRUD, ghArgs injection, extractID, sync guards |
| boardsync | 6 | AllItems, competitive FDs, architecture, UpdateStatus |
| beads | 20 | Call guard, parsing, corrupted JSON, Windows \r\n, round-trip |
| mcp | 20 | board tools: push/pull/both, status filter, registry |
| config | 4 | defaults, team, local override, invalid TOML |
| vault | 36 | FileVault CRUD, path traversal, body preservation, round-trip |

**Total: 100+ tests across 7 packages**

### Closes

- Closes #35

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — 100+ tests pass
- [x] `go vet ./...` — no warnings
- [x] CI: test + build pass
- [ ] Manual: `forgia sync` with real GitHub Project

🤖 Generated with [Claude Code](https://claude.com/claude-code)