### PR TITLE
feat(#52): runtime guardrails — deny.toml enforcement, 3 modes, secret scanning

### DIFF
--- a/internal/guardrails/guardrails.go
+++ b/internal/guardrails/guardrails.go
@@ -1,8 +1,62 @@
 // Package guardrails implements validation and safety checks for SDD execution.
 // Reads deny.toml and enforces read/execute/write deny patterns.
+// Supports three runtime modes: Careful (warn on destructive), Freeze (restrict writes),
+// Guard (careful + freeze combined).
 package guardrails
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// Mode controls guardrail enforcement level during SDD execution.
+type Mode int
+
+const (
+	// ModeOff disables runtime guardrails (deny.toml still applies).
+	ModeOff Mode = iota
+	// ModeCareful warns before destructive commands.
+	ModeCareful
+	// ModeFreeze restricts file writes to SDD boundaries.
+	ModeFreeze
+	// ModeGuard combines Careful + Freeze.
+	ModeGuard
+)
+
+// String returns the mode name.
+func (m Mode) String() string {
+	switch m {
+	case ModeCareful:
+		return "careful"
+	case ModeFreeze:
+		return "freeze"
+	case ModeGuard:
+		return "guard"
+	default:
+		return "off"
+	}
+}
+
+// ParseMode converts a string to a Mode.
+func ParseMode(s string) Mode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "careful":
+		return ModeCareful
+	case "freeze":
+		return ModeFreeze
+	case "guard":
+		return ModeGuard
+	default:
+		return ModeOff
+	}
+}
 
 // Guardrails holds the deny lists from deny.toml.
 type Guardrails struct {
@@ -12,39 +66,358 @@ type Guardrails struct {
 }
 
 // DenyList contains glob patterns that are denied.
+// Patterns prefixed with "!" are allow-list exceptions.
 type DenyList struct {
 	Patterns []string `toml:"patterns"`
 }
 
 // Violation records a guardrail breach.
 type Violation struct {
-	Type    string // read, execute, write
+	Type    string // read, execute, write, boundary, secret, destructive
 	Pattern string // the pattern that matched
 	Target  string // the file or command that violated
 }
 
-// CheckFilePaths returns violations for file paths that match [write] or [read] glob patterns.
-// This checks paths only — use ScanForSecrets to check file contents.
+// Error implements the error interface for Violation.
+func (v Violation) Error() string {
+	return fmt.Sprintf("guardrail violation [%s]: %q matched pattern %q", v.Type, v.Target, v.Pattern)
+}
+
+// destructiveCommands are commands that ModeCareful warns about.
+var destructiveCommands = []string{
+	"rm -rf",
+	"rm -r",
+	"DROP TABLE",
+	"DROP DATABASE",
+	"TRUNCATE",
+	"DELETE FROM",
+	"git push --force",
+	"git push -f",
+	"git reset --hard",
+	"git clean -f",
+	"docker rm",
+	"docker rmi",
+	"docker system prune",
+	"kubectl delete",
+	"kill -9",
+	"pkill",
+	"chmod 777",
+}
+
+// secretPatterns are regexes for common API keys and credentials.
+var secretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),                          // AWS access key
+	regexp.MustCompile(`sk-ant-[a-zA-Z0-9\-_]{20,}`),                // Anthropic API key
+	regexp.MustCompile(`sk-[a-zA-Z0-9]{20,}`),                       // OpenAI API key
+	regexp.MustCompile(`ghp_[a-zA-Z0-9]{36}`),                       // GitHub personal access token
+	regexp.MustCompile(`gho_[a-zA-Z0-9]{36}`),                       // GitHub OAuth token
+	regexp.MustCompile(`github_pat_[a-zA-Z0-9_]{22,}`),              // GitHub fine-grained PAT
+	regexp.MustCompile(`glpat-[a-zA-Z0-9\-_]{20,}`),                 // GitLab PAT
+	regexp.MustCompile(`xoxb-[0-9]{10,}-[0-9]{10,}-[a-zA-Z0-9]+`),  // Slack bot token
+	regexp.MustCompile(`xoxp-[0-9]{10,}-[0-9]{10,}-[a-zA-Z0-9]+`),  // Slack user token
+	regexp.MustCompile(`-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----`), // Private keys
+	regexp.MustCompile(`(?i)password\s*[:=]\s*["'][^"']{8,}["']`),    // Hardcoded passwords
+	regexp.MustCompile(`(?i)api[_-]?key\s*[:=]\s*["'][a-zA-Z0-9\-_]{16,}["']`), // Generic API keys
+}
+
+// Parse reads deny.toml from raw bytes.
+func Parse(data []byte) (*Guardrails, error) {
+	if len(data) == 0 {
+		return &Guardrails{}, nil
+	}
+	var g Guardrails
+	if err := toml.Unmarshal(data, &g); err != nil {
+		return nil, fmt.Errorf("guardrails: parse deny.toml: %w", err)
+	}
+	return &g, nil
+}
+
+// CheckFilePaths returns violations for file paths that match [write] or [read] deny patterns.
 func (g *Guardrails) CheckFilePaths(ctx context.Context, paths []string) []Violation {
-	// TODO: implement glob matching
-	return nil
+	var violations []Violation
+	for _, p := range paths {
+		if v := matchDenyList(p, &g.Read, "read"); v != nil {
+			violations = append(violations, *v)
+		}
+		if v := matchDenyList(p, &g.Write, "write"); v != nil {
+			violations = append(violations, *v)
+		}
+	}
+	return violations
+}
+
+// CheckWritePaths returns violations only for [write] deny patterns.
+func (g *Guardrails) CheckWritePaths(ctx context.Context, paths []string) []Violation {
+	var violations []Violation
+	for _, p := range paths {
+		if v := matchDenyList(p, &g.Write, "write"); v != nil {
+			violations = append(violations, *v)
+		}
+	}
+	return violations
+}
+
+// CheckReadPaths returns violations only for [read] deny patterns.
+func (g *Guardrails) CheckReadPaths(ctx context.Context, paths []string) []Violation {
+	var violations []Violation
+	for _, p := range paths {
+		if v := matchDenyList(p, &g.Read, "read"); v != nil {
+			violations = append(violations, *v)
+		}
+	}
+	return violations
 }
 
 // CheckCommand returns a violation if the command matches [execute] patterns.
 func (g *Guardrails) CheckCommand(ctx context.Context, cmd string) *Violation {
-	// TODO: implement pattern matching
+	cmd = strings.TrimSpace(cmd)
+	for _, pattern := range g.Execute.Patterns {
+		if strings.HasPrefix(pattern, "!") {
+			continue
+		}
+		// Execute patterns use prefix/glob matching.
+		// "pass show*" matches "pass show secret/email"
+		if matchExecutePattern(cmd, pattern) {
+			return &Violation{Type: "execute", Pattern: pattern, Target: cmd}
+		}
+	}
 	return nil
+}
+
+// CheckDestructive returns a violation if the command is destructive (for ModeCareful/ModeGuard).
+func (g *Guardrails) CheckDestructive(_ context.Context, cmd string) *Violation {
+	lower := strings.ToLower(strings.TrimSpace(cmd))
+	for _, d := range destructiveCommands {
+		if strings.Contains(lower, strings.ToLower(d)) {
+			return &Violation{Type: "destructive", Pattern: d, Target: cmd}
+		}
+	}
+	return nil
+}
+
+// CheckBoundaries validates that paths are within SDD write_dirs and not in forbidden_dirs.
+// Used in ModeFreeze and ModeGuard.
+func (g *Guardrails) CheckBoundaries(_ context.Context, paths []string, writeDirs, forbiddenDirs []string) []Violation {
+	var violations []Violation
+
+	for _, p := range paths {
+		clean := filepath.Clean(p)
+
+		// Check forbidden dirs first.
+		for _, forbidden := range forbiddenDirs {
+			matched, _ := filepath.Match(forbidden, clean)
+			if matched || strings.HasPrefix(clean, filepath.Clean(forbidden)) {
+				violations = append(violations, Violation{
+					Type:    "boundary",
+					Pattern: forbidden,
+					Target:  p,
+				})
+			}
+		}
+
+		// If write_dirs is specified, path must be within at least one.
+		if len(writeDirs) > 0 {
+			allowed := false
+			for _, dir := range writeDirs {
+				if strings.HasPrefix(clean, filepath.Clean(dir)) {
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				violations = append(violations, Violation{
+					Type:    "boundary",
+					Pattern: fmt.Sprintf("not in write_dirs: %v", writeDirs),
+					Target:  p,
+				})
+			}
+		}
+	}
+	return violations
 }
 
 // ScanForSecrets checks file contents for API key / credential patterns.
 func (g *Guardrails) ScanForSecrets(ctx context.Context, files []string) []Violation {
-	// TODO: implement regex scanning (AKIA, sk-ant-, ghp_, etc.)
+	var violations []Violation
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			slog.WarnContext(ctx, "guardrails: cannot read file for secret scan", "file", f, "error", err)
+			continue
+		}
+		content := string(data)
+		for _, re := range secretPatterns {
+			if loc := re.FindStringIndex(content); loc != nil {
+				// Don't include the actual secret in the violation.
+				violations = append(violations, Violation{
+					Type:    "secret",
+					Pattern: re.String(),
+					Target:  f,
+				})
+				break // One finding per file is enough.
+			}
+		}
+	}
+	return violations
+}
+
+// Enforce runs all applicable checks for the given mode and returns all violations.
+// This is the main entry point for runtime guardrails during SDD execution.
+func (g *Guardrails) Enforce(ctx context.Context, mode Mode, opts EnforceOpts) []Violation {
+	var all []Violation
+
+	// deny.toml checks always apply (regardless of mode).
+	if len(opts.FilePaths) > 0 {
+		all = append(all, g.CheckFilePaths(ctx, opts.FilePaths)...)
+	}
+	if opts.Command != "" {
+		if v := g.CheckCommand(ctx, opts.Command); v != nil {
+			all = append(all, *v)
+		}
+	}
+	if len(opts.ScanFiles) > 0 {
+		all = append(all, g.ScanForSecrets(ctx, opts.ScanFiles)...)
+	}
+
+	// Mode-specific checks.
+	if mode == ModeCareful || mode == ModeGuard {
+		if opts.Command != "" {
+			if v := g.CheckDestructive(ctx, opts.Command); v != nil {
+				all = append(all, *v)
+			}
+		}
+	}
+	if mode == ModeFreeze || mode == ModeGuard {
+		if len(opts.FilePaths) > 0 {
+			all = append(all, g.CheckBoundaries(ctx, opts.FilePaths, opts.WriteDirs, opts.ForbiddenDirs)...)
+		}
+	}
+
+	return all
+}
+
+// EnforceOpts holds the inputs for an Enforce call.
+type EnforceOpts struct {
+	Command      string   // command being executed (for execute + destructive checks)
+	FilePaths    []string // file paths being accessed (for read/write + boundary checks)
+	ScanFiles    []string // files to scan for secrets
+	WriteDirs    []string // allowed write directories (from SDD boundaries)
+	ForbiddenDirs []string // forbidden directories (from SDD boundaries)
+}
+
+// matchDenyList checks a path against a deny list, respecting ! exceptions.
+func matchDenyList(path string, dl *DenyList, violationType string) *Violation {
+	denied := false
+	matchedPattern := ""
+
+	for _, pattern := range dl.Patterns {
+		// Exception pattern: "!**/.env.example" undoes a previous deny.
+		if strings.HasPrefix(pattern, "!") {
+			exception := pattern[1:]
+			if matchGlob(path, exception) {
+				denied = false
+			}
+			continue
+		}
+
+		if matchGlob(path, pattern) {
+			denied = true
+			matchedPattern = pattern
+		}
+	}
+
+	if denied {
+		return &Violation{Type: violationType, Pattern: matchedPattern, Target: path}
+	}
 	return nil
 }
 
-// Parse reads deny.toml from raw bytes.
-// Vault provides the raw bytes via GuardrailsRaw(), this package parses them.
-func Parse(data []byte) (*Guardrails, error) {
-	// TODO: implement TOML parsing
-	return &Guardrails{}, nil
+// matchGlob matches a path against a glob pattern.
+// Supports ** for recursive directory matching.
+func matchGlob(path, pattern string) bool {
+	// Normalize separators.
+	path = filepath.ToSlash(path)
+	pattern = filepath.ToSlash(pattern)
+
+	// Handle ** patterns by converting to a more flexible match.
+	if strings.Contains(pattern, "**") {
+		// "**/*.pem" should match "foo/bar/baz.pem" and "baz.pem"
+		// Convert ** to regex-like matching.
+		return matchDoubleStarGlob(path, pattern)
+	}
+
+	// Simple filepath.Match for non-** patterns.
+	matched, _ := filepath.Match(pattern, path)
+	if matched {
+		return true
+	}
+
+	// Also try matching against just the filename.
+	matched, _ = filepath.Match(pattern, filepath.Base(path))
+	return matched
+}
+
+// matchDoubleStarGlob handles ** glob patterns.
+func matchDoubleStarGlob(path, pattern string) bool {
+	// Split pattern on **
+	parts := strings.Split(pattern, "**")
+	if len(parts) != 2 {
+		// Multiple ** — fall back to simple check.
+		return strings.Contains(path, strings.ReplaceAll(pattern, "**", ""))
+	}
+
+	prefix := strings.TrimSuffix(parts[0], "/")
+	suffix := strings.TrimPrefix(parts[1], "/")
+
+	// If no prefix, just match the suffix against the path and all subpaths.
+	if prefix == "" {
+		// "**/*.pem" — check if any path segment + suffix matches.
+		if suffix == "" {
+			return true
+		}
+		// Match suffix against the full path and the basename.
+		matched, _ := filepath.Match(suffix, filepath.ToSlash(path))
+		if matched {
+			return true
+		}
+		matched, _ = filepath.Match(suffix, filepath.Base(path))
+		if matched {
+			return true
+		}
+		// Check each possible subpath.
+		segments := strings.Split(path, "/")
+		for i := range segments {
+			subpath := strings.Join(segments[i:], "/")
+			matched, _ = filepath.Match(suffix, subpath)
+			if matched {
+				return true
+			}
+		}
+		return false
+	}
+
+	// "foo/**/*.pem" — prefix must match, then suffix against remainder.
+	if !strings.HasPrefix(path, prefix+"/") && path != prefix {
+		return false
+	}
+	remainder := strings.TrimPrefix(path, prefix+"/")
+	if suffix == "" {
+		return true
+	}
+	matched, _ := filepath.Match(suffix, remainder)
+	if matched {
+		return true
+	}
+	matched, _ = filepath.Match(suffix, filepath.Base(remainder))
+	return matched
+}
+
+// matchExecutePattern matches a command against an execute deny pattern.
+// Patterns ending in * are prefix matches. Others are exact.
+func matchExecutePattern(cmd, pattern string) bool {
+	if strings.HasSuffix(pattern, "*") {
+		prefix := strings.TrimSuffix(pattern, "*")
+		return strings.HasPrefix(cmd, prefix)
+	}
+	return cmd == pattern
 }

--- a/internal/guardrails/guardrails.go
+++ b/internal/guardrails/guardrails.go
@@ -357,59 +357,53 @@ func matchGlob(path, pattern string) bool {
 	return matched
 }
 
-// matchDoubleStarGlob handles ** glob patterns.
+// matchDoubleStarGlob handles ** glob patterns by converting to regex.
+// Supports multiple ** in one pattern (e.g. "**/.azure/**").
 func matchDoubleStarGlob(path, pattern string) bool {
-	// Split pattern on **
-	parts := strings.Split(pattern, "**")
-	if len(parts) != 2 {
-		// Multiple ** — fall back to simple check.
-		return strings.Contains(path, strings.ReplaceAll(pattern, "**", ""))
-	}
+	re := globToRegex(pattern)
+	return re.MatchString(path)
+}
 
-	prefix := strings.TrimSuffix(parts[0], "/")
-	suffix := strings.TrimPrefix(parts[1], "/")
+// globToRegex converts a glob pattern with ** to a compiled regex.
+// ** matches zero or more path segments, * matches within a segment.
+func globToRegex(pattern string) *regexp.Regexp {
+	var b strings.Builder
+	b.WriteString("^")
 
-	// If no prefix, just match the suffix against the path and all subpaths.
-	if prefix == "" {
-		// "**/*.pem" — check if any path segment + suffix matches.
-		if suffix == "" {
-			return true
-		}
-		// Match suffix against the full path and the basename.
-		matched, _ := filepath.Match(suffix, filepath.ToSlash(path))
-		if matched {
-			return true
-		}
-		matched, _ = filepath.Match(suffix, filepath.Base(path))
-		if matched {
-			return true
-		}
-		// Check each possible subpath.
-		segments := strings.Split(path, "/")
-		for i := range segments {
-			subpath := strings.Join(segments[i:], "/")
-			matched, _ = filepath.Match(suffix, subpath)
-			if matched {
-				return true
+	i := 0
+	for i < len(pattern) {
+		if i+1 < len(pattern) && pattern[i] == '*' && pattern[i+1] == '*' {
+			// ** matches any number of path segments (including zero).
+			// Consume trailing slash if present.
+			b.WriteString(".*")
+			i += 2
+			if i < len(pattern) && pattern[i] == '/' {
+				i++
 			}
+			continue
 		}
-		return false
+		switch pattern[i] {
+		case '*':
+			b.WriteString("[^/]*") // * matches within a single segment
+		case '?':
+			b.WriteString("[^/]")
+		case '.':
+			b.WriteString(`\.`)
+		case '/':
+			b.WriteString("/")
+		default:
+			b.WriteString(regexp.QuoteMeta(string(pattern[i])))
+		}
+		i++
 	}
 
-	// "foo/**/*.pem" — prefix must match, then suffix against remainder.
-	if !strings.HasPrefix(path, prefix+"/") && path != prefix {
-		return false
+	b.WriteString("$")
+	re, err := regexp.Compile(b.String())
+	if err != nil {
+		// Fallback: literal substring check.
+		return regexp.MustCompile(regexp.QuoteMeta(pattern))
 	}
-	remainder := strings.TrimPrefix(path, prefix+"/")
-	if suffix == "" {
-		return true
-	}
-	matched, _ := filepath.Match(suffix, remainder)
-	if matched {
-		return true
-	}
-	matched, _ = filepath.Match(suffix, filepath.Base(remainder))
-	return matched
+	return re
 }
 
 // matchExecutePattern matches a command against an execute deny pattern.

--- a/internal/guardrails/guardrails.go
+++ b/internal/guardrails/guardrails.go
@@ -63,6 +63,9 @@ type Guardrails struct {
 	Read    DenyList `toml:"read"`
 	Execute DenyList `toml:"execute"`
 	Write   DenyList `toml:"write"`
+
+	// globCache holds pre-compiled regexes for ** glob patterns (populated by Parse).
+	globCache map[string]*regexp.Regexp
 }
 
 // DenyList contains glob patterns that are denied.
@@ -120,14 +123,24 @@ var secretPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)api[_-]?key\s*[:=]\s*["'][a-zA-Z0-9\-_]{16,}["']`), // Generic API keys
 }
 
-// Parse reads deny.toml from raw bytes.
+// Parse reads deny.toml from raw bytes and pre-compiles glob regexes.
 func Parse(data []byte) (*Guardrails, error) {
 	if len(data) == 0 {
-		return &Guardrails{}, nil
+		return &Guardrails{globCache: make(map[string]*regexp.Regexp)}, nil
 	}
 	var g Guardrails
 	if err := toml.Unmarshal(data, &g); err != nil {
 		return nil, fmt.Errorf("guardrails: parse deny.toml: %w", err)
+	}
+	// Pre-compile glob regexes for all ** patterns.
+	g.globCache = make(map[string]*regexp.Regexp)
+	for _, patterns := range [][]string{g.Read.Patterns, g.Write.Patterns} {
+		for _, p := range patterns {
+			clean := strings.TrimPrefix(p, "!")
+			if strings.Contains(clean, "**") {
+				g.globCache[clean] = globToRegex(filepath.ToSlash(clean))
+			}
+		}
 	}
 	return &g, nil
 }
@@ -136,10 +149,10 @@ func Parse(data []byte) (*Guardrails, error) {
 func (g *Guardrails) CheckFilePaths(ctx context.Context, paths []string) []Violation {
 	var violations []Violation
 	for _, p := range paths {
-		if v := matchDenyList(p, &g.Read, "read"); v != nil {
+		if v := matchDenyList(p, &g.Read, "read", g.globCache); v != nil {
 			violations = append(violations, *v)
 		}
-		if v := matchDenyList(p, &g.Write, "write"); v != nil {
+		if v := matchDenyList(p, &g.Write, "write", g.globCache); v != nil {
 			violations = append(violations, *v)
 		}
 	}
@@ -150,7 +163,7 @@ func (g *Guardrails) CheckFilePaths(ctx context.Context, paths []string) []Viola
 func (g *Guardrails) CheckWritePaths(ctx context.Context, paths []string) []Violation {
 	var violations []Violation
 	for _, p := range paths {
-		if v := matchDenyList(p, &g.Write, "write"); v != nil {
+		if v := matchDenyList(p, &g.Write, "write", g.globCache); v != nil {
 			violations = append(violations, *v)
 		}
 	}
@@ -161,7 +174,7 @@ func (g *Guardrails) CheckWritePaths(ctx context.Context, paths []string) []Viol
 func (g *Guardrails) CheckReadPaths(ctx context.Context, paths []string) []Violation {
 	var violations []Violation
 	for _, p := range paths {
-		if v := matchDenyList(p, &g.Read, "read"); v != nil {
+		if v := matchDenyList(p, &g.Read, "read", g.globCache); v != nil {
 			violations = append(violations, *v)
 		}
 	}
@@ -205,8 +218,10 @@ func (g *Guardrails) CheckBoundaries(_ context.Context, paths []string, writeDir
 
 		// Check forbidden dirs first.
 		for _, forbidden := range forbiddenDirs {
-			matched, _ := filepath.Match(forbidden, clean)
-			if matched || strings.HasPrefix(clean, filepath.Clean(forbidden)) {
+			cleanForbidden := filepath.Clean(forbidden)
+			matched, _ := filepath.Match(cleanForbidden, clean)
+			// Append separator to prevent "src" matching "src2/" (sibling bypass).
+			if matched || clean == cleanForbidden || strings.HasPrefix(clean, cleanForbidden+string(filepath.Separator)) {
 				violations = append(violations, Violation{
 					Type:    "boundary",
 					Pattern: forbidden,
@@ -219,7 +234,9 @@ func (g *Guardrails) CheckBoundaries(_ context.Context, paths []string, writeDir
 		if len(writeDirs) > 0 {
 			allowed := false
 			for _, dir := range writeDirs {
-				if strings.HasPrefix(clean, filepath.Clean(dir)) {
+				cleanDir := filepath.Clean(dir)
+				// Append separator to prevent "src" matching "src2/" (sibling bypass).
+				if clean == cleanDir || strings.HasPrefix(clean, cleanDir+string(filepath.Separator)) {
 					allowed = true
 					break
 				}
@@ -238,8 +255,18 @@ func (g *Guardrails) CheckBoundaries(_ context.Context, paths []string, writeDir
 
 // ScanForSecrets checks file contents for API key / credential patterns.
 func (g *Guardrails) ScanForSecrets(ctx context.Context, files []string) []Violation {
+	const maxScanSize = 1 << 20 // 1 MB — skip large/binary files
 	var violations []Violation
 	for _, f := range files {
+		info, err := os.Stat(f)
+		if err != nil {
+			slog.WarnContext(ctx, "guardrails: cannot stat file for secret scan", "file", f, "error", err)
+			continue
+		}
+		if info.Size() > maxScanSize {
+			slog.InfoContext(ctx, "guardrails: skipping large file for secret scan", "file", f, "size", info.Size())
+			continue
+		}
 		data, err := os.ReadFile(f)
 		if err != nil {
 			slog.WarnContext(ctx, "guardrails: cannot read file for secret scan", "file", f, "error", err)
@@ -306,7 +333,8 @@ type EnforceOpts struct {
 }
 
 // matchDenyList checks a path against a deny list, respecting ! exceptions.
-func matchDenyList(path string, dl *DenyList, violationType string) *Violation {
+// cache is a map of pre-compiled regexes for ** patterns (may be nil).
+func matchDenyList(path string, dl *DenyList, violationType string, cache map[string]*regexp.Regexp) *Violation {
 	denied := false
 	matchedPattern := ""
 
@@ -314,13 +342,13 @@ func matchDenyList(path string, dl *DenyList, violationType string) *Violation {
 		// Exception pattern: "!**/.env.example" undoes a previous deny.
 		if strings.HasPrefix(pattern, "!") {
 			exception := pattern[1:]
-			if matchGlob(path, exception) {
+			if matchGlob(path, exception, cache) {
 				denied = false
 			}
 			continue
 		}
 
-		if matchGlob(path, pattern) {
+		if matchGlob(path, pattern, cache) {
 			denied = true
 			matchedPattern = pattern
 		}
@@ -333,17 +361,21 @@ func matchDenyList(path string, dl *DenyList, violationType string) *Violation {
 }
 
 // matchGlob matches a path against a glob pattern.
-// Supports ** for recursive directory matching.
-func matchGlob(path, pattern string) bool {
+// Supports ** for recursive directory matching. cache is optional (may be nil).
+func matchGlob(path, pattern string, cache map[string]*regexp.Regexp) bool {
 	// Normalize separators.
 	path = filepath.ToSlash(path)
 	pattern = filepath.ToSlash(pattern)
 
-	// Handle ** patterns by converting to a more flexible match.
+	// Handle ** patterns — use cached regex if available.
 	if strings.Contains(pattern, "**") {
-		// "**/*.pem" should match "foo/bar/baz.pem" and "baz.pem"
-		// Convert ** to regex-like matching.
-		return matchDoubleStarGlob(path, pattern)
+		if cache != nil {
+			if re, ok := cache[pattern]; ok {
+				return re.MatchString(path)
+			}
+		}
+		// Fallback: compile on the fly (for patterns not in cache).
+		return globToRegex(pattern).MatchString(path)
 	}
 
 	// Simple filepath.Match for non-** patterns.
@@ -355,13 +387,6 @@ func matchGlob(path, pattern string) bool {
 	// Also try matching against just the filename.
 	matched, _ = filepath.Match(pattern, filepath.Base(path))
 	return matched
-}
-
-// matchDoubleStarGlob handles ** glob patterns by converting to regex.
-// Supports multiple ** in one pattern (e.g. "**/.azure/**").
-func matchDoubleStarGlob(path, pattern string) bool {
-	re := globToRegex(pattern)
-	return re.MatchString(path)
 }
 
 // globToRegex converts a glob pattern with ** to a compiled regex.

--- a/internal/guardrails/guardrails_test.go
+++ b/internal/guardrails/guardrails_test.go
@@ -1,0 +1,491 @@
+package guardrails
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var ctx = context.Background()
+
+// --- Parse ---
+
+func TestParseValidDenyToml(t *testing.T) {
+	data := []byte(`
+[read]
+patterns = ["**/.env", "**/*.pem"]
+
+[execute]
+patterns = ["pass show*", "gpg --export-secret*"]
+
+[write]
+patterns = ["**/.env", ".forgia/constitution.md"]
+`)
+	g, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(g.Read.Patterns) != 2 {
+		t.Errorf("expected 2 read patterns, got %d", len(g.Read.Patterns))
+	}
+	if len(g.Execute.Patterns) != 2 {
+		t.Errorf("expected 2 execute patterns, got %d", len(g.Execute.Patterns))
+	}
+	if len(g.Write.Patterns) != 2 {
+		t.Errorf("expected 2 write patterns, got %d", len(g.Write.Patterns))
+	}
+}
+
+func TestParseEmpty(t *testing.T) {
+	g, err := Parse([]byte{})
+	if err != nil {
+		t.Fatalf("Parse empty failed: %v", err)
+	}
+	if len(g.Read.Patterns) != 0 {
+		t.Errorf("expected 0 read patterns, got %d", len(g.Read.Patterns))
+	}
+}
+
+func TestParseInvalidToml(t *testing.T) {
+	_, err := Parse([]byte(`this is not valid toml [[[`))
+	if err == nil {
+		t.Fatal("expected error for invalid TOML")
+	}
+}
+
+// --- CheckFilePaths ---
+
+func TestCheckFilePathsDenied(t *testing.T) {
+	g := &Guardrails{
+		Read:  DenyList{Patterns: []string{"**/.env", "**/*.pem"}},
+		Write: DenyList{Patterns: []string{"**/.env", ".forgia/constitution.md"}},
+	}
+
+	violations := g.CheckFilePaths(ctx, []string{
+		"config/.env",
+		"src/main.go",
+		"certs/server.pem",
+	})
+
+	// .env matches read + write (2), server.pem matches read (1) = 3
+	if len(violations) != 3 {
+		t.Fatalf("expected 3 violations, got %d: %v", len(violations), violations)
+	}
+}
+
+func TestCheckFilePathsAllowed(t *testing.T) {
+	g := &Guardrails{
+		Read:  DenyList{Patterns: []string{"**/.env"}},
+		Write: DenyList{Patterns: []string{"**/.env"}},
+	}
+
+	violations := g.CheckFilePaths(ctx, []string{"src/main.go", "README.md"})
+	if len(violations) != 0 {
+		t.Fatalf("expected 0 violations, got %d", len(violations))
+	}
+}
+
+func TestCheckFilePathsException(t *testing.T) {
+	g := &Guardrails{
+		Read: DenyList{Patterns: []string{"**/.env", "**/.env.*", "!**/.env.example"}},
+	}
+
+	// .env.example should be allowed (exception), .env.local should be denied
+	violations := g.CheckReadPaths(ctx, []string{".env.example", ".env.local"})
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Target != ".env.local" {
+		t.Errorf("expected violation on .env.local, got %s", violations[0].Target)
+	}
+}
+
+func TestCheckFilePathsConstitution(t *testing.T) {
+	g := &Guardrails{
+		Write: DenyList{Patterns: []string{".forgia/constitution.md", ".forgia/config.toml"}},
+	}
+
+	violations := g.CheckWritePaths(ctx, []string{".forgia/constitution.md"})
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+}
+
+// --- CheckCommand ---
+
+func TestCheckCommandDenied(t *testing.T) {
+	g := &Guardrails{
+		Execute: DenyList{Patterns: []string{"pass show*", "gpg --export-secret*", "cat ~/.ssh/id_*"}},
+	}
+
+	tests := []struct {
+		cmd    string
+		denied bool
+	}{
+		{"pass show secret/email", true},
+		{"pass show", true},
+		{"gpg --export-secret-keys", true},
+		{"cat ~/.ssh/id_rsa", true},
+		{"cat ~/.ssh/id_ed25519", true},
+		{"ls -la", false},
+		{"go build ./...", false},
+		{"git push origin main", false},
+	}
+
+	for _, tt := range tests {
+		v := g.CheckCommand(ctx, tt.cmd)
+		if tt.denied && v == nil {
+			t.Errorf("expected %q to be denied", tt.cmd)
+		}
+		if !tt.denied && v != nil {
+			t.Errorf("expected %q to be allowed, got violation: %v", tt.cmd, v)
+		}
+	}
+}
+
+// --- CheckDestructive ---
+
+func TestCheckDestructive(t *testing.T) {
+	g := &Guardrails{}
+
+	tests := []struct {
+		cmd         string
+		destructive bool
+	}{
+		{"rm -rf /tmp/test", true},
+		{"rm -r build/", true},
+		{"git push --force", true},
+		{"git push -f origin main", true},
+		{"git reset --hard HEAD~1", true},
+		{"docker rm container123", true},
+		{"kubectl delete pod foo", true},
+		{"chmod 777 /tmp/test", true},
+		{"git push origin main", false},
+		{"go test ./...", false},
+		{"rm single-file.txt", false},
+		{"docker ps", false},
+	}
+
+	for _, tt := range tests {
+		v := g.CheckDestructive(ctx, tt.cmd)
+		if tt.destructive && v == nil {
+			t.Errorf("expected %q to be destructive", tt.cmd)
+		}
+		if !tt.destructive && v != nil {
+			t.Errorf("expected %q to be safe, got: %v", tt.cmd, v)
+		}
+	}
+}
+
+// --- CheckBoundaries ---
+
+func TestCheckBoundariesAllowed(t *testing.T) {
+	g := &Guardrails{}
+
+	violations := g.CheckBoundaries(ctx,
+		[]string{"src/main.go", "src/lib/utils.go"},
+		[]string{"src/"},
+		nil,
+	)
+	if len(violations) != 0 {
+		t.Fatalf("expected 0 violations, got %d: %v", len(violations), violations)
+	}
+}
+
+func TestCheckBoundariesOutsideWriteDirs(t *testing.T) {
+	g := &Guardrails{}
+
+	violations := g.CheckBoundaries(ctx,
+		[]string{"src/main.go", "docs/README.md"},
+		[]string{"src/"},
+		nil,
+	)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Target != "docs/README.md" {
+		t.Errorf("expected violation on docs/README.md, got %s", violations[0].Target)
+	}
+}
+
+func TestCheckBoundariesForbiddenDir(t *testing.T) {
+	g := &Guardrails{}
+
+	violations := g.CheckBoundaries(ctx,
+		[]string{"src/main.go", ".forgia/config.toml"},
+		nil, // no write_dirs restriction
+		[]string{".forgia/"},
+	)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %v", len(violations), violations)
+	}
+	if violations[0].Target != ".forgia/config.toml" {
+		t.Errorf("expected violation on .forgia/config.toml, got %s", violations[0].Target)
+	}
+}
+
+func TestCheckBoundariesNoRestrictions(t *testing.T) {
+	g := &Guardrails{}
+
+	violations := g.CheckBoundaries(ctx,
+		[]string{"anywhere/file.go"},
+		nil,
+		nil,
+	)
+	if len(violations) != 0 {
+		t.Fatalf("expected 0 violations with no restrictions, got %d", len(violations))
+	}
+}
+
+// --- ScanForSecrets ---
+
+func TestScanForSecretsFindsKeys(t *testing.T) {
+	g := &Guardrails{}
+	dir := t.TempDir()
+
+	// File with AWS key
+	awsFile := filepath.Join(dir, "config.py")
+	os.WriteFile(awsFile, []byte(`aws_key = "AKIAIOSFODNN7EXAMPLE"`), 0o644)
+
+	// File with OpenAI key
+	openaiFile := filepath.Join(dir, "app.js")
+	os.WriteFile(openaiFile, []byte(`const key = "sk-abcdefghijklmnopqrstuvwxyz123456"`), 0o644)
+
+	// Clean file
+	cleanFile := filepath.Join(dir, "main.go")
+	os.WriteFile(cleanFile, []byte(`package main; func main() {}`), 0o644)
+
+	violations := g.ScanForSecrets(ctx, []string{awsFile, openaiFile, cleanFile})
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d: %v", len(violations), violations)
+	}
+
+	targets := map[string]bool{}
+	for _, v := range violations {
+		targets[v.Target] = true
+		if v.Type != "secret" {
+			t.Errorf("expected type 'secret', got %q", v.Type)
+		}
+	}
+	if !targets[awsFile] {
+		t.Error("expected AWS key file to be flagged")
+	}
+	if !targets[openaiFile] {
+		t.Error("expected OpenAI key file to be flagged")
+	}
+}
+
+func TestScanForSecretsPrivateKey(t *testing.T) {
+	g := &Guardrails{}
+	dir := t.TempDir()
+
+	keyFile := filepath.Join(dir, "key.pem")
+	os.WriteFile(keyFile, []byte("-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----"), 0o644)
+
+	violations := g.ScanForSecrets(ctx, []string{keyFile})
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(violations))
+	}
+}
+
+func TestScanForSecretsCleanFile(t *testing.T) {
+	g := &Guardrails{}
+	dir := t.TempDir()
+
+	cleanFile := filepath.Join(dir, "main.go")
+	os.WriteFile(cleanFile, []byte(`package main; func main() { println("hello") }`), 0o644)
+
+	violations := g.ScanForSecrets(ctx, []string{cleanFile})
+	if len(violations) != 0 {
+		t.Fatalf("expected 0 violations, got %d", len(violations))
+	}
+}
+
+func TestScanForSecretsMissingFile(t *testing.T) {
+	g := &Guardrails{}
+	// Should not panic on missing file, just skip with warning.
+	violations := g.ScanForSecrets(ctx, []string{"/nonexistent/file.go"})
+	if len(violations) != 0 {
+		t.Fatalf("expected 0 violations for missing file, got %d", len(violations))
+	}
+}
+
+// --- Enforce ---
+
+func TestEnforceGuardMode(t *testing.T) {
+	g := &Guardrails{
+		Write:   DenyList{Patterns: []string{"**/.env"}},
+		Execute: DenyList{Patterns: []string{"pass show*"}},
+	}
+
+	violations := g.Enforce(ctx, ModeGuard, EnforceOpts{
+		Command:      "rm -rf /tmp",
+		FilePaths:    []string{"src/main.go", "docs/readme.md"},
+		WriteDirs:    []string{"src/"},
+		ForbiddenDirs: []string{},
+	})
+
+	// Expected: "rm -rf" is destructive (guard mode) + docs/readme.md outside write_dirs (freeze)
+	found := map[string]bool{}
+	for _, v := range violations {
+		found[v.Type] = true
+	}
+	if !found["destructive"] {
+		t.Error("expected destructive violation for rm -rf")
+	}
+	if !found["boundary"] {
+		t.Error("expected boundary violation for docs/readme.md")
+	}
+}
+
+func TestEnforceCarefulModeNoFreeze(t *testing.T) {
+	g := &Guardrails{}
+
+	violations := g.Enforce(ctx, ModeCareful, EnforceOpts{
+		Command:   "rm -rf /tmp",
+		FilePaths: []string{"anywhere/file.go"},
+		WriteDirs: []string{"src/"}, // careful mode ignores write_dirs
+	})
+
+	// Only destructive, no boundary check.
+	for _, v := range violations {
+		if v.Type == "boundary" {
+			t.Error("careful mode should not check boundaries")
+		}
+	}
+}
+
+func TestEnforceOffMode(t *testing.T) {
+	g := &Guardrails{
+		Execute: DenyList{Patterns: []string{"pass show*"}},
+	}
+
+	violations := g.Enforce(ctx, ModeOff, EnforceOpts{
+		Command:   "rm -rf /tmp",
+		FilePaths: []string{"anywhere/file.go"},
+		WriteDirs: []string{"src/"},
+	})
+
+	// deny.toml still applies ("pass show" would be caught), but rm -rf is not in execute patterns.
+	// No destructive check (mode off), no boundary check (mode off).
+	for _, v := range violations {
+		if v.Type == "destructive" || v.Type == "boundary" {
+			t.Errorf("mode off should not check %s", v.Type)
+		}
+	}
+}
+
+// --- Mode ---
+
+func TestParseMode(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected Mode
+	}{
+		{"careful", ModeCareful},
+		{"Careful", ModeCareful},
+		{"freeze", ModeFreeze},
+		{"guard", ModeGuard},
+		{"GUARD", ModeGuard},
+		{"off", ModeOff},
+		{"", ModeOff},
+		{"unknown", ModeOff},
+	}
+	for _, tt := range tests {
+		got := ParseMode(tt.input)
+		if got != tt.expected {
+			t.Errorf("ParseMode(%q) = %v, want %v", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestModeString(t *testing.T) {
+	if ModeGuard.String() != "guard" {
+		t.Errorf("expected 'guard', got %q", ModeGuard.String())
+	}
+	if ModeOff.String() != "off" {
+		t.Errorf("expected 'off', got %q", ModeOff.String())
+	}
+}
+
+// --- Glob matching ---
+
+func TestMatchGlobDoublestar(t *testing.T) {
+	tests := []struct {
+		path    string
+		pattern string
+		match   bool
+	}{
+		{"config/.env", "**/.env", true},
+		{"deep/nested/.env", "**/.env", true},
+		{".env", "**/.env", true},
+		{"certs/server.pem", "**/*.pem", true},
+		{"deep/nested/cert.pem", "**/*.pem", true},
+		{"main.go", "**/*.pem", false},
+		{".env.example", "**/.env.example", true},
+		{".env.local", "**/.env.*", true},
+		{".ssh/id_rsa", "**/.ssh/id_*", true},
+	}
+
+	for _, tt := range tests {
+		got := matchGlob(tt.path, tt.pattern)
+		if got != tt.match {
+			t.Errorf("matchGlob(%q, %q) = %v, want %v", tt.path, tt.pattern, got, tt.match)
+		}
+	}
+}
+
+// --- Full deny.toml integration ---
+
+func TestFullDenyTomlIntegration(t *testing.T) {
+	data := []byte(`
+[read]
+patterns = [
+  "**/.env",
+  "**/.env.*",
+  "!**/.env.example",
+  "**/*.pem",
+  "**/.ssh/id_*",
+]
+
+[execute]
+patterns = [
+  "pass show*",
+  "gpg --export-secret*",
+  "cat ~/.ssh/id_*",
+]
+
+[write]
+patterns = [
+  "**/.env",
+  ".forgia/constitution.md",
+  "**/*.pem",
+]
+`)
+	g, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	// Read check
+	readV := g.CheckReadPaths(ctx, []string{".env", ".env.example", ".env.local", "server.pem", "main.go"})
+	// .env (denied), .env.example (exception = allowed), .env.local (denied), server.pem (denied), main.go (allowed)
+	if len(readV) != 3 {
+		t.Errorf("expected 3 read violations, got %d: %v", len(readV), readV)
+	}
+
+	// Write check
+	writeV := g.CheckWritePaths(ctx, []string{".forgia/constitution.md", "src/main.go"})
+	if len(writeV) != 1 {
+		t.Errorf("expected 1 write violation, got %d: %v", len(writeV), writeV)
+	}
+
+	// Execute check
+	if v := g.CheckCommand(ctx, "pass show secret/email"); v == nil {
+		t.Error("expected 'pass show' to be denied")
+	}
+	if v := g.CheckCommand(ctx, "go build ./..."); v != nil {
+		t.Error("expected 'go build' to be allowed")
+	}
+}

--- a/internal/guardrails/guardrails_test.go
+++ b/internal/guardrails/guardrails_test.go
@@ -417,6 +417,7 @@ func TestMatchGlobDoublestar(t *testing.T) {
 		pattern string
 		match   bool
 	}{
+		// Single ** prefix
 		{"config/.env", "**/.env", true},
 		{"deep/nested/.env", "**/.env", true},
 		{".env", "**/.env", true},
@@ -426,6 +427,18 @@ func TestMatchGlobDoublestar(t *testing.T) {
 		{".env.example", "**/.env.example", true},
 		{".env.local", "**/.env.*", true},
 		{".ssh/id_rsa", "**/.ssh/id_*", true},
+
+		// Multiple ** (e.g. "**/.azure/**")
+		{".azure/config", "**/.azure/**", true},
+		{"home/.azure/credentials", "**/.azure/**", true},
+		{"deep/nested/.azure/tokens/access.json", "**/.azure/**", true},
+		{"flask-aws-utils/config.py", "**/.azure/**", false},
+		{".gcloud/key.json", "**/.gcloud/**", true},
+
+		// Prefix ** + suffix
+		{".aws/credentials", "**/.aws/credentials", true},
+		{"home/.aws/credentials", "**/.aws/credentials", true},
+		{".aws/config", "**/.aws/credentials", false},
 	}
 
 	for _, tt := range tests {

--- a/internal/guardrails/guardrails_test.go
+++ b/internal/guardrails/guardrails_test.go
@@ -225,6 +225,36 @@ func TestCheckBoundariesForbiddenDir(t *testing.T) {
 	}
 }
 
+func TestCheckBoundariesSiblingBypass(t *testing.T) {
+	g := &Guardrails{}
+
+	// "src2/main.go" must NOT be allowed when write_dirs is ["src/"]
+	violations := g.CheckBoundaries(ctx,
+		[]string{"src/main.go", "src2/main.go"},
+		[]string{"src/"},
+		nil,
+	)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation (src2 not allowed), got %d: %v", len(violations), violations)
+	}
+	if violations[0].Target != "src2/main.go" {
+		t.Errorf("expected violation on src2/main.go, got %s", violations[0].Target)
+	}
+
+	// Same for forbidden: ".forgia" must not match ".forgia2/"
+	violations = g.CheckBoundaries(ctx,
+		[]string{".forgia/config.toml", ".forgia2/data.txt"},
+		nil,
+		[]string{".forgia"},
+	)
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation (.forgia only), got %d: %v", len(violations), violations)
+	}
+	if violations[0].Target != ".forgia/config.toml" {
+		t.Errorf("expected violation on .forgia/config.toml, got %s", violations[0].Target)
+	}
+}
+
 func TestCheckBoundariesNoRestrictions(t *testing.T) {
 	g := &Guardrails{}
 
@@ -442,7 +472,7 @@ func TestMatchGlobDoublestar(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := matchGlob(tt.path, tt.pattern)
+		got := matchGlob(tt.path, tt.pattern, nil)
 		if got != tt.match {
 			t.Errorf("matchGlob(%q, %q) = %v, want %v", tt.path, tt.pattern, got, tt.match)
 		}


### PR DESCRIPTION
## Summary

Replaces all 4 stubs in `internal/guardrails/guardrails.go` with working implementations. Adds 3 runtime modes (Careful, Freeze, Guard) and a unified `Enforce()` entry point.

### What's implemented

| Function | What it does |
|----------|-------------|
| `Parse()` | TOML parsing of deny.toml via pelletier/go-toml |
| `CheckFilePaths()` | Glob matching with `**` support and `!` exceptions |
| `CheckReadPaths()` / `CheckWritePaths()` | Separate read/write checks |
| `CheckCommand()` | Prefix/exact matching for [execute] deny patterns |
| `CheckDestructive()` | Warns on rm -rf, DROP TABLE, force-push, kill -9, etc. |
| `CheckBoundaries()` | Enforces SDD `write_dirs` / `forbidden_dirs` |
| `ScanForSecrets()` | Regex scan for AWS, OpenAI, Anthropic, GitHub, Slack, GitLab tokens, private keys, hardcoded passwords |
| `Enforce()` | Unified entry point — runs all checks based on mode |

### Modes

| Mode | deny.toml | Destructive warn | Boundary check |
|------|-----------|------------------|----------------|
| Off | Yes | No | No |
| Careful | Yes | Yes | No |
| Freeze | Yes | No | Yes |
| Guard | Yes | Yes | Yes |

### Test coverage

24 tests: TOML parsing (valid/empty/invalid), glob matching with `**` and exceptions, file path checks (denied/allowed/exception/constitution), command checks (8 commands), destructive detection (12 commands), boundary enforcement (4 scenarios), secret scanning (AWS/OpenAI/private key/clean/missing file), Enforce with all modes, mode parsing, full deny.toml integration.

## Closes

- Closes #52

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` — all tests pass (24 guardrails + all existing)
- [x] `go vet ./...` — no warnings
- [x] Parses real deny.toml from vault template
- [x] Exception patterns (`!**/.env.example`) work correctly
- [x] Secret patterns don't leak actual secret values in violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)