### PR TITLE
feat(FD-010): add codebase-memory-mcp CLI hooks (SDD-002)

### DIFF
--- a/bin/forgia
+++ b/bin/forgia
@@ -316,8 +316,8 @@ cmd_init() {
     local auto_index=true
     if [[ -f "$VAULT_DIR/config.toml" ]]; then
       local idx_val
-      idx_val=$(grep -A5 '\[knowledge\]' \
-        "$VAULT_DIR/config.toml" \
+      idx_val=$(grep -v '^#' "$VAULT_DIR/config.toml" \
+        | grep -A5 '^\[knowledge\]' \
         | grep 'auto_index' | head -1 \
         | sed 's/.*= *//' | tr -d ' ' || echo "")
       if [[ "$idx_val" == "false" ]]; then

--- a/bin/forgia
+++ b/bin/forgia
@@ -83,6 +83,112 @@ strip_runner_arg() {
   echo "${args[@]}"
 }
 
+# --- codebase-memory-mcp helpers ---
+
+_cbm_check_installed() {
+  command -v codebase-memory-mcp >/dev/null 2>&1
+}
+
+_cbm_index() {
+  local output
+  output=$(codebase-memory-mcp cli index_repository path=./ \
+    2>/dev/null) || return 1
+  if command -v jq >/dev/null 2>&1; then
+    echo "$output" | jq -r '.symbols_indexed // 0' 2>/dev/null
+  else
+    echo "$output" \
+      | grep -o '"symbols_indexed":[0-9]*' \
+      | head -1 | sed 's/.*://'
+  fi
+}
+
+_cbm_get_stats() {
+  local output
+  output=$(codebase-memory-mcp cli list_projects \
+    2>/dev/null) || return 1
+  local symbols edges synced
+  if command -v jq >/dev/null 2>&1; then
+    symbols=$(echo "$output" \
+      | jq -r '.[0].node_count // 0')
+    edges=$(echo "$output" \
+      | jq -r '.[0].edge_count // 0')
+    synced=$(echo "$output" \
+      | jq -r '.[0].last_indexed // empty' \
+      2>/dev/null) || synced=""
+  else
+    symbols=$(echo "$output" \
+      | grep -o '"node_count":[0-9]*' \
+      | head -1 | sed 's/.*://')
+    edges=$(echo "$output" \
+      | grep -o '"edge_count":[0-9]*' \
+      | head -1 | sed 's/.*://')
+    synced=""
+  fi
+  echo "${symbols:-0} ${edges:-0} ${synced:-}"
+}
+
+_cbm_relative_time() {
+  local ts="$1"
+  [[ -n "$ts" ]] || return 1
+  local now then_s diff
+  now=$(date +%s)
+  # macOS: date -j -f, Linux: date -d
+  then_s=$(date -j -f "%Y-%m-%dT%H:%M:%S" \
+    "${ts%%.*}" +%s 2>/dev/null) \
+    || then_s=$(date -d "$ts" +%s 2>/dev/null) \
+    || return 1
+  diff=$((now - then_s))
+  if (( diff < 60 )); then
+    echo "${diff}s ago"
+  elif (( diff < 3600 )); then
+    echo "$((diff / 60))m ago"
+  elif (( diff < 86400 )); then
+    echo "$((diff / 3600))h ago"
+  else
+    echo "$((diff / 86400))d ago"
+  fi
+}
+
+_cbm_ensure_mcp_json() {
+  local mcp_file=".mcp.json"
+
+  if [[ ! -f "$mcp_file" ]]; then
+    cat > "$mcp_file" <<'JSON'
+{
+  "mcpServers": {
+    "codebase-memory-mcp": {
+      "type": "stdio",
+      "command": "codebase-memory-mcp"
+    }
+  }
+}
+JSON
+    echo "  Created: .mcp.json"
+    return 0
+  fi
+
+  if grep -q '"codebase-memory-mcp"' "$mcp_file" 2>/dev/null; then
+    echo "  .mcp.json: codebase-memory-mcp already configured"
+    return 0
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    local merged
+    merged=$(jq '.mcpServers["codebase-memory-mcp"] = {
+      "type":"stdio",
+      "command":"codebase-memory-mcp"
+    }' "$mcp_file")
+    echo "$merged" > "$mcp_file"
+    echo "  Updated: .mcp.json (merged codebase-memory-mcp)"
+  else
+    echo "  WARN: jq not available, cannot safely merge" \
+      ".mcp.json" >&2
+    echo "  Add manually: \"codebase-memory-mcp\":" \
+      "{\"type\":\"stdio\"," \
+      "\"command\":\"codebase-memory-mcp\"}" >&2
+  fi
+}
+
 # --- init ---
 
 cmd_init() {
@@ -203,6 +309,39 @@ cmd_init() {
     fi
   else
     echo "  Beads: not installed (optional — run: mise run bd:install)"
+  fi
+
+  # Tier 3: codebase-memory-mcp integration
+  if _cbm_check_installed; then
+    local auto_index=true
+    if [[ -f "$VAULT_DIR/config.toml" ]]; then
+      local idx_val
+      idx_val=$(grep -A5 '\[knowledge\]' \
+        "$VAULT_DIR/config.toml" \
+        | grep 'auto_index' | head -1 \
+        | sed 's/.*= *//' | tr -d ' ' || echo "")
+      if [[ "$idx_val" == "false" ]]; then
+        auto_index=false
+      fi
+    fi
+
+    if [[ "$auto_index" == "true" ]]; then
+      echo ""
+      echo "→ Tier 3: indexing with codebase-memory-mcp..."
+      local idx_symbols
+      idx_symbols=$(_cbm_index) || idx_symbols=""
+      if [[ -n "$idx_symbols" ]] && [[ "$idx_symbols" != "0" ]]; then
+        echo "  Tier 3: codebase-memory-mcp indexed" \
+          "($idx_symbols symbols)"
+      else
+        echo "  Tier 3: codebase-memory-mcp index completed"
+      fi
+    fi
+
+    _cbm_ensure_mcp_json
+  else
+    echo "  Tier 3: codebase-memory-mcp not found" \
+      "(optional — install for code intelligence)"
   fi
 
   # .gitignore for .forgia/ (exclude local-only files)
@@ -349,6 +488,28 @@ cmd_status() {
     echo "--- Beads (ready tasks) ---"
     bd ready 2>/dev/null || echo "  (no ready tasks)"
     echo ""
+  fi
+
+  # Knowledge Layer
+  if _cbm_check_installed; then
+    local kl_stats
+    kl_stats=$(_cbm_get_stats 2>/dev/null) || kl_stats=""
+    if [[ -n "$kl_stats" ]]; then
+      local kl_symbols kl_edges kl_synced kl_time
+      kl_symbols=$(echo "$kl_stats" | awk '{print $1}')
+      kl_edges=$(echo "$kl_stats" | awk '{print $2}')
+      kl_synced=$(echo "$kl_stats" | awk '{print $3}')
+      kl_time=$(_cbm_relative_time "$kl_synced" \
+        2>/dev/null) || kl_time=""
+      echo "── Knowledge Layer ──"
+      local kl_msg
+      kl_msg="$kl_symbols symbols  $kl_edges edges"
+      if [[ -n "$kl_time" ]]; then
+        kl_msg="$kl_msg  synced $kl_time"
+      fi
+      printf "  Tier 3: codebase-memory-mcp  %s\n" "$kl_msg"
+      echo ""
+    fi
   fi
 
   echo ""
@@ -516,6 +677,45 @@ cmd_doctor() {
     ok=$((ok + 1))
   else
     printf "  %-25s MISSING (set ANTHROPIC_API_KEY or OPENAI_API_KEY)\n" "llm api key"
+    warn=$((warn + 1))
+  fi
+
+  # Check codebase-memory-mcp
+  if _cbm_check_installed; then
+    local cbm_stats
+    cbm_stats=$(_cbm_get_stats) || cbm_stats=""
+    if [[ -n "$cbm_stats" ]]; then
+      local cbm_symbols cbm_edges cbm_synced cbm_time
+      cbm_symbols=$(echo "$cbm_stats" | awk '{print $1}')
+      cbm_edges=$(echo "$cbm_stats" | awk '{print $2}')
+      cbm_synced=$(echo "$cbm_stats" | awk '{print $3}')
+      cbm_time=$(_cbm_relative_time "$cbm_synced" \
+        2>/dev/null) || cbm_time=""
+      if [[ "$cbm_symbols" != "0" ]] \
+          || [[ "$cbm_edges" != "0" ]]; then
+        local cbm_msg
+        cbm_msg="$cbm_symbols symbols, $cbm_edges edges"
+        if [[ -n "$cbm_time" ]]; then
+          cbm_msg="$cbm_msg, synced $cbm_time"
+        fi
+        printf "  %-25s OK    %s\n" \
+          "codebase-memory-mcp" "$cbm_msg"
+        ok=$((ok + 1))
+      else
+        printf "  %-25s WARN  %s\n" \
+          "codebase-memory-mcp" \
+          "installed but no index (run forgia init)"
+        warn=$((warn + 1))
+      fi
+    else
+      printf "  %-25s WARN  %s\n" \
+        "codebase-memory-mcp" \
+        "installed but no index (run forgia init)"
+      warn=$((warn + 1))
+    fi
+  else
+    printf "  %-25s WARN  %s\n" \
+      "codebase-memory-mcp" "not installed (optional)"
     warn=$((warn + 1))
   fi
 

--- a/tests/e2e-codebase-memory.sh
+++ b/tests/e2e-codebase-memory.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Forgia E2E Tests — codebase-memory-mcp integration
+# Run from repo root: ./tests/e2e-codebase-memory.sh
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORGIA="$ROOT_DIR/bin/forgia"
+TEST_DIR=$(mktemp -d)
+MOCK_DIR=$(mktemp -d)
+PASSED=0
+FAILED=0
+TOTAL=0
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+cleanup() {
+  rm -rf "$TEST_DIR" "$MOCK_DIR"
+}
+trap cleanup EXIT
+
+# --- Test helpers ---
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  TOTAL=$((TOTAL + 1))
+  if echo "$haystack" | grep -qF "$needle"; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    expected to contain: %s\n" "$needle"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  TOTAL=$((TOTAL + 1))
+  if ! echo "$haystack" | grep -qF "$needle"; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    expected NOT to contain: %s\n" "$needle"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+assert_file_exists() {
+  local desc="$1" file="$2"
+  TOTAL=$((TOTAL + 1))
+  if [[ -f "$file" ]]; then
+    printf "  ${GREEN}PASS${NC} %s\n" "$desc"
+    PASSED=$((PASSED + 1))
+  else
+    printf "  ${RED}FAIL${NC} %s\n" "$desc"
+    printf "    file not found: %s\n" "$file"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+# --- Create mock codebase-memory-mcp ---
+
+cat > "$MOCK_DIR/codebase-memory-mcp" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  cli)
+    case "${2:-}" in
+      list_projects)
+        if [[ "${MOCK_CBM_NO_INDEX:-}" == "true" ]]; then
+          echo '[]'
+        else
+          cat <<'JSON'
+[{"path":"./","node_count":1234,"edge_count":5678}]
+JSON
+        fi
+        ;;
+      index_repository)
+        echo '{"symbols_indexed":1234}'
+        ;;
+      *)
+        echo "Unknown CLI command: ${2:-}" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "codebase-memory-mcp mock v0.1.0"
+    ;;
+esac
+MOCK
+chmod +x "$MOCK_DIR/codebase-memory-mcp"
+
+# Minimal PATH that excludes codebase-memory-mcp
+# but includes all standard system tools
+CLEAN_PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
+# --- Tests ---
+
+echo "=== Forgia E2E Tests — codebase-memory-mcp ==="
+echo "  Test dir: $TEST_DIR"
+echo "  Mock dir: $MOCK_DIR"
+echo ""
+
+# =====================================================
+echo "--- 1. forgia init: cbm not installed → skip ---"
+# =====================================================
+
+cd "$TEST_DIR"
+git init --initial-branch=main -q
+
+output=$(PATH="$CLEAN_PATH" "$FORGIA" init 2>&1)
+assert_contains "prints not found message" \
+  "codebase-memory-mcp not found" "$output"
+assert_contains "mentions optional" \
+  "optional" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- 2. forgia init: mock cbm → index + stats ---"
+# =====================================================
+
+rm -rf "$TEST_DIR/.forgia" "$TEST_DIR/.mcp.json"
+output=$(PATH="$MOCK_DIR:$CLEAN_PATH" "$FORGIA" init 2>&1)
+assert_contains "prints indexed message" \
+  "codebase-memory-mcp indexed" "$output"
+assert_contains "prints symbol count" \
+  "1234 symbols" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- 3. forgia init: generates .mcp.json ---"
+# =====================================================
+
+assert_file_exists ".mcp.json created" \
+  "$TEST_DIR/.mcp.json"
+mcp_content=$(cat "$TEST_DIR/.mcp.json")
+assert_contains ".mcp.json has codebase-memory-mcp" \
+  "codebase-memory-mcp" "$mcp_content"
+assert_contains ".mcp.json has stdio type" \
+  "stdio" "$mcp_content"
+
+echo ""
+
+# =====================================================
+echo "--- 4. forgia init: merge existing .mcp.json ---"
+# =====================================================
+
+rm -rf "$TEST_DIR/.forgia"
+
+# Create an existing .mcp.json with another server
+cat > "$TEST_DIR/.mcp.json" <<'EXISTING'
+{
+  "mcpServers": {
+    "other-server": {
+      "type": "stdio",
+      "command": "other-tool"
+    }
+  }
+}
+EXISTING
+
+output=$(PATH="$MOCK_DIR:$CLEAN_PATH" "$FORGIA" init 2>&1)
+mcp_content=$(cat "$TEST_DIR/.mcp.json")
+assert_contains "preserves other-server" \
+  "other-server" "$mcp_content"
+assert_contains "adds codebase-memory-mcp" \
+  "codebase-memory-mcp" "$mcp_content"
+
+echo ""
+
+# =====================================================
+echo "--- 5. forgia doctor: cbm not installed → WARN ---"
+# =====================================================
+
+cd "$TEST_DIR"
+output=$(PATH="$CLEAN_PATH" "$FORGIA" doctor 2>&1)
+assert_contains "doctor shows WARN for cbm" \
+  "WARN" "$output"
+assert_contains "doctor mentions not installed" \
+  "not installed (optional)" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- 6. forgia doctor: mock cbm → OK + stats ---"
+# =====================================================
+
+output=$(PATH="$MOCK_DIR:$CLEAN_PATH" "$FORGIA" doctor 2>&1)
+assert_contains "doctor shows OK for cbm" \
+  "OK" "$output"
+assert_contains "doctor shows symbol count" \
+  "1234 symbols" "$output"
+assert_contains "doctor shows edge count" \
+  "5678 edges" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- 7. forgia status: cbm installed → Knowledge Layer ---"
+# =====================================================
+
+output=$(PATH="$MOCK_DIR:$CLEAN_PATH" "$FORGIA" status 2>&1)
+assert_contains "status shows Knowledge Layer" \
+  "Knowledge Layer" "$output"
+assert_contains "status shows Tier 3" \
+  "Tier 3" "$output"
+assert_contains "status shows symbol count" \
+  "1234 symbols" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- 8. forgia status: cbm not installed → omit ---"
+# =====================================================
+
+output=$(PATH="$CLEAN_PATH" "$FORGIA" status 2>&1)
+assert_not_contains "status omits Knowledge Layer" \
+  "Knowledge Layer" "$output"
+
+echo ""
+
+# =====================================================
+echo "--- 9. regression: existing e2e.sh tests ---"
+# =====================================================
+
+TOTAL=$((TOTAL + 1))
+if "$ROOT_DIR/tests/e2e.sh" >/dev/null 2>&1; then
+  printf "  ${GREEN}PASS${NC} %s\n" \
+    "existing e2e.sh tests pass"
+  PASSED=$((PASSED + 1))
+else
+  printf "  ${RED}FAIL${NC} %s\n" \
+    "existing e2e.sh tests regression"
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+
+# =====================================================
+# Summary
+# =====================================================
+
+echo "=== Results ==="
+echo ""
+printf "  Total:  %d\n" "$TOTAL"
+printf "  ${GREEN}Passed: %d${NC}\n" "$PASSED"
+if (( FAILED > 0 )); then
+  printf "  ${RED}Failed: %d${NC}\n" "$FAILED"
+else
+  printf "  Failed: %d\n" "$FAILED"
+fi
+echo ""
+
+if (( FAILED > 0 )); then
+  echo "FAILED"
+  exit 1
+else
+  echo "ALL TESTS PASSED"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- Wire `codebase-memory-mcp` into `bin/forgia` for `init`, `doctor`, and `status` commands
- `init`: auto-indexes with `codebase-memory-mcp cli index_repository`, generates/merges `.mcp.json`
- `doctor`: reports codebase-memory-mcp status (OK with stats, WARN if missing/no index)
- `status`: shows Knowledge Layer section with symbol/edge counts
- All hooks degrade gracefully when binary is not installed (no errors, clear messages)

## Files changed

- `bin/forgia` — added `_cbm_*` helper functions, extended `cmd_init`, `cmd_doctor`, `cmd_status`
- `tests/e2e-codebase-memory.sh` — 8 new E2E test scenarios + regression gate (19 assertions total)

## Test plan

- [x] `shellcheck bin/forgia` passes clean
- [x] `shellcheck tests/e2e-codebase-memory.sh` passes clean
- [x] All 68 existing `tests/e2e.sh` tests pass (no regressions)
- [x] All 19 new `tests/e2e-codebase-memory.sh` assertions pass
- [x] `forgia init` with mock cbm → indexes + generates `.mcp.json`
- [x] `forgia init` without cbm → prints "not found (optional)" message
- [x] `.mcp.json` merge preserves existing server entries
- [x] `forgia doctor` with mock cbm → shows OK + stats
- [x] `forgia doctor` without cbm → shows WARN
- [x] `forgia status` with mock cbm → shows Knowledge Layer section
- [x] `forgia status` without cbm → omits Knowledge Layer (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)