### PR TITLE
feat(FD-010): implement MCPSubprocessProvider (SDD-001)

### DIFF
--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -1,0 +1,53 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const jsonrpcVersion = "2.0"
+
+// jsonrpcRequest represents a JSON-RPC 2.0 request.
+type jsonrpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+// jsonrpcResponse represents a JSON-RPC 2.0 response.
+type jsonrpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      *int            `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// jsonrpcNotification represents a JSON-RPC 2.0 notification (no response expected).
+type jsonrpcNotification struct {
+	JSONRPC string `json:"jsonrpc"`
+	Method  string `json:"method"`
+	Params  any    `json:"params,omitempty"`
+}
+
+// RPCError represents a JSON-RPC 2.0 error object.
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
+}
+
+// Error implements the error interface for RPCError.
+func (e *RPCError) Error() string {
+	return fmt.Sprintf("rpc error %d: %s", e.Code, e.Message)
+}
+
+// newRequest creates a new JSON-RPC 2.0 request with the given ID, method, and params.
+func newRequest(id int, method string, params any) jsonrpcRequest {
+	return jsonrpcRequest{
+		JSONRPC: jsonrpcVersion,
+		ID:      id,
+		Method:  method,
+		Params:  params,
+	}
+}

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -66,6 +66,9 @@ func (r *ProviderRegistry) AllTools() []ToolDefinition {
 
 	var tools []ToolDefinition
 	for _, p := range r.providers {
+		if !p.Healthy() {
+			continue
+		}
 		for _, t := range p.Tools() {
 			t.Name = ToolName(t.Namespace, t.Name)
 			tools = append(tools, t)

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -1,8 +1,257 @@
 package mcp
 
 import (
+	"context"
+	"fmt"
+	"sync"
 	"testing"
 )
+
+// mockProvider implements ToolProvider for testing.
+type mockProvider struct {
+	name    string
+	tools   []ToolDefinition
+	healthy bool
+	callFn  func(ctx context.Context, tool string, params map[string]any) (any, error)
+}
+
+func (m *mockProvider) Name() string            { return m.name }
+func (m *mockProvider) Tools() []ToolDefinition { return m.tools }
+func (m *mockProvider) Healthy() bool           { return m.healthy }
+func (m *mockProvider) Start(context.Context) error { return nil }
+func (m *mockProvider) Stop() error                 { return nil }
+func (m *mockProvider) Call(ctx context.Context, tool string, params map[string]any) (any, error) {
+	if m.callFn != nil {
+		return m.callFn(ctx, tool, params)
+	}
+	return fmt.Sprintf("called %s", tool), nil
+}
+
+func TestNewProviderRegistry(t *testing.T) {
+	r := NewProviderRegistry()
+	if r == nil {
+		t.Fatal("NewProviderRegistry returned nil")
+	}
+	if len(r.providers) != 0 {
+		t.Errorf("new registry should be empty, got %d providers", len(r.providers))
+	}
+}
+
+func TestRegister(t *testing.T) {
+	r := NewProviderRegistry()
+	p := &mockProvider{name: "code", healthy: true}
+
+	r.Register(p)
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if got, ok := r.providers["code"]; !ok {
+		t.Error("provider 'code' not found after Register")
+	} else if got != p {
+		t.Error("provider 'code' does not match registered instance")
+	}
+}
+
+func TestRegisterOverwrites(t *testing.T) {
+	r := NewProviderRegistry()
+	p1 := &mockProvider{name: "code", healthy: true, tools: []ToolDefinition{{Name: "old"}}}
+	p2 := &mockProvider{name: "code", healthy: true, tools: []ToolDefinition{{Name: "new"}}}
+
+	r.Register(p1)
+	r.Register(p2)
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if len(r.providers) != 1 {
+		t.Errorf("expected 1 provider after overwrite, got %d", len(r.providers))
+	}
+	if r.providers["code"].Tools()[0].Name != "new" {
+		t.Error("Register should overwrite existing provider with same name")
+	}
+}
+
+func TestAllToolsEmpty(t *testing.T) {
+	r := NewProviderRegistry()
+	tools := r.AllTools()
+	if len(tools) != 0 {
+		t.Errorf("expected 0 tools from empty registry, got %d", len(tools))
+	}
+}
+
+func TestAllToolsNamespacing(t *testing.T) {
+	r := NewProviderRegistry()
+	r.Register(&mockProvider{
+		name:    "code",
+		healthy: true,
+		tools: []ToolDefinition{
+			{Name: "search_graph", Namespace: "code", Description: "search"},
+			{Name: "detect_changes", Namespace: "code", Description: "detect"},
+		},
+	})
+	r.Register(&mockProvider{
+		name:    "mem",
+		healthy: true,
+		tools: []ToolDefinition{
+			{Name: "recall", Namespace: "mem", Description: "recall"},
+		},
+	})
+
+	tools := r.AllTools()
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(tools))
+	}
+
+	names := make(map[string]bool)
+	for _, td := range tools {
+		names[td.Name] = true
+	}
+	for _, want := range []string{"forgia_code_search_graph", "forgia_code_detect_changes", "forgia_mem_recall"} {
+		if !names[want] {
+			t.Errorf("expected tool %q in AllTools, got %v", want, names)
+		}
+	}
+}
+
+func TestAllToolsSkipsUnhealthy(t *testing.T) {
+	r := NewProviderRegistry()
+	r.Register(&mockProvider{
+		name:    "healthy",
+		healthy: true,
+		tools:   []ToolDefinition{{Name: "ok", Namespace: "healthy"}},
+	})
+	r.Register(&mockProvider{
+		name:    "down",
+		healthy: false,
+		tools:   []ToolDefinition{{Name: "nope", Namespace: "down"}},
+	})
+
+	tools := r.AllTools()
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool (unhealthy skipped), got %d", len(tools))
+	}
+	if tools[0].Name != "forgia_healthy_ok" {
+		t.Errorf("expected forgia_healthy_ok, got %s", tools[0].Name)
+	}
+}
+
+func TestCallRoutesToProvider(t *testing.T) {
+	r := NewProviderRegistry()
+	var calledTool string
+	r.Register(&mockProvider{
+		name:    "code",
+		healthy: true,
+		callFn: func(_ context.Context, tool string, _ map[string]any) (any, error) {
+			calledTool = tool
+			return "result", nil
+		},
+	})
+
+	result, err := r.Call(context.Background(), "forgia_code_search_graph", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calledTool != "search_graph" {
+		t.Errorf("expected provider to receive tool 'search_graph', got %q", calledTool)
+	}
+	if result != "result" {
+		t.Errorf("expected 'result', got %v", result)
+	}
+}
+
+func TestCallUnknownNamespace(t *testing.T) {
+	r := NewProviderRegistry()
+	r.Register(&mockProvider{name: "code", healthy: true})
+
+	_, err := r.Call(context.Background(), "forgia_unknown_tool", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown namespace")
+	}
+	if want := "unknown provider namespace: unknown"; err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestCallInvalidToolName(t *testing.T) {
+	r := NewProviderRegistry()
+
+	_, err := r.Call(context.Background(), "bad_tool_name", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid tool name")
+	}
+}
+
+func TestCallPassesParams(t *testing.T) {
+	r := NewProviderRegistry()
+	var gotParams map[string]any
+	r.Register(&mockProvider{
+		name:    "code",
+		healthy: true,
+		callFn: func(_ context.Context, _ string, params map[string]any) (any, error) {
+			gotParams = params
+			return nil, nil
+		},
+	})
+
+	params := map[string]any{"query": "test", "limit": 10}
+	_, _ = r.Call(context.Background(), "forgia_code_search", params)
+
+	if gotParams["query"] != "test" || gotParams["limit"] != 10 {
+		t.Errorf("params not passed through: got %v", gotParams)
+	}
+}
+
+func TestCallProviderError(t *testing.T) {
+	r := NewProviderRegistry()
+	r.Register(&mockProvider{
+		name:    "code",
+		healthy: true,
+		callFn: func(_ context.Context, _ string, _ map[string]any) (any, error) {
+			return nil, fmt.Errorf("provider exploded")
+		},
+	})
+
+	_, err := r.Call(context.Background(), "forgia_code_search", nil)
+	if err == nil {
+		t.Fatal("expected error from provider")
+	}
+	if err.Error() != "provider exploded" {
+		t.Errorf("error = %q, want 'provider exploded'", err.Error())
+	}
+}
+
+func TestRegistryConcurrentAccess(t *testing.T) {
+	r := NewProviderRegistry()
+	for i := range 10 {
+		r.Register(&mockProvider{
+			name:    fmt.Sprintf("p%d", i),
+			healthy: true,
+			tools:   []ToolDefinition{{Name: "t", Namespace: fmt.Sprintf("p%d", i)}},
+		})
+	}
+
+	var wg sync.WaitGroup
+	// Concurrent reads (AllTools + Call) while registering new providers.
+	for i := range 50 {
+		wg.Add(3)
+		go func(i int) {
+			defer wg.Done()
+			r.AllTools()
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			r.Call(context.Background(), fmt.Sprintf("forgia_p%d_t", i%10), nil)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			r.Register(&mockProvider{
+				name:    fmt.Sprintf("new%d", i),
+				healthy: true,
+				tools:   []ToolDefinition{{Name: "t", Namespace: fmt.Sprintf("new%d", i)}},
+			})
+		}(i)
+	}
+	wg.Wait()
+}
 
 func TestToolName(t *testing.T) {
 	tests := []struct {

--- a/internal/mcp/subprocess.go
+++ b/internal/mcp/subprocess.go
@@ -1,0 +1,475 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/Deepzima/forgia/internal/config"
+)
+
+// Compile-time interface check.
+var _ ToolProvider = (*MCPSubprocessProvider)(nil)
+
+// MCPSubprocessProvider spawns an MCP server as a long-lived subprocess
+// and communicates via JSON-RPC 2.0 over stdio.
+type MCPSubprocessProvider struct {
+	name            string
+	command         string
+	args            []string
+	lazy            bool
+	restartOnCrash  bool
+	healthCheckTool string
+	exposeTools     map[string]bool
+	namespace       string
+
+	mu       sync.RWMutex
+	cmd      *exec.Cmd
+	stdin    io.WriteCloser
+	enc      *json.Encoder
+	tools    []ToolDefinition
+	healthy  bool
+	started  bool
+	stopping bool
+
+	writeMu sync.Mutex
+	startMu sync.Mutex
+	nextID  atomic.Int64
+	pending sync.Map // int → chan jsonrpcResponse
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	done   chan struct{} // closed when subprocess exits
+	logger *slog.Logger
+	env    []string // additional env vars for subprocess
+}
+
+// NewMCPSubprocessProvider creates a provider from config. Does NOT start the subprocess.
+func NewMCPSubprocessProvider(cfg config.MCPProviderConfig) *MCPSubprocessProvider {
+	expose := make(map[string]bool, len(cfg.ExposeTools))
+	for _, t := range cfg.ExposeTools {
+		expose[t] = true
+	}
+	return &MCPSubprocessProvider{
+		name:            cfg.Namespace,
+		command:         cfg.Command,
+		args:            cfg.Args,
+		lazy:            cfg.Lazy,
+		restartOnCrash:  cfg.RestartOnCrash,
+		healthCheckTool: cfg.HealthCheck,
+		exposeTools:     expose,
+		namespace:       cfg.Namespace,
+		logger:          slog.With("provider", cfg.Namespace),
+	}
+}
+
+// Name returns the provider identifier.
+func (p *MCPSubprocessProvider) Name() string {
+	return p.name
+}
+
+// Tools returns cached tool definitions, filtered by ExposeTools if configured.
+func (p *MCPSubprocessProvider) Tools() []ToolDefinition {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if len(p.exposeTools) == 0 {
+		result := make([]ToolDefinition, len(p.tools))
+		copy(result, p.tools)
+		return result
+	}
+
+	var filtered []ToolDefinition
+	for _, t := range p.tools {
+		if p.exposeTools[t.Name] {
+			filtered = append(filtered, t)
+		}
+	}
+	return filtered
+}
+
+// Call invokes a tool via JSON-RPC tools/call and returns the parsed result.
+func (p *MCPSubprocessProvider) Call(ctx context.Context, tool string, params map[string]any) (any, error) {
+	if err := p.ensureRunning(ctx); err != nil {
+		return nil, err
+	}
+
+	callParams := map[string]any{
+		"name":      tool,
+		"arguments": params,
+	}
+
+	result, err := p.sendRequest(ctx, "tools/call", callParams)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		return nil, fmt.Errorf("mcp provider %s: parse result: %w", p.name, err)
+	}
+	return parsed, nil
+}
+
+// Start initializes the provider. If lazy, defers subprocess spawn until first Call.
+func (p *MCPSubprocessProvider) Start(ctx context.Context) error {
+	p.ctx, p.cancel = context.WithCancel(context.Background())
+
+	if p.lazy {
+		p.logger.Info("lazy mode, deferring subprocess start")
+		return nil
+	}
+	return p.doStart(ctx)
+}
+
+// Stop sends SIGTERM, waits 5s, then SIGKILL. Cleans up resources.
+func (p *MCPSubprocessProvider) Stop() error {
+	p.mu.Lock()
+	if p.stopping {
+		p.mu.Unlock()
+		return nil
+	}
+	p.stopping = true
+	p.healthy = false
+	p.mu.Unlock()
+
+	p.logger.Info("stopping")
+
+	if p.cancel != nil {
+		p.cancel()
+	}
+
+	return p.killProcess()
+}
+
+// Healthy returns true if the subprocess is alive and initialized.
+func (p *MCPSubprocessProvider) Healthy() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.healthy
+}
+
+// ensureRunning guarantees the subprocess is running. Handles lazy start.
+func (p *MCPSubprocessProvider) ensureRunning(ctx context.Context) error {
+	p.mu.RLock()
+	healthy := p.healthy
+	stopping := p.stopping
+	started := p.started
+	p.mu.RUnlock()
+
+	if stopping {
+		return fmt.Errorf("mcp provider %s: stopping", p.name)
+	}
+	if healthy {
+		return nil
+	}
+	if started {
+		return fmt.Errorf("mcp provider %s: not ready", p.name)
+	}
+
+	// Lazy first start
+	p.startMu.Lock()
+	defer p.startMu.Unlock()
+
+	// Double-check under lock
+	p.mu.RLock()
+	healthy = p.healthy
+	p.mu.RUnlock()
+	if healthy {
+		return nil
+	}
+
+	return p.doStart(ctx)
+}
+
+// doStart spawns the subprocess, initializes it, and caches tool definitions.
+func (p *MCPSubprocessProvider) doStart(ctx context.Context) error {
+	if err := p.spawn(); err != nil {
+		return fmt.Errorf("mcp provider %s: spawn: %w", p.name, err)
+	}
+	if err := p.initialize(ctx); err != nil {
+		p.killProcess()
+		return fmt.Errorf("mcp provider %s: initialize: %w", p.name, err)
+	}
+	if err := p.fetchTools(ctx); err != nil {
+		p.killProcess()
+		return fmt.Errorf("mcp provider %s: fetch tools: %w", p.name, err)
+	}
+
+	p.mu.Lock()
+	p.healthy = true
+	p.started = true
+	p.mu.Unlock()
+
+	p.logger.Info("started", "tools", len(p.tools))
+
+	if p.restartOnCrash {
+		go p.monitorLoop()
+	}
+	return nil
+}
+
+// spawn starts the subprocess and sets up pipes and reader goroutine.
+func (p *MCPSubprocessProvider) spawn() error {
+	cmd := exec.Command(p.command, p.args...)
+	if len(p.env) > 0 {
+		cmd.Env = p.env
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("stdin pipe: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		stdin.Close()
+		return fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start command: %w", err)
+	}
+
+	done := make(chan struct{})
+
+	p.mu.Lock()
+	p.cmd = cmd
+	p.stdin = stdin
+	p.enc = json.NewEncoder(stdin)
+	p.done = done
+	p.mu.Unlock()
+
+	dec := json.NewDecoder(stdout)
+	go p.readLoop(dec)
+
+	go func() {
+		cmd.Wait()
+		p.mu.Lock()
+		if !p.stopping {
+			p.healthy = false
+		}
+		p.mu.Unlock()
+		close(done)
+	}()
+
+	p.logger.Info("subprocess spawned", "pid", cmd.Process.Pid)
+	return nil
+}
+
+// initialize performs the MCP initialize handshake.
+func (p *MCPSubprocessProvider) initialize(ctx context.Context) error {
+	params := map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "forgia",
+			"version": "0.1.0",
+		},
+	}
+
+	if _, err := p.sendRequest(ctx, "initialize", params); err != nil {
+		return fmt.Errorf("initialize handshake: %w", err)
+	}
+
+	if err := p.sendNotification("notifications/initialized", nil); err != nil {
+		return fmt.Errorf("initialized notification: %w", err)
+	}
+
+	return nil
+}
+
+// fetchTools retrieves tool definitions from the subprocess via tools/list.
+func (p *MCPSubprocessProvider) fetchTools(ctx context.Context) error {
+	result, err := p.sendRequest(ctx, "tools/list", nil)
+	if err != nil {
+		return fmt.Errorf("tools/list: %w", err)
+	}
+
+	var resp struct {
+		Tools []struct {
+			Name        string         `json:"name"`
+			Description string         `json:"description"`
+			InputSchema map[string]any `json:"inputSchema"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(result, &resp); err != nil {
+		return fmt.Errorf("parse tools: %w", err)
+	}
+
+	tools := make([]ToolDefinition, 0, len(resp.Tools))
+	for _, t := range resp.Tools {
+		tools = append(tools, ToolDefinition{
+			Name:        t.Name,
+			Description: t.Description,
+			Parameters:  t.InputSchema,
+			Namespace:   p.namespace,
+		})
+	}
+
+	p.mu.Lock()
+	p.tools = tools
+	p.mu.Unlock()
+
+	return nil
+}
+
+// sendRequest sends a JSON-RPC request and waits for the response.
+func (p *MCPSubprocessProvider) sendRequest(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	id := int(p.nextID.Add(1))
+	req := newRequest(id, method, params)
+
+	ch := make(chan jsonrpcResponse, 1)
+	p.pending.Store(id, ch)
+	defer p.pending.Delete(id)
+
+	p.writeMu.Lock()
+	encErr := p.enc.Encode(req)
+	p.writeMu.Unlock()
+	if encErr != nil {
+		return nil, fmt.Errorf("mcp provider %s: send %s: %w", p.name, method, encErr)
+	}
+
+	p.mu.RLock()
+	done := p.done
+	p.mu.RUnlock()
+
+	select {
+	case resp := <-ch:
+		if resp.Error != nil {
+			return nil, fmt.Errorf("mcp provider %s: %w", p.name, resp.Error)
+		}
+		return resp.Result, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("mcp provider %s: %s: %w", p.name, method, ctx.Err())
+	case <-done:
+		return nil, fmt.Errorf("mcp provider %s: subprocess exited during %s", p.name, method)
+	}
+}
+
+// sendNotification sends a JSON-RPC notification (no response expected).
+func (p *MCPSubprocessProvider) sendNotification(method string, params any) error {
+	notif := jsonrpcNotification{
+		JSONRPC: jsonrpcVersion,
+		Method:  method,
+		Params:  params,
+	}
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
+	return p.enc.Encode(notif)
+}
+
+// readLoop reads JSON-RPC responses from stdout and dispatches to pending callers.
+func (p *MCPSubprocessProvider) readLoop(dec *json.Decoder) {
+	for {
+		var resp jsonrpcResponse
+		if err := dec.Decode(&resp); err != nil {
+			return // EOF or read error — subprocess exited
+		}
+		if resp.ID == nil {
+			continue // server notification, skip
+		}
+		if ch, ok := p.pending.LoadAndDelete(*resp.ID); ok {
+			ch.(chan jsonrpcResponse) <- resp
+		}
+	}
+}
+
+// monitorLoop watches for subprocess crashes and handles restart with exponential backoff.
+func (p *MCPSubprocessProvider) monitorLoop() {
+	backoff := time.Second
+	maxBackoff := 30 * time.Second
+
+	for {
+		p.mu.RLock()
+		done := p.done
+		p.mu.RUnlock()
+
+		<-done
+
+		p.mu.RLock()
+		stopping := p.stopping
+		p.mu.RUnlock()
+		if stopping {
+			return
+		}
+
+		p.logger.Error("subprocess crashed, restarting", "backoff", backoff)
+
+		select {
+		case <-time.After(backoff):
+		case <-p.ctx.Done():
+			return
+		}
+
+		if err := p.spawn(); err != nil {
+			p.logger.Error("restart spawn failed", "error", err)
+			backoff = min(backoff*2, maxBackoff)
+			continue
+		}
+
+		ctx, cancel := context.WithTimeout(p.ctx, 10*time.Second)
+		initErr := p.initialize(ctx)
+		if initErr == nil {
+			initErr = p.fetchTools(ctx)
+		}
+		cancel()
+
+		if initErr != nil {
+			p.logger.Error("restart init failed", "error", initErr)
+			p.killProcess()
+			backoff = min(backoff*2, maxBackoff)
+			continue
+		}
+
+		p.mu.Lock()
+		p.healthy = true
+		p.mu.Unlock()
+
+		backoff = time.Second
+		p.logger.Info("restarted successfully")
+	}
+}
+
+// killProcess sends SIGTERM, waits 5s, then SIGKILL. Closes stdin.
+func (p *MCPSubprocessProvider) killProcess() error {
+	p.mu.RLock()
+	cmd := p.cmd
+	done := p.done
+	p.mu.RUnlock()
+
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+
+	p.logger.Info("killing subprocess", "pid", cmd.Process.Pid)
+
+	// Close stdin
+	p.writeMu.Lock()
+	if p.stdin != nil {
+		p.stdin.Close()
+		p.stdin = nil
+	}
+	p.writeMu.Unlock()
+
+	// Send SIGTERM
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+
+	// Wait up to 5s for graceful exit
+	select {
+	case <-done:
+		return nil
+	case <-time.After(5 * time.Second):
+		p.logger.Warn("subprocess did not exit after SIGTERM, sending SIGKILL")
+		_ = cmd.Process.Kill()
+		<-done
+		return nil
+	}
+}

--- a/internal/mcp/subprocess_test.go
+++ b/internal/mcp/subprocess_test.go
@@ -1,0 +1,416 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Deepzima/forgia/internal/config"
+)
+
+// ---------------------------------------------------------------------------
+// Mock MCP server — runs inside the test binary when FORGIA_MOCK_MCP is set.
+// ---------------------------------------------------------------------------
+
+// mockMessage is a flexible JSON-RPC message for the mock server (handles both
+// requests with ID and notifications without).
+type mockMessage struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      *int            `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+func TestMain(m *testing.M) {
+	if os.Getenv("FORGIA_MOCK_MCP") != "" {
+		runMockMCPServer()
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func runMockMCPServer() {
+	dec := json.NewDecoder(os.Stdin)
+	enc := json.NewEncoder(os.Stdout)
+
+	crashFile := os.Getenv("MOCK_CRASH_FILE")
+	rpcErrorTool := os.Getenv("MOCK_RPC_ERROR_TOOL")
+
+	toolsJSON := json.RawMessage(`{"tools":[` +
+		`{"name":"search_graph","description":"Search the code graph","inputSchema":{"type":"object","properties":{"query":{"type":"string"}}}},` +
+		`{"name":"get_architecture","description":"Get architecture overview","inputSchema":{"type":"object","properties":{}}},` +
+		`{"name":"list_projects","description":"List projects","inputSchema":{"type":"object","properties":{}}}` +
+		`]}`)
+
+	initResultJSON := json.RawMessage(`{"protocolVersion":"2024-11-05","capabilities":{"tools":{}},"serverInfo":{"name":"mock-mcp","version":"1.0.0"}}`)
+
+	for {
+		var msg mockMessage
+		if err := dec.Decode(&msg); err != nil {
+			return // EOF — parent closed stdin
+		}
+
+		// Notifications have no ID — skip (no response expected).
+		if msg.ID == nil {
+			continue
+		}
+
+		id := *msg.ID
+
+		switch msg.Method {
+		case "initialize":
+			enc.Encode(jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: &id, Result: initResultJSON})
+
+		case "tools/list":
+			enc.Encode(jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: &id, Result: toolsJSON})
+
+			// Crash-after-init: if crash file says "1", crash now.
+			if crashFile != "" {
+				data, _ := os.ReadFile(crashFile)
+				if strings.TrimSpace(string(data)) == "1" {
+					os.WriteFile(crashFile, []byte("0"), 0o644)
+					time.Sleep(50 * time.Millisecond)
+					os.Exit(1)
+				}
+			}
+
+		case "tools/call":
+			var params struct {
+				Name      string         `json:"name"`
+				Arguments map[string]any `json:"arguments"`
+			}
+			json.Unmarshal(msg.Params, &params)
+
+			// Return RPC error for a specific tool if configured.
+			if rpcErrorTool != "" && params.Name == rpcErrorTool {
+				enc.Encode(jsonrpcResponse{
+					JSONRPC: jsonrpcVersion,
+					ID:      &id,
+					Error:   &RPCError{Code: -32601, Message: "Method not found"},
+				})
+				continue
+			}
+
+			result := map[string]any{
+				"content": []map[string]any{
+					{"type": "text", "text": fmt.Sprintf("mock result for %s", params.Name)},
+				},
+				"requestId": id,
+			}
+			resultBytes, _ := json.Marshal(result)
+			enc.Encode(jsonrpcResponse{JSONRPC: jsonrpcVersion, ID: &id, Result: json.RawMessage(resultBytes)})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+func mockEnv(extra ...string) []string {
+	env := os.Environ()
+	env = append(env, "FORGIA_MOCK_MCP=1")
+	env = append(env, extra...)
+	return env
+}
+
+func newTestProvider(t *testing.T, overrides func(*config.MCPProviderConfig)) *MCPSubprocessProvider {
+	t.Helper()
+	cfg := config.MCPProviderConfig{
+		Command:   os.Args[0],
+		Args:      []string{"-test.run=^$"},
+		Namespace: "test",
+	}
+	if overrides != nil {
+		overrides(&cfg)
+	}
+	p := NewMCPSubprocessProvider(cfg)
+	p.env = mockEnv()
+	return p
+}
+
+func startTestProvider(t *testing.T, overrides func(*config.MCPProviderConfig), envExtra ...string) *MCPSubprocessProvider {
+	t.Helper()
+	p := newTestProvider(t, overrides)
+	p.env = mockEnv(envExtra...)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	t.Cleanup(func() { p.Stop() })
+	return p
+}
+
+// ---------------------------------------------------------------------------
+// Tests (11 required by SDD)
+// ---------------------------------------------------------------------------
+
+func TestStartSpawnsAndInitializes(t *testing.T) {
+	p := startTestProvider(t, nil)
+
+	if !p.Healthy() {
+		t.Fatal("expected Healthy() == true after Start()")
+	}
+	if len(p.Tools()) == 0 {
+		t.Fatal("expected Tools() to return definitions after Start()")
+	}
+}
+
+func TestToolsReturnsDefinitions(t *testing.T) {
+	p := startTestProvider(t, nil)
+
+	tools := p.Tools()
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(tools))
+	}
+
+	names := make(map[string]bool)
+	for _, td := range tools {
+		names[td.Name] = true
+		if td.Namespace != "test" {
+			t.Errorf("expected namespace 'test', got %q", td.Namespace)
+		}
+	}
+	for _, want := range []string{"search_graph", "get_architecture", "list_projects"} {
+		if !names[want] {
+			t.Errorf("missing tool %q in definitions", want)
+		}
+	}
+}
+
+func TestCallSendsRequestAndParsesResponse(t *testing.T) {
+	p := startTestProvider(t, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := p.Call(ctx, "search_graph", map[string]any{"query": "test"})
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map result, got %T", result)
+	}
+	content, ok := m["content"]
+	if !ok {
+		t.Fatal("result missing 'content' key")
+	}
+	items := content.([]any)
+	if len(items) == 0 {
+		t.Fatal("content array is empty")
+	}
+}
+
+func TestCallCancelledContext(t *testing.T) {
+	p := startTestProvider(t, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := p.Call(ctx, "search_graph", map[string]any{"query": "test"})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("expected context canceled error, got: %v", err)
+	}
+}
+
+func TestCallRPCError(t *testing.T) {
+	p := startTestProvider(t, nil, "MOCK_RPC_ERROR_TOOL=bad_tool")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := p.Call(ctx, "bad_tool", nil)
+	if err == nil {
+		t.Fatal("expected RPC error")
+	}
+	if !strings.Contains(err.Error(), "rpc error") {
+		t.Errorf("expected 'rpc error' in message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "-32601") {
+		t.Errorf("expected error code -32601, got: %v", err)
+	}
+}
+
+func TestHealthyFalseAfterCrash(t *testing.T) {
+	p := startTestProvider(t, nil)
+
+	if !p.Healthy() {
+		t.Fatal("expected healthy before crash")
+	}
+
+	// Kill the subprocess directly.
+	p.mu.RLock()
+	cmd := p.cmd
+	p.mu.RUnlock()
+	cmd.Process.Signal(syscall.SIGKILL)
+
+	// Wait for crash detection.
+	time.Sleep(500 * time.Millisecond)
+
+	if p.Healthy() {
+		t.Fatal("expected Healthy() == false after crash")
+	}
+}
+
+func TestRestartOnCrash(t *testing.T) {
+	crashFile := filepath.Join(t.TempDir(), "crash")
+	os.WriteFile(crashFile, []byte("1"), 0o644)
+
+	p := startTestProvider(t, func(cfg *config.MCPProviderConfig) {
+		cfg.RestartOnCrash = true
+	}, "MOCK_CRASH_FILE="+crashFile)
+
+	// Provider started — the mock will crash after tools/list due to crash file.
+	// monitorLoop should detect crash and restart.
+
+	// Wait for crash + 1s backoff + restart.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.Healthy() {
+			// Verify tools are available after restart.
+			if len(p.Tools()) > 0 {
+				return // success
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatal("provider did not recover within 5s")
+}
+
+func TestStop(t *testing.T) {
+	p := startTestProvider(t, nil)
+
+	if !p.Healthy() {
+		t.Fatal("expected healthy before Stop()")
+	}
+
+	err := p.Stop()
+	if err != nil {
+		t.Fatalf("Stop() returned error: %v", err)
+	}
+	if p.Healthy() {
+		t.Fatal("expected Healthy() == false after Stop()")
+	}
+}
+
+func TestExposeToolsFilter(t *testing.T) {
+	p := startTestProvider(t, func(cfg *config.MCPProviderConfig) {
+		cfg.ExposeTools = []string{"search_graph", "get_architecture"}
+	})
+
+	tools := p.Tools()
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 filtered tools, got %d", len(tools))
+	}
+	names := make(map[string]bool)
+	for _, td := range tools {
+		names[td.Name] = true
+	}
+	if names["list_projects"] {
+		t.Error("list_projects should be filtered out")
+	}
+	if !names["search_graph"] || !names["get_architecture"] {
+		t.Error("expected search_graph and get_architecture to be present")
+	}
+}
+
+func TestLazyStart(t *testing.T) {
+	p := newTestProvider(t, func(cfg *config.MCPProviderConfig) {
+		cfg.Lazy = true
+	})
+	t.Cleanup(func() { p.Stop() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	// After Start() in lazy mode, subprocess should NOT be running.
+	if p.Healthy() {
+		t.Fatal("expected Healthy() == false before first Call() in lazy mode")
+	}
+	if len(p.Tools()) != 0 {
+		t.Fatal("expected no tools before first Call() in lazy mode")
+	}
+
+	// First Call() triggers the actual start.
+	result, err := p.Call(ctx, "search_graph", map[string]any{"query": "lazy"})
+	if err != nil {
+		t.Fatalf("lazy Call failed: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result from lazy Call")
+	}
+	if !p.Healthy() {
+		t.Fatal("expected Healthy() == true after lazy Call()")
+	}
+	if len(p.Tools()) == 0 {
+		t.Fatal("expected tools after lazy Call()")
+	}
+}
+
+func TestConcurrentRequestIDs(t *testing.T) {
+	p := startTestProvider(t, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const n = 20
+	var (
+		mu  sync.Mutex
+		ids []float64
+		wg  sync.WaitGroup
+	)
+
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result, err := p.Call(ctx, "search_graph", map[string]any{"query": fmt.Sprintf("q%d", i)})
+			if err != nil {
+				t.Errorf("concurrent Call %d failed: %v", i, err)
+				return
+			}
+			m, ok := result.(map[string]any)
+			if !ok {
+				return
+			}
+			mu.Lock()
+			if rid, ok := m["requestId"].(float64); ok {
+				ids = append(ids, rid)
+			}
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify all IDs are unique.
+	seen := make(map[float64]bool)
+	for _, id := range ids {
+		if seen[id] {
+			t.Errorf("duplicate request ID: %v", id)
+		}
+		seen[id] = true
+	}
+	if len(seen) != n {
+		t.Errorf("expected %d unique IDs, got %d", n, len(seen))
+	}
+}


### PR DESCRIPTION
## Summary
- Implements `MCPSubprocessProvider` — a generic `ToolProvider` that spawns any MCP server as a long-lived subprocess over stdio and communicates via JSON-RPC 2.0
- Adds `ToolProvider` interface, `ToolDefinition`, `ProviderRegistry` to `internal/mcp/mcp.go`
- Adds `MCPProviderConfig` struct to `internal/config/config.go`
- JSON-RPC 2.0 thin layer in `internal/mcp/jsonrpc.go`
- Full lifecycle: `Start`, `Stop`, `Call`, `Tools`, `Healthy`, lazy start, restart-on-crash with exponential backoff, `ExposeTools` filtering

## Test plan
- [x] `go test ./internal/mcp/...` — 11 unit tests, all pass
- [x] `go test ./...` — full suite passes, no circular dependencies
- [x] `go vet ./internal/mcp/...` — clean
- [ ] Manual: verify integration with real MCP server (deferred to SDD-002)

### Tests (11):
1. `TestStartSpawnsAndInitializes` — spawn + MCP initialize handshake
2. `TestToolsReturnsDefinitions` — tools/list returns 3 tool definitions
3. `TestCallSendsRequestAndParsesResponse` — tools/call roundtrip
4. `TestCallCancelledContext` — context cancellation returns error
5. `TestCallRPCError` — JSON-RPC error surfaces as Go error
6. `TestHealthyFalseAfterCrash` — crash detection
7. `TestRestartOnCrash` — auto-restart with re-initialization
8. `TestStop` — SIGTERM cleanup
9. `TestExposeToolsFilter` — tool filtering
10. `TestLazyStart` — deferred spawn until first Call()
11. `TestConcurrentRequestIDs` — unique IDs under concurrent calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)