### PR TITLE
feat: /sdd-dry-run simulation + --dry-run CLI flag

### DIFF
--- a/bin/forgia
+++ b/bin/forgia
@@ -13,14 +13,15 @@ Incantesimi (comandi):
   status                        Mostra la dashboard FD + SDD
   doctor                        Verifica salute (docker, openhands, vault)
   validate <sdd-file|FD-NNN>    Valida un SDD o tutti gli SDD di un FD
-  exec <sdd-file> [--runner=X]  Esegui un SDD (runner: claude|openhands)
-  batch <FD-NNN> [--runner=X]   Esegui tutti gli SDD di un FD
+  exec <sdd-file> [opts]        Esegui un SDD (runner: claude|openhands)
+  batch <FD-NNN> [opts]         Esegui tutti gli SDD di un FD
   watch <FD-NNN> [--runner=X]   Osserva e esegui nuovi SDD automaticamente
 
-Runner:
+Options (exec/batch):
   --runner=claude               Claude Code sub-agent (usa Max subscription)
   --runner=openhands            OpenHands container (usa API key)
-  (default: da .forgia/config.toml)
+  --dry-run                     Simula esecuzione senza modificare file
+  (default runner: da .forgia/config.toml)
 
 USAGE
 }
@@ -81,6 +82,111 @@ strip_runner_arg() {
     [[ "$arg" =~ ^--runner= ]] || args+=("$arg")
   done
   echo "${args[@]}"
+}
+
+# Parse --dry-run from arguments
+parse_dry_run_arg() {
+  for arg in "$@"; do
+    if [[ "$arg" == "--dry-run" ]]; then
+      echo "true"
+      return
+    fi
+  done
+  echo ""
+}
+
+# Remove --dry-run from arguments
+strip_dry_run_arg() {
+  local args=()
+  for arg in "$@"; do
+    [[ "$arg" == "--dry-run" ]] || args+=("$arg")
+  done
+  echo "${args[@]}"
+}
+
+# --- dry-run invocation ---
+
+# Build system context for Claude invocation (shared with runners)
+_build_system_context() {
+  local ctx=""
+  if [[ -f "$VAULT_DIR/constitution.md" ]]; then
+    ctx+="## Constitution"$'\n'
+    ctx+="$(cat "$VAULT_DIR/constitution.md")"$'\n\n'
+  fi
+  if [[ -f "$VAULT_DIR/guardrails/deny.toml" ]]; then
+    ctx+="## Security Guardrails — MANDATORY"$'\n'
+    ctx+="$(cat "$VAULT_DIR/guardrails/deny.toml")"$'\n'
+    ctx+="NEVER read secrets, NEVER execute key export commands, NEVER write to .env or forgia meta files."$'\n\n'
+  fi
+  if [[ -d "$VAULT_DIR/dev-guide/principles" ]]; then
+    for f in "$VAULT_DIR/dev-guide/principles/"*.md; do
+      [[ -f "$f" ]] && ctx+="$(cat "$f")"$'\n\n'
+    done
+  fi
+  if [[ -d "$VAULT_DIR/dev-guide/lang" ]]; then
+    for f in "$VAULT_DIR/dev-guide/lang/"*.md; do
+      [[ -f "$f" ]] && ctx+="$(cat "$f")"$'\n\n'
+    done
+  fi
+  echo "$ctx"
+}
+
+# Run dry-run simulation for a single SDD file.
+# Prints the feasibility report to stdout.
+# Returns 0 for GO/CAUTION, 1 for NO-GO.
+run_dry_run() {
+  local sdd_file="$1"
+  local slash_cmd="$ROOT_DIR/modules/claude-commands/sdd-dry-run.md"
+
+  if ! command -v claude >/dev/null 2>&1; then
+    echo "Errore: 'claude' CLI non trovato. Installa Claude Code prima." >&2
+    return 1
+  fi
+
+  if [[ ! -f "$slash_cmd" ]]; then
+    echo "Errore: sdd-dry-run.md non trovato — esegui prima SDD-001 di FD-012" >&2
+    return 1
+  fi
+
+  if [[ ! -f "$sdd_file" ]]; then
+    echo "Errore: SDD non trovato: $sdd_file" >&2
+    return 1
+  fi
+
+  local sdd_id
+  sdd_id=$(grep '^id:' "$sdd_file" | head -1 | sed 's/id: *//;s/"//g')
+
+  local system_context
+  system_context=$(_build_system_context)
+
+  local task_prompt="Run /sdd-dry-run on ${sdd_file}. Read the slash command instructions from ${slash_cmd} and follow them exactly."
+
+  # Log directory
+  mkdir -p "$VAULT_DIR/logs"
+  local log_file
+  log_file="$VAULT_DIR/logs/dry-run-${sdd_id}-$(date +%Y-%m-%dT%H:%M:%S).log"
+
+  echo "→ Dry-run: simulazione $sdd_id..."
+
+  local output
+  output=$(claude --append-system-prompt "$system_context" -p "$task_prompt" 2>&1)
+
+  # Save log
+  echo "$output" > "$log_file"
+  echo "  Log: $log_file"
+
+  # Print report
+  echo ""
+  echo "$output"
+
+  # Parse feasibility
+  local feasibility
+  feasibility=$(echo "$output" | grep -i 'Feasibility:' | head -1 | sed 's/.*Feasibility: *//' | tr -d '[:space:]')
+
+  if [[ "$feasibility" == "NO-GO" ]]; then
+    return 1
+  fi
+  return 0
 }
 
 # --- [knowledge] config parsing ---
@@ -818,9 +924,32 @@ cmd_validate() {
 # --- exec ---
 
 cmd_exec() {
-  local sdd_file="${1:?Usage: forgia exec <sdd-file> [--runner=claude|openhands]}"
+  local sdd_file="${1:?Usage: forgia exec <sdd-file> [--runner=claude|openhands] [--dry-run]}"
+  local dry_run
+  dry_run=$(parse_dry_run_arg "$@")
   local runner
   runner=$(resolve_runner "$(parse_runner_arg "$@")")
+
+  # --- dry-run mode ---
+  if [[ "$dry_run" == "true" ]]; then
+    if [[ -n "$(parse_runner_arg "$@")" ]]; then
+      echo "Nota: --runner ignorato durante dry-run (la simulazione usa Claude)"
+    fi
+
+    # Pre-exec validation
+    local validate_script="$ROOT_DIR/modules/runners/validate-sdd.sh"
+    if ! "$validate_script" "$sdd_file"; then
+      echo ""
+      echo "Errore: validazione SDD fallita — correggi prima di proseguire" >&2
+      exit 1
+    fi
+    echo ""
+
+    run_dry_run "$sdd_file"
+    return $?
+  fi
+
+  # --- normal execution ---
   local script
   script=$(get_runner_script "$runner")
 
@@ -869,7 +998,9 @@ cmd_exec() {
 # --- batch ---
 
 cmd_batch() {
-  local fd_id="${1:?Usage: forgia batch <FD-NNN> [--runner=claude|openhands]}"
+  local fd_id="${1:?Usage: forgia batch <FD-NNN> [--runner=claude|openhands] [--dry-run]}"
+  local dry_run
+  dry_run=$(parse_dry_run_arg "$@")
   local runner
   runner=$(resolve_runner "$(parse_runner_arg "$@")")
   local sdd_dir="$VAULT_DIR/sdd/$fd_id"
@@ -894,6 +1025,40 @@ cmd_batch() {
     exit 0
   fi
 
+  # --- dry-run mode ---
+  if [[ "$dry_run" == "true" ]]; then
+    if [[ -n "$(parse_runner_arg "$@")" ]]; then
+      echo "Nota: --runner ignorato durante dry-run (la simulazione usa Claude)"
+    fi
+
+    echo "=== FD Dry Run: $fd_id (${#sdd_files[@]} SDDs) ==="
+    echo ""
+
+    local go_count=0 nogo_count=0
+    for sdd_file in "${sdd_files[@]}"; do
+      local sid
+      sid=$(grep '^id:' "$sdd_file" | head -1 | sed 's/id: *//')
+      echo "--- $sid ---"
+
+      if run_dry_run "$sdd_file"; then
+        go_count=$((go_count + 1))
+      else
+        nogo_count=$((nogo_count + 1))
+      fi
+      echo ""
+    done
+
+    echo "=== Dry Run Summary ==="
+    echo "  GO/CAUTION: $go_count"
+    echo "  NO-GO:      $nogo_count"
+
+    if (( nogo_count > 0 )); then
+      return 1
+    fi
+    return 0
+  fi
+
+  # --- normal execution ---
   echo "=== Forgia Batch Execution ==="
   echo "  FD:     $fd_id"
   echo "  Runner: $runner"

--- a/cmd/forgia/cmd/batch.go
+++ b/cmd/forgia/cmd/batch.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Deepzima/forgia/internal/runner"
+	"github.com/Deepzima/forgia/internal/vault"
+	"github.com/spf13/cobra"
+)
+
+var batchDryRun bool
+var batchRunner string
+
+var batchCmd = &cobra.Command{
+	Use:   "batch <FD-NNN> [--runner=claude|openhands] [--dry-run]",
+	Short: "Execute all pending SDDs for an FD (or simulate with --dry-run)",
+	Long:  "Execute all pending SDDs for the given FD. With --dry-run, runs feasibility simulation on each SDD without modifying any files.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fdID := args[0]
+		sddDir := filepath.Join(".forgia", "sdd", fdID)
+
+		if _, err := os.Stat(sddDir); os.IsNotExist(err) {
+			return fmt.Errorf("nessun SDD trovato per %s in %s", fdID, sddDir)
+		}
+
+		entries, err := os.ReadDir(sddDir)
+		if err != nil {
+			return fmt.Errorf("lettura directory %s: %w", sddDir, err)
+		}
+
+		var pendingSDDs []string
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasPrefix(e.Name(), "SDD-") || !strings.HasSuffix(e.Name(), ".md") {
+				continue
+			}
+			sddPath := filepath.Join(sddDir, e.Name())
+			data, err := os.ReadFile(sddPath)
+			if err != nil {
+				continue
+			}
+			// Simple status check — skip done SDDs
+			if strings.Contains(string(data), "status: done") {
+				continue
+			}
+			pendingSDDs = append(pendingSDDs, sddPath)
+		}
+
+		if len(pendingSDDs) == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "Nessun SDD pendente per", fdID)
+			return nil
+		}
+
+		if batchDryRun {
+			if batchRunner != "" {
+				fmt.Fprintln(cmd.OutOrStdout(), "Nota: --runner ignorato durante dry-run (la simulazione usa Claude)")
+			}
+			return runBatchDryRun(cmd, fdID, pendingSDDs)
+		}
+
+		// Normal execution
+		resolvedRunner := batchRunner
+		if resolvedRunner == "" {
+			resolvedRunner = "claude"
+		}
+
+		r, err := runner.Resolve(resolvedRunner)
+		if err != nil {
+			return err
+		}
+
+		var completed, failed int
+		for _, sddFile := range pendingSDDs {
+			sdd := &vault.SDD{FilePath: sddFile}
+			result, err := r.Execute(cmd.Context(), sdd, runner.ExecOptions{})
+			if err != nil || result.ExitCode != 0 {
+				failed++
+				fmt.Fprintf(cmd.ErrOrStderr(), "Avviso: %s fallito\n", sddFile)
+			} else {
+				completed++
+			}
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Completati: %d, Falliti: %d\n", completed, failed)
+		if failed > 0 {
+			return fmt.Errorf("%d SDD falliti", failed)
+		}
+		return nil
+	},
+}
+
+func runBatchDryRun(cmd *cobra.Command, fdID string, sddFiles []string) error {
+	slashCmd := filepath.Join("modules", "claude-commands", "sdd-dry-run.md")
+	if _, err := os.Stat(slashCmd); os.IsNotExist(err) {
+		return fmt.Errorf("sdd-dry-run.md non trovato — esegui prima SDD-001 di FD-012")
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "=== FD Dry Run: %s (%d SDDs) ===\n\n", fdID, len(sddFiles))
+
+	var nogoCount int
+	for _, sddFile := range sddFiles {
+		sdd := &vault.SDD{FilePath: sddFile}
+		result, err := runner.DryRun(cmd.Context(), sdd, runner.DryRunOptions{
+			SlashCommandPath: slashCmd,
+		})
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Errore dry-run %s: %v\n", sddFile, err)
+			nogoCount++
+			continue
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "--- %s ---\n", filepath.Base(sddFile))
+		fmt.Fprintln(cmd.OutOrStdout(), result.ReportText)
+		fmt.Fprintln(cmd.OutOrStdout())
+
+		if !result.IsGo() {
+			nogoCount++
+		}
+	}
+
+	if nogoCount > 0 {
+		return fmt.Errorf("dry-run: %d SDD con NO-GO", nogoCount)
+	}
+	return nil
+}
+
+func init() {
+	batchCmd.Flags().BoolVar(&batchDryRun, "dry-run", false, "Simula esecuzione senza modificare file")
+	batchCmd.Flags().StringVar(&batchRunner, "runner", "", "Runner da usare (claude|openhands)")
+	rootCmd.AddCommand(batchCmd)
+}

--- a/cmd/forgia/cmd/batch_test.go
+++ b/cmd/forgia/cmd/batch_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestBatchCommand_FlagsRegistered(t *testing.T) {
+	t.Parallel()
+
+	dryRunFlag := batchCmd.Flags().Lookup("dry-run")
+	if dryRunFlag == nil {
+		t.Fatal("expected --dry-run flag to be registered on batch command")
+	}
+	if dryRunFlag.DefValue != "false" {
+		t.Errorf("expected --dry-run default to be false, got %s", dryRunFlag.DefValue)
+	}
+
+	runnerFlag := batchCmd.Flags().Lookup("runner")
+	if runnerFlag == nil {
+		t.Fatal("expected --runner flag to be registered on batch command")
+	}
+	if runnerFlag.DefValue != "" {
+		t.Errorf("expected --runner default to be empty, got %s", runnerFlag.DefValue)
+	}
+}
+
+func TestBatchCommand_RegisteredWithRoot(t *testing.T) {
+	t.Parallel()
+
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "batch" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected batch command to be registered with root")
+	}
+}
+
+func TestBatchCommand_RequiresArgs(t *testing.T) {
+	t.Parallel()
+
+	if batchCmd.Args == nil {
+		t.Fatal("expected batch command to have Args validation")
+	}
+	if err := batchCmd.Args(batchCmd, []string{}); err == nil {
+		t.Error("expected error when no args provided")
+	}
+	if err := batchCmd.Args(batchCmd, []string{"FD-001"}); err != nil {
+		t.Errorf("expected no error with one arg, got %v", err)
+	}
+}

--- a/cmd/forgia/cmd/exec.go
+++ b/cmd/forgia/cmd/exec.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Deepzima/forgia/internal/runner"
+	"github.com/Deepzima/forgia/internal/vault"
+	"github.com/spf13/cobra"
+)
+
+var execDryRun bool
+var execRunner string
+
+var execCmd = &cobra.Command{
+	Use:   "exec <sdd-file> [--runner=claude|openhands] [--dry-run]",
+	Short: "Execute an SDD (or simulate with --dry-run)",
+	Long:  "Execute an SDD using the specified runner. With --dry-run, runs a feasibility simulation via Claude without modifying any files.",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sddFile := args[0]
+
+		if _, err := os.Stat(sddFile); os.IsNotExist(err) {
+			return fmt.Errorf("SDD non trovato: %s", sddFile)
+		}
+
+		if execDryRun {
+			if execRunner != "" {
+				fmt.Fprintln(cmd.OutOrStdout(), "Nota: --runner ignorato durante dry-run (la simulazione usa Claude)")
+			}
+			return runExecDryRun(cmd, sddFile)
+		}
+
+		// Normal execution
+		resolvedRunner := execRunner
+		if resolvedRunner == "" {
+			resolvedRunner = "claude"
+		}
+
+		r, err := runner.Resolve(resolvedRunner)
+		if err != nil {
+			return err
+		}
+
+		sdd := &vault.SDD{FilePath: sddFile}
+		result, err := r.Execute(cmd.Context(), sdd, runner.ExecOptions{})
+		if err != nil {
+			return fmt.Errorf("esecuzione fallita: %w", err)
+		}
+
+		if result.ExitCode != 0 {
+			return fmt.Errorf("runner terminato con codice %d", result.ExitCode)
+		}
+		return nil
+	},
+}
+
+func runExecDryRun(cmd *cobra.Command, sddFile string) error {
+	slashCmd := filepath.Join("modules", "claude-commands", "sdd-dry-run.md")
+	if _, err := os.Stat(slashCmd); os.IsNotExist(err) {
+		return fmt.Errorf("sdd-dry-run.md non trovato — esegui prima SDD-001 di FD-012")
+	}
+
+	sdd := &vault.SDD{FilePath: sddFile}
+
+	result, err := runner.DryRun(cmd.Context(), sdd, runner.DryRunOptions{
+		SlashCommandPath: slashCmd,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), result.ReportText)
+
+	if !result.IsGo() {
+		return fmt.Errorf("dry-run: NO-GO")
+	}
+	return nil
+}
+
+func init() {
+	execCmd.Flags().BoolVar(&execDryRun, "dry-run", false, "Simula esecuzione senza modificare file")
+	execCmd.Flags().StringVar(&execRunner, "runner", "", "Runner da usare (claude|openhands)")
+	rootCmd.AddCommand(execCmd)
+}

--- a/cmd/forgia/cmd/exec_test.go
+++ b/cmd/forgia/cmd/exec_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestExecCommand_FlagsRegistered(t *testing.T) {
+	t.Parallel()
+
+	dryRunFlag := execCmd.Flags().Lookup("dry-run")
+	if dryRunFlag == nil {
+		t.Fatal("expected --dry-run flag to be registered on exec command")
+	}
+	if dryRunFlag.DefValue != "false" {
+		t.Errorf("expected --dry-run default to be false, got %s", dryRunFlag.DefValue)
+	}
+
+	runnerFlag := execCmd.Flags().Lookup("runner")
+	if runnerFlag == nil {
+		t.Fatal("expected --runner flag to be registered on exec command")
+	}
+	if runnerFlag.DefValue != "" {
+		t.Errorf("expected --runner default to be empty, got %s", runnerFlag.DefValue)
+	}
+}
+
+func TestExecCommand_RegisteredWithRoot(t *testing.T) {
+	t.Parallel()
+
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "exec" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected exec command to be registered with root")
+	}
+}
+
+func TestExecCommand_RequiresArgs(t *testing.T) {
+	t.Parallel()
+
+	if execCmd.Args == nil {
+		t.Fatal("expected exec command to have Args validation")
+	}
+	if err := execCmd.Args(execCmd, []string{}); err == nil {
+		t.Error("expected error when no args provided")
+	}
+	if err := execCmd.Args(execCmd, []string{"file.md"}); err != nil {
+		t.Errorf("expected no error with one arg, got %v", err)
+	}
+}

--- a/internal/runner/dryrun.go
+++ b/internal/runner/dryrun.go
@@ -1,0 +1,121 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/Deepzima/forgia/internal/vault"
+)
+
+// Feasibility represents the dry-run verdict.
+type Feasibility string
+
+const (
+	FeasibilityGo      Feasibility = "GO"
+	FeasibilityNoGo    Feasibility = "NO-GO"
+	FeasibilityCaution Feasibility = "CAUTION"
+)
+
+// DryRunOptions configures a dry-run invocation.
+type DryRunOptions struct {
+	SlashCommandPath string // path to sdd-dry-run.md
+	SystemContext    string // constitution + guardrails + principles
+	MaxTurns         int
+}
+
+// DryRunResult holds the parsed dry-run report.
+type DryRunResult struct {
+	Feasibility Feasibility
+	Confidence  string
+	Complexity  string
+	ReportText  string
+	Blockers    []string
+	Warnings    []string
+}
+
+// feasibilityRe matches "Feasibility: GO", "Feasibility: NO-GO", "Feasibility: CAUTION".
+var feasibilityRe = regexp.MustCompile(`(?i)Feasibility:\s*(GO|NO-GO|CAUTION)`)
+
+// DryRun runs a dry-run simulation for the given SDD via Claude CLI.
+func DryRun(ctx context.Context, sdd *vault.SDD, opts DryRunOptions) (*DryRunResult, error) {
+	if _, err := exec.LookPath("claude"); err != nil {
+		return nil, fmt.Errorf("'claude' CLI non trovato: installa Claude Code prima")
+	}
+
+	prompt := fmt.Sprintf(
+		"Run /sdd-dry-run on %s. Read the slash command instructions from %s and follow them exactly.",
+		sdd.FilePath, opts.SlashCommandPath,
+	)
+
+	args := []string{"-p", prompt}
+	if opts.SystemContext != "" {
+		args = append([]string{"--append-system-prompt", opts.SystemContext}, args...)
+	}
+
+	cmd := exec.CommandContext(ctx, "claude", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	output := stdout.String()
+	if err != nil {
+		return nil, fmt.Errorf("claude invocation failed: %w\nstderr: %s", err, stderr.String())
+	}
+
+	result := ParseDryRunReport(output)
+	return result, nil
+}
+
+// ParseDryRunReport extracts structured data from a dry-run report text.
+func ParseDryRunReport(report string) *DryRunResult {
+	result := &DryRunResult{
+		ReportText:  report,
+		Feasibility: FeasibilityNoGo, // default to NO-GO if unparseable
+	}
+
+	if match := feasibilityRe.FindStringSubmatch(report); len(match) > 1 {
+		switch strings.ToUpper(match[1]) {
+		case "GO":
+			result.Feasibility = FeasibilityGo
+		case "NO-GO":
+			result.Feasibility = FeasibilityNoGo
+		case "CAUTION":
+			result.Feasibility = FeasibilityCaution
+		}
+	}
+
+	// Parse confidence
+	confRe := regexp.MustCompile(`(?i)Confidence:\s*(\d+%?)`)
+	if match := confRe.FindStringSubmatch(report); len(match) > 1 {
+		result.Confidence = match[1]
+	}
+
+	// Parse complexity
+	compRe := regexp.MustCompile(`(?i)Complexity:\s*(low|medium|high|very-high)`)
+	if match := compRe.FindStringSubmatch(report); len(match) > 1 {
+		result.Complexity = match[1]
+	}
+
+	// Parse blockers (lines starting with "x " under BLOCKERS)
+	for _, line := range strings.Split(report, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "x ") || strings.HasPrefix(trimmed, "✗ ") {
+			result.Blockers = append(result.Blockers, trimmed)
+		}
+		if strings.HasPrefix(trimmed, "! ") || strings.HasPrefix(trimmed, "⚠ ") {
+			result.Warnings = append(result.Warnings, trimmed)
+		}
+	}
+
+	return result
+}
+
+// IsGo returns true if execution should proceed (GO or CAUTION).
+func (r *DryRunResult) IsGo() bool {
+	return r.Feasibility == FeasibilityGo || r.Feasibility == FeasibilityCaution
+}

--- a/internal/runner/dryrun_test.go
+++ b/internal/runner/dryrun_test.go
@@ -1,0 +1,145 @@
+package runner
+
+import (
+	"testing"
+)
+
+func TestParseDryRunReport_GO(t *testing.T) {
+	t.Parallel()
+
+	report := `=== SDD Dry Run: SDD-001 ===
+
+  Feasibility: GO
+  Confidence: 92%
+  Complexity: low
+
+  BLOCKERS (must fix before execution):
+    (none)
+
+  WARNINGS (review recommended):
+    (none)
+
+  PASS:
+    v [Pass 1] All preconditions met
+    v [Pass 2] No guardrail conflicts
+
+  RECOMMENDATION:
+    Esecuzione sicura, nessun blocco rilevato.
+`
+
+	result := ParseDryRunReport(report)
+
+	if result.Feasibility != FeasibilityGo {
+		t.Errorf("expected GO, got %s", result.Feasibility)
+	}
+	if result.Confidence != "92%" {
+		t.Errorf("expected confidence 92%%, got %s", result.Confidence)
+	}
+	if result.Complexity != "low" {
+		t.Errorf("expected complexity low, got %s", result.Complexity)
+	}
+	if !result.IsGo() {
+		t.Error("expected IsGo() to be true for GO")
+	}
+	if len(result.Blockers) != 0 {
+		t.Errorf("expected 0 blockers, got %d", len(result.Blockers))
+	}
+}
+
+func TestParseDryRunReport_NOGO(t *testing.T) {
+	t.Parallel()
+
+	report := `=== SDD Dry Run: SDD-002 ===
+
+  Feasibility: NO-GO
+  Confidence: 25%
+  Complexity: very-high
+
+  BLOCKERS (must fix before execution):
+    x [Pass 1] Missing context file: internal/auth/handler.go
+    x [Pass 2] Guardrail conflict: SDD requires reading .env
+
+  WARNINGS (review recommended):
+    ! [Pass 4] Cross-SDD dependency on SDD-001 not yet complete
+
+  RECOMMENDATION:
+    Blocchi critici impediscono l'esecuzione. Risolvere prima i blocchi.
+`
+
+	result := ParseDryRunReport(report)
+
+	if result.Feasibility != FeasibilityNoGo {
+		t.Errorf("expected NO-GO, got %s", result.Feasibility)
+	}
+	if result.Confidence != "25%" {
+		t.Errorf("expected confidence 25%%, got %s", result.Confidence)
+	}
+	if result.Complexity != "very-high" {
+		t.Errorf("expected complexity very-high, got %s", result.Complexity)
+	}
+	if result.IsGo() {
+		t.Error("expected IsGo() to be false for NO-GO")
+	}
+	if len(result.Blockers) != 2 {
+		t.Errorf("expected 2 blockers, got %d", len(result.Blockers))
+	}
+	if len(result.Warnings) != 1 {
+		t.Errorf("expected 1 warning, got %d", len(result.Warnings))
+	}
+}
+
+func TestParseDryRunReport_CAUTION(t *testing.T) {
+	t.Parallel()
+
+	report := `=== SDD Dry Run: SDD-003 ===
+
+  Feasibility: CAUTION
+  Confidence: 65%
+  Complexity: high
+
+  BLOCKERS (must fix before execution):
+    (none)
+
+  WARNINGS (review recommended):
+    ! [Pass 3] Ambiguous scope: "configure database" could require .env access
+    ! [Pass 4] Cross-SDD dependency on SDD-001
+    ! [Pass 4] 8 files to modify — high complexity
+
+  RECOMMENDATION:
+    Procedere con cautela. Verificare manualmente le dipendenze.
+`
+
+	result := ParseDryRunReport(report)
+
+	if result.Feasibility != FeasibilityCaution {
+		t.Errorf("expected CAUTION, got %s", result.Feasibility)
+	}
+	if result.Confidence != "65%" {
+		t.Errorf("expected confidence 65%%, got %s", result.Confidence)
+	}
+	if result.Complexity != "high" {
+		t.Errorf("expected complexity high, got %s", result.Complexity)
+	}
+	if !result.IsGo() {
+		t.Error("expected IsGo() to be true for CAUTION")
+	}
+	if len(result.Blockers) != 0 {
+		t.Errorf("expected 0 blockers, got %d", len(result.Blockers))
+	}
+	if len(result.Warnings) != 3 {
+		t.Errorf("expected 3 warnings, got %d", len(result.Warnings))
+	}
+}
+
+func TestParseDryRunReport_UnparseableDefaults(t *testing.T) {
+	t.Parallel()
+
+	result := ParseDryRunReport("no structured output here")
+
+	if result.Feasibility != FeasibilityNoGo {
+		t.Errorf("expected default NO-GO for unparseable report, got %s", result.Feasibility)
+	}
+	if result.IsGo() {
+		t.Error("expected IsGo() to be false for unparseable report")
+	}
+}

--- a/modules/claude-commands/sdd-dry-run.md
+++ b/modules/claude-commands/sdd-dry-run.md
@@ -1,0 +1,209 @@
+Simulate SDD execution without writing any code or files. Produces a structured feasibility report with go/no-go recommendation.
+
+## Instructions
+
+Given SDD file path or FD identifier: $ARGUMENTS
+
+**This is a READ-ONLY operation. Do NOT create, modify, or delete any file.**
+
+### Step 0: Resolve Input
+
+1. If `$ARGUMENTS` matches a file path (contains `/` or ends in `.md`):
+   - Verify the file exists. If not, refuse with: "SDD non trovato: <path>. Verifica il percorso del file."
+   - Set mode = `single-sdd`
+2. If `$ARGUMENTS` matches an FD identifier (e.g., `FD-012`):
+   - Verify `.forgia/fd/` contains a file matching `FD-NNN*.md`. If not, refuse with: "FD-NNN non trovato. Verifica l'identificatore."
+   - Find all SDD files in `.forgia/sdd/FD-NNN/SDD-*.md`. If none, refuse with: "FD-NNN non ha SDD generati. Esegui `/fd-sdd FD-NNN` prima."
+   - Set mode = `fd-aggregate`
+3. If `$ARGUMENTS` is empty or unrecognizable, refuse with: "Uso: /sdd-dry-run <percorso-SDD> oppure /sdd-dry-run FD-NNN"
+
+### Step 1: Load Context
+
+For each SDD to analyze:
+
+1. Read the SDD file — extract all sections: frontmatter, Scope, Interfaces, Constraints, Best Practices, Test Requirements, Acceptance Criteria, Context
+2. Read the parent FD file from `.forgia/fd/FD-NNN*.md`
+3. Read `.forgia/constitution.md`
+4. Read `.forgia/guardrails/deny.toml`
+5. Read all files in `.forgia/dev-guide/` and `.forgia/dev-guide/principles/` and `.forgia/dev-guide/lang/`
+6. Collect the list of context files from the SDD "Context" section (the file paths listed there)
+
+### Step 2: Run 5 Analysis Passes
+
+For each SDD, execute these passes in order. Never silently skip a pass — always report results even if empty.
+
+---
+
+#### Pass 1: Precondition Check
+
+Check:
+- All files listed in SDD "Context" section exist and are readable
+- SDD has all required sections: Scope, Interfaces, Constraints, Test Requirements, Acceptance Criteria
+- Parent FD file exists in `.forgia/fd/`
+
+**Before checking context file existence**: check each file path against the deny patterns in `.forgia/guardrails/deny.toml` `[read]` section. If a context file matches a deny pattern, do NOT attempt to read it — instead flag it as: "cannot verify — blocked by guardrails (matches deny pattern: <pattern>)"
+
+Output: list of blockers (missing files, missing required sections) and warnings (empty sections, unverifiable files)
+
+---
+
+#### Pass 2: Guardrail Conflict Detection
+
+Analyze the SDD Scope, Constraints, and Context sections for operations that would conflict with `deny.toml`:
+
+- **Read conflicts**: Does the SDD scope require reading files that match `[read]` deny patterns? (e.g., `.env` files, `*.pem`, `credentials.json`)
+- **Write conflicts**: Does the SDD scope require creating/modifying files that match `[write]` deny patterns? (e.g., `.forgia/constitution.md`, `.env`)
+- **Execute conflicts**: Does the SDD scope require running commands that match `[execute]` deny patterns?
+
+For each conflict, assess severity:
+- **BLOCKER**: The SDD explicitly requires the denied operation to succeed (e.g., "read .env to extract DB_URL")
+- **WARNING**: The SDD mentions a denied pattern but might work around it (e.g., "configure database" without specifying .env)
+
+Output: list of guardrail conflicts with severity and the specific deny pattern matched
+
+---
+
+#### Pass 3: Step Planning
+
+Simulate the execution by breaking the SDD into ordered steps the agent would take:
+
+1. Analyze the Scope/Deliverables to identify all files to create, modify, or read
+2. Analyze Test Requirements to identify test commands to run
+3. Analyze Acceptance Criteria for verification steps
+4. Order the steps logically (context loading → implementation → testing → verification)
+
+For each step, specify:
+- Action: `[read]`, `[create]`, `[modify]`, `[run]`, `[verify]`
+- Target: file path or command
+- Description: what this step accomplishes
+- Estimated complexity: trivial / simple / moderate / complex
+
+Output: ordered step list
+
+---
+
+#### Pass 4: Scope & Complexity Assessment
+
+Evaluate whether the SDD scope is tractable for a single agent session:
+
+- Count files to create and modify
+- Count interfaces to implement
+- Count test cases required
+- Identify cross-SDD dependencies (references to other SDDs)
+- Check for ambiguities or underspecified requirements in the Scope
+
+Score complexity:
+- **low**: ≤3 files, ≤2 interfaces, clear scope, no cross-SDD deps
+- **medium**: 4-7 files, 3-5 interfaces, minor ambiguities
+- **high**: 8-12 files, 6+ interfaces, cross-SDD deps, some ambiguities
+- **very-high**: 13+ files, complex interfaces, significant ambiguities, heavy cross-SDD deps
+
+Output: complexity score with justification
+
+---
+
+#### Pass 5: Cost Estimation
+
+Estimate tokens for actual execution:
+
+- **Input tokens**: Sum approximate sizes of all context files + SDD + constitution + dev-guide files. Use file sizes as proxy (roughly 1 token per 4 characters for English/code).
+- **Output tokens**: Estimate from scope complexity — number of files to create × estimated lines per file, plus test files, plus Work Log.
+- **Duration**: Estimate based on complexity score:
+  - low: 5-15 min
+  - medium: 15-30 min
+  - high: 30-60 min
+  - very-high: 60-120+ min
+
+Include disclaimer: "Le stime sono approssimative e dipendono dalla complessità effettiva dell'implementazione."
+
+Output: token estimates (input + output), duration range, file counts
+
+---
+
+### Step 3: Determine Feasibility
+
+Apply these deterministic rules:
+
+- **GO**: no blockers, 0-2 warnings, complexity low or medium
+- **CAUTION**: no blockers but 3+ warnings, OR complexity high
+- **NO-GO**: any blocker present, OR guardrail conflict on required operation (BLOCKER severity), OR complexity very-high with unresolved ambiguities
+
+Set confidence percentage:
+- GO with 0 warnings: 90-95%
+- GO with 1-2 warnings: 80-90%
+- CAUTION: 50-75%
+- NO-GO: 10-40%
+
+### Step 4: Produce Report
+
+#### Single SDD Report
+
+```
+=== SDD Dry Run: SDD-NNN ===
+
+  Feasibility: GO | NO-GO | CAUTION
+  Confidence: NN%
+  Complexity: low | medium | high | very-high
+
+  BLOCKERS (must fix before execution):
+    x [Pass #N] description — file/field affected
+
+  WARNINGS (review recommended):
+    ! [Pass #N] description — file/field affected
+
+  PASS:
+    v [Pass #N] description
+
+  PLANNED STEPS:
+    1. [read]   path/to/file — context loading
+    2. [create] path/to/new/file — implementation
+    3. [modify] path/to/existing — add interface
+    4. [run]    test command — verification
+    ...
+
+  ESTIMATES:
+    Input tokens:  ~NNk (context files + SDD + rules)
+    Output tokens: ~NNk (code + tests + Work Log)
+    Duration:      NN-NN min
+    Files:         N to create, N to modify
+
+  RECOMMENDATION:
+    Brief explanation of go/no-go decision and suggested actions.
+
+  (Le stime sono approssimative e dipendono dalla complessità effettiva dell'implementazione.)
+```
+
+#### FD Aggregate Report (mode = `fd-aggregate`)
+
+When given an FD identifier, wrap individual SDD reports in an aggregate:
+
+```
+=== FD Dry Run: FD-NNN (N SDDs) ===
+
+  Overall Feasibility: GO | NO-GO | CAUTION
+  Total Estimates: ~NNk input, ~NNk output, NN-NN min
+
+  --- SDD-001: title ---
+  [individual report as above]
+
+  --- SDD-002: title ---
+  [individual report as above]
+
+  CROSS-SDD ISSUES:
+    x Interface mismatch between SDD-001 and SDD-003: ...
+    ! Overlapping file modifications: SDD-002 and SDD-004 both modify ...
+```
+
+For the aggregate:
+- **Overall Feasibility**: worst-case of all individual SDDs (any NO-GO → overall NO-GO; any CAUTION → overall CAUTION)
+- **Cross-SDD checks**: compare Interfaces sections across SDDs for mismatches; check if multiple SDDs modify the same files; check for dependency ordering issues
+- **Total Estimates**: sum of individual estimates
+
+## Important
+
+- **READ-ONLY**: This skill must NEVER create, modify, or delete any file. It is a pure analysis tool. Do not offer to fix any issues found — only report them.
+- **Respect deny.toml**: If a context file matches a deny pattern from `.forgia/guardrails/deny.toml`, do NOT read it. Flag it as "cannot verify — blocked by guardrails" instead.
+- **Never silently skip a pass**: Always report results for all 5 passes, even if a pass finds nothing.
+- **Deterministic feasibility**: Same input must always produce the same GO/NO-GO/CAUTION decision based on the rules above.
+- **Actionable output**: Every blocker and warning must specify the exact file and field affected, so the user knows exactly what to fix.
+- **Italian for user-facing messages**: Error messages and recommendation text in Italian. Report structure labels in English for consistency with other Forgia reports.


### PR DESCRIPTION
## Summary

Closes #23

Adds the ability to simulate SDD execution before committing to it — catching missing context files, guardrail conflicts, and scope issues without spending tokens on actual execution.

## What's included

### 1. `/sdd-dry-run` slash command (`modules/claude-commands/sdd-dry-run.md`)

A new read-only Claude Code slash command that simulates SDD execution through 5 analysis passes:

| Pass | What it checks |
|------|---------------|
| **Precondition check** | All context files exist, SDD has required sections, parent FD exists |
| **Guardrail conflict detection** | SDD scope doesn't require operations blocked by `deny.toml` (reading secrets, writing protected files, running denied commands) |
| **Step planning** | Breaks the SDD into ordered execution steps: read → create → modify → test → verify |
| **Scope & complexity assessment** | Rates complexity (low/medium/high/very-high) based on file count, interfaces, cross-SDD dependencies, ambiguities |
| **Cost estimation** | Estimates input/output tokens and execution duration |

Produces a structured feasibility report with a deterministic **GO / NO-GO / CAUTION** verdict:
- **GO**: no blockers, ≤2 warnings, manageable complexity
- **CAUTION**: no blockers but 3+ warnings, or high complexity
- **NO-GO**: any blocker, guardrail conflict on required operation, or very-high complexity with ambiguities

Supports two modes:
- **Single SDD**: `/sdd-dry-run .forgia/sdd/FD-NNN/SDD-001.md`
- **Full FD (aggregate)**: `/sdd-dry-run FD-NNN` — runs all SDDs, adds cross-SDD checks (interface mismatches, overlapping file modifications)

### 2. `--dry-run` flag on `forgia exec` and `forgia batch`

#### Bash CLI (`bin/forgia`)

- New `--dry-run` flag for both `exec` and `batch` commands
- `parse_dry_run_arg()` / `strip_dry_run_arg()` helpers following the existing `parse_runner_arg()` pattern
- `_build_system_context()` extracted as shared helper (constitution + guardrails + principles — same logic as `claude.sh` but reusable)
- `run_dry_run()` invokes Claude with the `/sdd-dry-run` prompt, parses feasibility, logs report to `.forgia/logs/dry-run-*.log`
- `--dry-run` + `--runner` prints a note that runner is ignored (simulation always uses Claude)
- Exit code: 0 = GO/CAUTION, 1 = NO-GO
- Usage text updated

#### Go CLI (`cmd/forgia`)

- `cmd/forgia/cmd/exec.go` — new cobra command with `--dry-run` and `--runner` flags
- `cmd/forgia/cmd/batch.go` — new cobra command with `--dry-run` and `--runner` flags
- `internal/runner/dryrun.go` — `DryRun()` function + `ParseDryRunReport()` with structured result parsing (`Feasibility`, `Confidence`, `Complexity`, `Blockers`, `Warnings`). Defaults to NO-GO for unparseable reports (fail-closed).

### Behavior

```
forgia exec .forgia/sdd/FD-012/SDD-001.md --dry-run
# → Runs simulation, prints feasibility report, exits. No files modified.

forgia batch FD-012 --dry-run
# → Simulates all pending SDDs, prints aggregate report, exits.

forgia exec .forgia/sdd/FD-012/SDD-001.md
# → Normal execution (unchanged behavior)
```

## Files changed

| File | Change |
|------|--------|
| `modules/claude-commands/sdd-dry-run.md` | New slash command (209 lines) |
| `bin/forgia` | `--dry-run` flag, helpers, usage update |
| `cmd/forgia/cmd/exec.go` | New cobra `exec` command |
| `cmd/forgia/cmd/batch.go` | New cobra `batch` command |
| `internal/runner/dryrun.go` | Dry-run runner helper + report parser |
| `cmd/forgia/cmd/exec_test.go` | Flag registration + arg validation tests |
| `cmd/forgia/cmd/batch_test.go` | Flag registration + arg validation tests |
| `internal/runner/dryrun_test.go` | Report parsing tests (GO, NO-GO, CAUTION, unparseable) |

## Test plan

- [x] `go test ./internal/runner/...` — DryRun report parsing (GO, NO-GO, CAUTION, unparseable default)
- [x] `go test ./cmd/forgia/cmd/...` — exec/batch flag registration and arg validation
- [x] `shellcheck bin/forgia` — clean
- [x] `./tests/e2e.sh` — all 68 existing tests pass (no regressions)
- [x] Manual: `/sdd-dry-run` on a completed SDD produces full 5-pass report
- [x] Manual: `forgia exec <sdd> --dry-run` prints report and exits without modifying files
- [x] Manual: `forgia batch <FD> --dry-run` aggregates reports for all pending SDDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)