### PR TITLE
feat(#63): port Bash CLI to Go binary — 9 commands, embedded templates, skill system

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,49 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+dolt-access.lock
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --claim
+bd update <issue-id> --status done
+
+# Sync with Dolt remote
+bd dolt push
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in Dolt database with version control and branching
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Always in sync**: Auto-syncs with your commits
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Automatic sync with git commits
+- Branch-aware issue tracking
+- Dolt-native three-way merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,54 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: JSONL-only, no Dolt database
+# When true, bd will use .beads/issues.jsonl as the source of truth
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Feedback title formatting for mutating commands (create/update/close/dep/edit)
+# 0 = hide titles, N > 0 = truncate to N characters
+# output:
+#   title-length: 255
+
+# Default actor for audit trails (overridden by BD_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct database
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# JSONL backup (periodic export for off-machine recovery)
+# Auto-enabled when a git remote exists. Override explicitly:
+# backup:
+#   enabled: false     # Disable auto-backup entirely
+#   interval: 15m      # Minimum time between auto-exports
+#   git-push: false    # Disable git push (export locally only)
+#   git-repo: ""       # Separate git repo for backups (default: project repo)
+
+# Integration settings (access with 'bd config get/set')
+# These are stored in the database, not in this file:
+# - jira.url
+# - jira.project
+# - linear.url
+# - linear.api-key
+# - github.org
+# - github.repo

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.60.0 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-merge "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.60.0 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.60.0 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-push "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.60.0 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'prepare-commit-msg'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.60.0 ---

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_database": "forgia",
+  "project_id": "a1deb847-986e-44ae-a77d-84a39b1da44f"
+}

--- a/.forgia/.gitignore
+++ b/.forgia/.gitignore
@@ -1,0 +1,7 @@
+# Local execution artifacts (not shared)
+logs/
+run/
+*.pid
+
+# Beads database (local, not portable)
+.beads/

--- a/.forgia/_dashboard.md
+++ b/.forgia/_dashboard.md
@@ -1,0 +1,92 @@
+# Forgia Dashboard
+
+---
+
+## Feature Designs
+
+### In Progress / In Corso
+
+```dataview
+TABLE WITHOUT ID
+  id AS "ID",
+  title AS "Title",
+  priority AS "P",
+  status AS "Status",
+  assignee AS "Assignee"
+FROM "fd"
+WHERE status = "in-progress" OR status = "design"
+SORT priority DESC, created ASC
+```
+
+### In Review / In Revisione
+
+```dataview
+LIST WITHOUT ID id + " — " + title
+FROM "fd"
+WHERE status = "review" OR (reviewed = false AND status != "planned")
+SORT created ASC
+```
+
+### Planned / Pianificati
+
+```dataview
+TABLE WITHOUT ID id AS "ID", title AS "Title", priority AS "P", effort AS "Effort"
+FROM "fd"
+WHERE status = "planned"
+SORT priority DESC
+```
+
+---
+
+## Execution Specs (SDD)
+
+### Active / Attivi
+
+```dataview
+TABLE WITHOUT ID
+  id AS "SDD",
+  fd AS "FD",
+  status AS "Status",
+  agent AS "Agent",
+  title AS "Title"
+FROM "sdd"
+WHERE status != "done" AND status != "failed"
+SORT fd ASC, id ASC
+```
+
+### Completed / Completati
+
+```dataview
+TABLE WITHOUT ID id AS "SDD", fd AS "FD", title AS "Title"
+FROM "sdd"
+WHERE status = "done"
+SORT file.mtime DESC
+LIMIT 10
+```
+
+---
+
+## Active Tasks / Task Attive
+
+```dataview
+TABLE WITHOUT ID
+  id AS "ID",
+  priority AS "P",
+  owner AS "Owner",
+  title AS "Task"
+FROM "ops/active"
+WHERE status = "active"
+SORT priority ASC, due ASC
+```
+
+---
+
+## Stats / Statistiche
+
+```dataview
+TABLE WITHOUT ID status AS "Status", length(rows) AS "Count"
+FROM "fd" OR "sdd"
+WHERE !contains(file.name, "_")
+GROUP BY status
+SORT status ASC
+```

--- a/.forgia/config.toml
+++ b/.forgia/config.toml
@@ -1,0 +1,58 @@
+# Forgia Configuration
+# This file controls how SDDs are executed.
+
+[runner]
+# Default runner for SDD execution: "claude" or "openhands"
+default = "claude"
+
+[runner.claude]
+# Claude Code runner — uses your Max subscription (no API key needed)
+# Sub-agents run in isolated git worktrees
+worktree = true
+# Auto-approve tool calls (set to false for interactive mode)
+auto_approve = true
+# Max turns before stopping (0 = unlimited)
+max_turns = 200
+
+[runner.openhands]
+# OpenHands runner — uses API keys, runs in Docker containers
+image = "ghcr.io/all-hands-ai/openhands:latest"
+# LLM model for OpenHands agent
+# Examples:
+#   "anthropic/claude-sonnet-4-20250514"   (Anthropic API)
+#   "openai/gpt-4o"                        (OpenAI API)
+#   "ollama/llama3.1:70b"                  (Local via Ollama/Exo)
+model = "anthropic/claude-sonnet-4-20250514"
+# Workspace mount (where the repo is mounted inside the container)
+workspace_mount = "/opt/workspace"
+# Max iterations before stopping
+max_iterations = 100
+# Port for OpenHands UI (0 = no UI, headless)
+ui_port = 3000
+
+[beads]
+# Beads (bd) task tracker integration
+enabled = true
+# Auto-create bd epic + tasks when SDDs are generated
+auto_create_tasks = true
+# Auto-close bd tasks when SDD execution completes
+auto_close_tasks = true
+# Use bd ready for dependency-aware batch execution
+dependency_aware_batch = true
+
+[knowledge]
+# Knowledge layer — codebase-memory-mcp integration (Tier 3)
+# Provider binary name (must be in PATH)
+provider = "codebase-memory-mcp"
+# Auto-index the codebase during `forgia init`
+auto_index = true
+# Reserved for future use — enable file watching for live re-indexing
+auto_sync = true
+
+[watcher]
+# Auto-execute SDDs when they appear in the vault
+enabled = false
+# Path to watch (relative to project root)
+path = ".forgia/sdd"
+# Debounce delay in seconds (wait before launching after file change)
+debounce = 5

--- a/.forgia/constitution.md
+++ b/.forgia/constitution.md
@@ -1,0 +1,50 @@
+# Constitution
+
+> EN: Immutable project rules. Every FD, SDD, and implementation must respect these principles.
+> IT: Regole immutabili del progetto. Ogni FD, SDD e implementazione deve rispettare questi principi.
+>
+> Inspired by [GitHub Spec Kit](https://github.com/github/spec-kit).
+
+---
+
+## Principles / Principi
+
+1. **Spec first, code second** — no implementation without an approved FD and generated SDD
+2. **Fail-closed** — if a gate fails (review, verify), work stops until resolved
+3. **Work Log is mandatory** — every SDD must have a completed Work Log before closing
+4. **Constitution is immutable** — changes require explicit team consensus and versioning
+5. **Agent isolation** — each SDD executes in its own worktree or container
+
+## Code Standards
+
+- Tests are required for every SDD (type and coverage defined in the SDD itself)
+- No silent fallbacks — errors must be explicit
+- No backwards-compatibility hacks — if deprecated, remove it
+
+## Security
+
+- **Guardrails are absolute** — `.forgia/guardrails/deny.toml` defines what agents CANNOT do
+- No hardcoded secrets — use environment variables or secret managers
+- No command injection — validate and sanitize all external input
+- Validate at system boundaries (user input, external APIs), trust internal code
+- Agents must use placeholders for secret values, never real credentials
+- If an agent encounters a file that might contain secrets, it must SKIP and warn
+- The deny list is fail-closed: if a pattern matches, the action is blocked
+
+## Commit Conventions
+
+- Format: `feat|fix|docs|refactor|test: description`
+- FD-linked: `feat(FD-NNN): description`
+- AI-generated commits include `Co-Authored-By`
+
+## Communication
+
+- Italian for documentation and communication
+- English for code, variable names, comments in code
+
+---
+
+> EN: Edit this file to match your project's specific rules.
+> IT: Modifica questo file con le regole specifiche del tuo progetto.
+>
+> This is loaded by `/fd-review` and `/fd-verify` as the baseline for all checks.

--- a/.forgia/dev-guide/coding-conventions.md
+++ b/.forgia/dev-guide/coding-conventions.md
@@ -1,0 +1,49 @@
+# Coding Conventions
+
+Rules for AI agents and developers. Loaded automatically by `/fd-review` and `/fd-verify`.
+
+## General Principles
+
+1. **No silent fallback**: never use default values that hide errors
+2. **DRY**: extract helpers for repeated code (but don't abstract prematurely)
+3. **No backwards compatibility hacks**: if deprecated, remove it
+4. **Explicit errors**: use appropriate return codes and error types
+5. **Validate at boundaries**: user input, external APIs, config files
+
+## Language-Specific
+
+### Rust
+- `anyhow` for applications, `thiserror` for libraries
+- Async: tokio runtime
+- Config: TOML files, env vars for secrets
+
+### Python
+- Type hints on all public functions
+- `uv` for dependency management
+- Async: asyncio
+- Config: TOML or env vars
+
+### TypeScript
+- Strict mode enabled
+- Prefer `const` over `let`
+- Use explicit return types on exported functions
+
+### Shell (Bash/Zsh)
+- `set -euo pipefail` in every script
+- Local variables with `local`
+- Usage strings on stderr
+- Tool check: `command -v tool >/dev/null 2>&1`
+
+## Testing
+
+- Every SDD defines its own test requirements
+- Minimum: unit tests for business logic, integration tests for boundaries
+- No mocking of databases in integration tests (use real instances)
+- Test names describe the behavior, not the method
+
+## Security
+
+- No hardcoded secrets (use env vars or secret managers)
+- No command injection (quote all variables in shell)
+- No SQL injection (use parameterized queries)
+- Validate and sanitize at system boundaries

--- a/.forgia/dev-guide/commit-conventions.md
+++ b/.forgia/dev-guide/commit-conventions.md
@@ -1,0 +1,61 @@
+# Commit Conventions
+
+## Format
+
+```
+type(scope): description
+
+[optional body]
+
+[optional footer]
+```
+
+## Types
+
+| Type | When |
+|------|------|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test` | Adding or updating tests |
+| `chore` | Build process, CI, tooling |
+
+## Scope
+
+- FD-linked: `feat(FD-001): add user authentication`
+- SDD-linked: `feat(FD-001/SDD-002): implement login endpoint`
+- General: `fix: resolve race condition in cache`
+
+## Rules
+
+1. Subject line under 72 characters
+2. Use imperative mood: "add", not "added" or "adds"
+3. No period at the end of the subject
+4. Body explains WHY, not WHAT (the diff shows what)
+5. AI-generated commits include footer:
+   ```
+   Co-Authored-By: Claude <noreply@anthropic.com>
+   ```
+6. Reference issues when applicable:
+   ```
+   Closes #123
+   ```
+
+## Examples
+
+```
+feat(FD-001): add JWT authentication middleware
+
+Implements HMAC-based token validation for the gateway proxy.
+Chose HMAC over RSA because this is a single-issuer system.
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+```
+fix(FD-002/SDD-001): handle timeout in venue bridge
+
+The paper bridge was silently swallowing connection timeouts,
+causing the agent loop to hang. Now raises BridgeTimeoutError.
+```

--- a/.forgia/dev-guide/lang/go.md
+++ b/.forgia/dev-guide/lang/go.md
@@ -1,0 +1,107 @@
+# Go Conventions
+
+> Auto-loaded when `go.mod` is detected in the project.
+
+## Project Structure
+
+- Follow [Standard Go Project Layout](https://github.com/golang-standards/project-layout)
+- `cmd/<app>/main.go` for entry points
+- `internal/` for private packages (not importable by other modules)
+- `pkg/` for public packages (if publishing a library)
+- Tests: colocated `*_test.go` files
+
+## Error Handling
+
+- Always check errors — never ignore with `_`
+- Wrap errors with context: `fmt.Errorf("failed to connect: %w", err)`
+- Use sentinel errors for expected conditions: `var ErrNotFound = errors.New("not found")`
+- Use custom error types for complex errors
+- Errors are values, not exceptions — handle them at every level
+
+```go
+func LoadConfig(path string) (*Config, error) {
+    data, err := os.ReadFile(path)
+    if err != nil {
+        return nil, fmt.Errorf("load config %s: %w", path, err)
+    }
+    var cfg Config
+    if err := toml.Unmarshal(data, &cfg); err != nil {
+        return nil, fmt.Errorf("parse config %s: %w", path, err)
+    }
+    return &cfg, nil
+}
+```
+
+## Concurrency
+
+- Use goroutines for concurrent work
+- Communicate via channels, not shared memory
+- Use `context.Context` for cancellation and timeouts
+- Use `sync.WaitGroup` for fan-out/fan-in
+- Use `errgroup.Group` for goroutines that can fail
+
+## Interfaces
+
+- Keep interfaces small (1-3 methods)
+- Define interfaces where they're consumed, not where they're implemented
+- Use `io.Reader`, `io.Writer`, `fmt.Stringer` as examples of good interfaces
+- Accept interfaces, return structs
+
+```go
+// Good — small, defined at consumer
+type Authenticator interface {
+    Authenticate(ctx context.Context, token string) (*Agent, error)
+}
+
+// Bad — too large, defined at implementation
+type UserService interface {
+    Create(ctx context.Context, u User) error
+    Get(ctx context.Context, id string) (*User, error)
+    Update(ctx context.Context, u User) error
+    Delete(ctx context.Context, id string) error
+    List(ctx context.Context, filter Filter) ([]User, error)
+    // ...20 more methods
+}
+```
+
+## Dependencies
+
+- HTTP: `net/http` (stdlib) or `chi` router
+- CLI: `cobra` + `viper`
+- Database: `sqlx` or `pgx`
+- Config: `viper` or `envconfig`
+- Logging: `slog` (stdlib, Go 1.21+)
+- Testing: stdlib `testing` + `testify`
+
+## Style
+
+- Formatter: `gofmt` or `goimports` — mandatory, no exceptions
+- Linter: `golangci-lint` with default + `errcheck`, `govet`, `staticcheck`
+- Naming: `camelCase` unexported, `PascalCase` exported, short variable names in small scopes
+- Package names: short, lowercase, no underscores (e.g., `auth`, `store`, `gateway`)
+- Comments: `// FunctionName does X` for exported functions (godoc style)
+
+## Testing
+
+- Table-driven tests for multiple cases
+- `testify/assert` for assertions (or stdlib)
+- `httptest.NewServer` for HTTP integration tests
+- Use `t.Parallel()` for independent tests
+- Test names: `Test<Function>_<scenario>`
+
+```go
+func TestAuthenticate_ExpiredToken(t *testing.T) {
+    t.Parallel()
+    auth := NewAuthenticator(testKey)
+    _, err := auth.Authenticate(ctx, expiredToken)
+    assert.ErrorIs(t, err, ErrTokenExpired)
+}
+```
+
+## What NOT to Do
+
+- Don't use `init()` functions — explicit initialization is clearer
+- Don't use package-level variables for state — use dependency injection
+- Don't use `panic` for error handling — return errors
+- Don't use `interface{}` / `any` when a concrete type works
+- Don't create packages named `util`, `common`, `helper` — name by purpose

--- a/.forgia/dev-guide/lang/shell.md
+++ b/.forgia/dev-guide/lang/shell.md
@@ -1,0 +1,106 @@
+# Shell Conventions (Bash/Zsh)
+
+> Auto-loaded when `.sh` or `.zsh` files are detected, or when the project uses shell scripts.
+
+## Script Header
+
+Every script must start with:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+```
+
+- `set -e`: exit on error
+- `set -u`: error on undefined variables
+- `set -o pipefail`: catch errors in pipes
+
+## Variables
+
+- Use `local` for function-scoped variables
+- Quote all variable expansions: `"$var"` not `$var`
+- Use `${var:-default}` for optional variables with defaults
+- Use `${var:?error message}` for required variables
+- Constants in `UPPER_CASE`, locals in `lower_case`
+
+```bash
+readonly CONFIG_DIR="/etc/myapp"
+local output_file="${1:?Usage: process <file>}"
+```
+
+## Functions
+
+- Naming: `prefix_action()` (e.g., `fd_new`, `ops_status`, `oh_start`)
+- Always use `local` for variables inside functions
+- Usage strings on stderr: `echo "Usage: ..." >&2`
+- Return codes: 0=success, 1=logic error, 64=usage error, 127=tool missing
+
+```bash
+cmd_install() {
+  local module="${1:?Module name required}"
+  local module_path="$MODULE_DIR/$module"
+
+  if [[ ! -d "$module_path" ]]; then
+    echo "Unknown module: $module" >&2
+    return 1
+  fi
+
+  echo "Installing $module"
+  "$module_path/install.sh"
+}
+```
+
+## Conditionals
+
+- Use `[[ ]]` not `[ ]` (bash/zsh extended test)
+- Use `(( ))` for arithmetic
+- String comparison: `==` inside `[[ ]]`
+- File tests: `-f` (file), `-d` (dir), `-x` (executable), `-e` (exists)
+- Command check: `command -v tool >/dev/null 2>&1`
+
+## Loops & Iteration
+
+- Use `for f in dir/*.md` over `find` when possible
+- Guard globs: `[[ -f "$f" ]] || continue`
+- Use `while IFS= read -r line` for reading files
+- Avoid subshell loops when modifying variables
+
+## Platform Detection
+
+```bash
+case "$(uname -s)" in
+  Darwin) platform="macos" ;;
+  Linux)  platform="linux" ;;
+  *)      echo "Unsupported platform" >&2; exit 1 ;;
+esac
+```
+
+## Dependencies
+
+- Prefer coreutils commands over external tools
+- Use `command -v` to check tool availability before using
+- Install via package manager when needed (brew, apt)
+
+## Style
+
+- Linter: `shellcheck` — mandatory
+- Indent: 2 spaces
+- Max line length: 100 characters (break with `\`)
+- Heredocs: use `<<'EOF'` (single-quoted) to prevent expansion when not needed
+- No trailing whitespace
+
+## Testing
+
+- Syntax check: `bash -n script.sh`
+- Lint: `shellcheck script.sh`
+- Test manually in a clean environment (container or fresh shell)
+- For complex scripts: use `bats` testing framework
+
+## What NOT to Do
+
+- Don't use `eval` — it's almost always a security risk
+- Don't parse `ls` output — use globs
+- Don't use backticks `` `cmd` `` — use `$(cmd)`
+- Don't use `echo` for error messages — use `echo ... >&2`
+- Don't rely on `$?` across multiple commands — check immediately
+- Don't use `cd` without `|| exit` or in a subshell `(cd dir && ...)`

--- a/.forgia/dev-guide/principles/clean-code.md
+++ b/.forgia/dev-guide/principles/clean-code.md
@@ -1,0 +1,80 @@
+# Clean Code Principles
+
+> Always loaded. Language-agnostic rules that apply to every codebase.
+
+## Naming
+
+- Names reveal intent — if you need a comment to explain a variable name, the name is wrong
+- Avoid abbreviations unless universally understood (`ctx`, `err`, `db` are OK; `proc_mgr_svc` is not)
+- Functions: verb + noun (`calculateTotal`, `parse_config`, `send_notification`)
+- Booleans: `is_`, `has_`, `can_`, `should_` prefix (`is_active`, `has_permission`)
+- Collections: plural (`users`, `pending_orders`), single item: singular (`user`, `order`)
+- Constants: describe the meaning, not the value (`MAX_RETRY_ATTEMPTS = 3`, not `THREE = 3`)
+
+## Functions
+
+- Do ONE thing — if you can describe it with "and", split it
+- Max 3 parameters (prefer structs/objects for more)
+- No side effects hidden in the name — `getUser()` should not modify state
+- Prefer pure functions where possible (same input → same output, no mutation)
+- Early return > deeply nested if/else
+
+```
+# Bad
+def process(data):
+    if data:
+        if data.is_valid():
+            if data.has_permission():
+                return do_work(data)
+            else:
+                raise PermissionError()
+        else:
+            raise ValidationError()
+    else:
+        raise ValueError()
+
+# Good
+def process(data):
+    if not data:
+        raise ValueError()
+    if not data.is_valid():
+        raise ValidationError()
+    if not data.has_permission():
+        raise PermissionError()
+    return do_work(data)
+```
+
+## Comments
+
+- Code tells HOW, comments tell WHY
+- Don't comment WHAT the code does — make the code readable instead
+- Acceptable comments: business logic reasoning, regulatory requirements, non-obvious performance decisions, workarounds with links to issues
+- Never commit commented-out code — that's what git is for
+
+## Error Handling
+
+- Fail fast, fail loud — don't silently swallow errors
+- Handle errors at the right level (not too deep, not too shallow)
+- Error messages must include: what failed, why, and what the user/dev can do about it
+- Never use exceptions for control flow
+
+## DRY vs WET
+
+- Rule of Three: duplicate once is fine, duplicate twice means extract
+- Don't DRY prematurely — two similar things might diverge later
+- Prefer clear duplication over wrong abstraction
+- When you DO abstract, the abstraction must be easier to understand than the duplication
+
+## Boy Scout Rule
+
+- Leave code better than you found it — but only if you're already touching it
+- Don't refactor code you're not working on (scope creep)
+- Small improvements compound: better names, simplified conditions, removed dead code
+
+## Testing (Universal)
+
+- Test behavior, not implementation
+- One assert per test (logical assert, not physical)
+- Test names describe the scenario: `test_<what>_<when>_<then>`
+- Tests are documentation — reading them should explain what the code does
+- Don't test the framework, test YOUR code

--- a/.forgia/dev-guide/principles/design-patterns.md
+++ b/.forgia/dev-guide/principles/design-patterns.md
@@ -1,0 +1,140 @@
+# Design Patterns Reference
+
+> Always loaded. Use the RIGHT pattern for the problem — don't force patterns where they don't fit.
+
+## When to Use Patterns
+
+Patterns are **solutions to recurring problems**, not goals. Apply them when:
+- You recognize the problem they solve
+- The alternative is demonstrably worse
+- The pattern simplifies, not complicates
+
+**Never use a pattern just because you can.** Simple code > clever code.
+
+---
+
+## Creational
+
+### Builder
+**When**: Object has many optional parameters, or construction is multi-step.
+```
+config = ConfigBuilder().port(8080).tls(true).timeout(30).build()
+```
+**Not when**: Object has 1-3 required fields — use a constructor.
+
+### Factory
+**When**: The concrete type depends on runtime data (config, feature flags, user input).
+```
+def create_bridge(venue: str) -> Bridge:
+    match venue:
+        case "binance": return BinanceBridge()
+        case "paper":   return PaperBridge()
+```
+**Not when**: You always know which type you need at compile time.
+
+### Singleton
+**Almost never.** Use dependency injection instead. Singletons hide dependencies and make testing hard.
+**Exception**: Logger, connection pool — things with true process-wide identity.
+
+---
+
+## Structural
+
+### Adapter
+**When**: You need to make an existing interface work with code expecting a different interface.
+```
+// Your code expects Authenticator, but LDAP library has its own API
+struct LdapAdapter { client: LdapClient }
+impl Authenticator for LdapAdapter { ... }
+```
+
+### Facade
+**When**: A subsystem has many moving parts and callers don't need the complexity.
+```
+// Instead of: connect(), authenticate(), query(), parse(), close()
+result = database.execute("SELECT ...")
+```
+
+### Decorator / Middleware
+**When**: Adding behavior (logging, auth, caching, retry) without modifying existing code.
+```
+app.use(auth_middleware)
+app.use(logging_middleware)
+app.use(rate_limit_middleware)
+```
+
+---
+
+## Behavioral
+
+### Strategy
+**When**: You need to swap algorithms at runtime.
+```
+class TradingEngine:
+    def __init__(self, strategy: Strategy):
+        self.strategy = strategy
+
+    def evaluate(self, candles):
+        return self.strategy.signal(candles)
+```
+
+### Observer / Event
+**When**: Multiple components need to react to state changes without coupling.
+```
+event_bus.emit("position_opened", position)
+// Multiple listeners: logger, risk_manager, notifier
+```
+**Not when**: There's only one listener — direct call is simpler.
+
+### State Machine
+**When**: An entity has distinct states with defined transitions.
+```
+Draft → Submitted → Approved → InProgress → Done
+                  ↘ Rejected → Draft
+```
+**Use for**: Order lifecycle, FD status, connection state, deployment pipeline.
+
+### Command
+**When**: You need to queue, undo, or replay operations.
+```
+commands = [OpenPosition(...), SetStopLoss(...), ClosePosition(...)]
+for cmd in commands:
+    cmd.execute()
+```
+
+---
+
+## Architecture Patterns
+
+### Repository
+**When**: Separating data access from business logic.
+```
+trait UserRepository {
+    fn find_by_id(&self, id: &str) -> Result<User>;
+    fn save(&self, user: &User) -> Result<()>;
+}
+// Implementations: PostgresUserRepo, InMemoryUserRepo (for tests)
+```
+
+### CQRS (Command Query Responsibility Segregation)
+**When**: Read and write models have different shapes or performance needs.
+- **Command**: write, validate, enforce rules
+- **Query**: read, optimize for display, denormalize if needed
+**Not when**: Simple CRUD — CQRS adds complexity.
+
+### Event Sourcing
+**When**: You need complete audit trail, or the "how we got here" matters as much as "where we are".
+**Not when**: Simple state management. Event sourcing is powerful but complex.
+
+---
+
+## Anti-Patterns to Avoid
+
+| Anti-Pattern | Problem | Instead |
+|---|---|---|
+| God Object | One class does everything | Single Responsibility |
+| Premature Abstraction | Abstract before you understand the problem | Wait for Rule of Three |
+| Golden Hammer | Using one pattern/tool for everything | Choose the right tool |
+| Cargo Cult | Using patterns without understanding why | Understand the problem first |
+| Lava Flow | Dead code left "just in case" | Delete it, git remembers |
+| Spaghetti | No structure, everything calls everything | Clear dependency direction |

--- a/.forgia/dev-guide/principles/solid.md
+++ b/.forgia/dev-guide/principles/solid.md
@@ -1,0 +1,124 @@
+# SOLID Principles
+
+> Always loaded. Apply pragmatically — SOLID is a compass, not a GPS.
+
+## S — Single Responsibility
+
+> A module should have one, and only one, reason to change.
+
+- One class/module = one job
+- If you can't describe what it does without "and", split it
+- **Practical test**: if a change in business logic forces you to change a module that handles persistence, they're coupled
+
+```
+# Bad — handles validation AND persistence AND notification
+class OrderService:
+    def create_order(self, data):
+        self.validate(data)
+        self.save_to_db(data)
+        self.send_email(data)
+
+# Good — each concern is separate
+class OrderValidator: ...
+class OrderRepository: ...
+class OrderNotifier: ...
+class CreateOrderUseCase:
+    def __init__(self, validator, repo, notifier): ...
+```
+
+## O — Open/Closed
+
+> Open for extension, closed for modification.
+
+- Add new behavior by adding new code, not changing existing code
+- Use interfaces/traits + implementations, not if/else chains
+- **Practical test**: can you add a new variant without touching existing code?
+
+```
+# Bad — must modify every time a new venue is added
+def connect(venue):
+    if venue == "binance": ...
+    elif venue == "kraken": ...
+
+# Good — add new venue by implementing trait
+trait VenueBridge { fn connect(&self); }
+struct BinanceBridge;
+struct KrakenBridge;
+// Adding CoinbaseBridge doesn't touch existing code
+```
+
+## L — Liskov Substitution
+
+> Subtypes must be substitutable for their base types.
+
+- If `Dog` extends `Animal`, anywhere you use `Animal` you must be able to use `Dog`
+- Don't override methods to throw "not supported" — that violates LSP
+- **Practical test**: does the subtype honor ALL contracts of the parent?
+
+```
+# Bad — violates LSP
+class ReadOnlyRepo(Repository):
+    def save(self, item):
+        raise NotImplementedError()  # Surprise!
+
+# Good — separate interfaces
+trait Readable { fn find(&self, id: &str) -> Item; }
+trait Writable { fn save(&self, item: &Item); }
+```
+
+## I — Interface Segregation
+
+> No client should be forced to depend on methods it doesn't use.
+
+- Small, focused interfaces > one large interface
+- If a class implements an interface but leaves methods empty, the interface is too fat
+
+```
+# Bad — forces implementors to handle everything
+trait DataStore {
+    fn read();
+    fn write();
+    fn watch();      // Not all stores support watching
+    fn replicate();  // Not all stores replicate
+}
+
+# Good — compose what you need
+trait Reader { fn read(); }
+trait Writer { fn write(); }
+trait Watcher { fn watch(); }
+// impl Reader + Writer for Postgres
+// impl Reader + Writer + Watcher for Redis
+```
+
+## D — Dependency Inversion
+
+> Depend on abstractions, not concretions.
+
+- High-level modules should not depend on low-level modules
+- Both should depend on abstractions (interfaces/traits)
+- **This is the most impactful SOLID principle** — it enables testing, swapping implementations, and clean architecture
+
+```
+# Bad — business logic depends directly on infrastructure
+class TradingEngine:
+    def __init__(self):
+        self.db = PostgresConnection("localhost:5432")
+
+# Good — depends on abstraction, injected from outside
+class TradingEngine:
+    def __init__(self, repo: PositionRepository):
+        self.repo = repo
+
+# In production: TradingEngine(PostgresRepo(...))
+# In tests:      TradingEngine(InMemoryRepo())
+```
+
+## When to Break SOLID
+
+SOLID is guidance, not law. Break it when:
+- **Prototyping**: get it working first, refactor later
+- **Scripts**: a 50-line script doesn't need interfaces
+- **Performance**: sometimes coupling is faster and the bottleneck matters
+- **Simplicity**: if the abstraction is harder to understand than the concrete code, skip it
+
+The goal is **maintainable code**, not **pattern-compliant code**.

--- a/.forgia/dev-guide/review-process.md
+++ b/.forgia/dev-guide/review-process.md
@@ -1,0 +1,61 @@
+# Review Process
+
+## Gates
+
+Forgia enforces 3 gates before code reaches production:
+
+```
+FD Review ──→ SDD Generation ──→ Implementation ──→ Verification ──→ Close
+ /fd-review    /fd-sdd            agent executes     /fd-verify       /fd-close
+ GATE 1                                              GATE 2           GATE 3
+```
+
+### Gate 1: FD Review (`/fd-review`)
+
+Before any SDD can be generated:
+- Problem clearly defined (what + why, not how)
+- At least 2 solutions considered
+- Architecture diagram present
+- Interfaces between components defined
+- Constitution compliance checked
+
+### Gate 2: Verification (`/fd-verify`)
+
+After all SDDs are executed:
+- All acceptance criteria met
+- All tests pass
+- Work Log completed in every SDD
+- Constitution compliance re-checked
+- Commits follow conventions
+
+### Gate 3: Close (`/fd-close`)
+
+Before archiving:
+- FD status is "complete" (Gate 2 passed)
+- Retrospective insights aggregated
+- Changelog updated
+
+## Who Reviews
+
+| Reviewer | When |
+|----------|------|
+| Claude (AI) | Default reviewer for `/fd-review` |
+| Human | Complex architectural decisions, security-sensitive FDs |
+| Both | Recommended for high-priority FDs |
+
+## Review Strictness
+
+- **Be strict**: vague problems, missing diagrams, undefined interfaces = FAIL
+- **Be specific**: every failed check includes actionable feedback
+- **Be consistent**: always check against the constitution
+- **No exceptions**: the gates cannot be bypassed
+
+## Work Log Review
+
+The Work Log in each SDD is reviewed during `/fd-verify`:
+- Agent section: who, when, how long
+- Decisions: any deviations from the plan
+- Output: commits, PRs, files
+- Retrospective: learnings for future FDs
+
+The retrospective is the most valuable artifact — it feeds back into better FDs.

--- a/.forgia/fd/FD-001-go-cli-porting.md
+++ b/.forgia/fd/FD-001-go-cli-porting.md
@@ -1,0 +1,210 @@
+---
+id: "FD-001"
+title: "Port Bash CLI to Go binary"
+status: in-progress
+priority: high
+effort: high
+impact: high
+author: "DeepZima"
+assignee: ""
+created: "2026-03-28"
+reviewed: true
+reviewer: "claude"
+tags: [go, cli, porting, phase-2]
+upstream_issue: "Deepzima/forgia#63"
+---
+
+# FD-001: Port Bash CLI to Go binary
+
+## Problem / Problema
+
+Forgia's CLI is split in two: a 1087-line Bash script (`bin/forgia`) handling 7 commands, and a Go binary (`cmd/forgia/`) with only `sync` and `version`. All internal Go packages are implemented and tested (FileVault, config, guardrails, MCP, beads, boardsync, runner interface) but none of them are wired to CLI commands.
+
+This means:
+- Users run the Bash CLI, which has known fragility (TOML parsing with grep/sed, stdin pipe issues, platform-dependent date/sed)
+- The Go packages sit unused despite being battle-tested (100+ tests)
+- Two codebases to maintain for the same functionality
+- New features require changes in both Bash and Go
+- 11 slash commands are loose markdown files with no registry, no embedding, no context wiring
+
+The goal is a single Go binary that replaces `bin/forgia` entirely — zero Bash dependency.
+
+## Solutions Considered / Soluzioni Considerate
+
+### Option A: Incremental migration (command by command)
+
+Each Bash command gets a Go equivalent alongside the Bash version. Users switch via `FORGIA_USE_GO=1` env var. When all commands are ported, Bash is removed.
+
+- **Pro:** Low risk, can ship incrementally, easy rollback per command
+- **Pro:** E2E tests can run against both backends
+- **Con / Contro:** Longer timeline, dual maintenance during migration
+- **Con / Contro:** Feature drift between Bash and Go versions
+
+### Option B (chosen): Full port in one branch / Porto completo in un branch (scelta)
+
+Port all 7 commands to Go in a single feature branch. Embed vault templates and slash commands via `go:embed`. Ship as a complete replacement.
+
+- **Pro:** Clean cut, no dual maintenance period, all packages already implemented
+- **Pro:** `go:embed` eliminates runtime dependency on `modules/` directory
+- **Pro:** Single binary distribution (cross-compiled for linux/darwin × amd64/arm64)
+- **Con / Contro:** Larger PR, higher review effort
+- **Con / Contro:** Risk of subtle behavior differences vs Bash (mitigated by existing E2E tests)
+
+## Architecture / Architettura
+
+### Integration Context / Contesto di Integrazione
+
+```mermaid
+flowchart TD
+    subgraph existing ["Existing / Esistente"]
+        V[internal/vault<br/>FileVault]
+        C[internal/config<br/>LoadConfig]
+        G[internal/guardrails<br/>Enforce]
+        B[internal/board<br/>GitHubBoard]
+        M[internal/mcp<br/>ProviderRegistry]
+        R[internal/runner<br/>Runner interface]
+        BD[internal/beads<br/>Client]
+        P[internal/process<br/>Spawn]
+    end
+
+    subgraph new ["New Cobra Commands / Nuovi"]
+        INIT[cmd init.go]
+        STATUS[cmd status.go]
+        DOCTOR[cmd doctor.go]
+        VALIDATE[cmd validate.go]
+        EXEC[cmd exec.go]
+        BATCH[cmd batch.go]
+        WATCH[cmd watch.go]
+        SKILL[cmd skill.go]
+    end
+
+    subgraph embed ["go:embed"]
+        TPL[vault-template/]
+        CMDS[claude-commands/*.md]
+    end
+
+    INIT --> V
+    INIT --> C
+    INIT --> BD
+    INIT --> TPL
+    STATUS --> V
+    STATUS --> B
+    STATUS --> BD
+    DOCTOR --> V
+    DOCTOR --> C
+    DOCTOR --> M
+    VALIDATE --> V
+    VALIDATE --> G
+    EXEC --> V
+    EXEC --> G
+    EXEC --> R
+    EXEC --> P
+    BATCH --> V
+    BATCH --> R
+    BATCH --> BD
+    WATCH --> V
+    WATCH --> R
+    SKILL --> CMDS
+    SKILL --> R
+
+    style existing fill:#f0f0f0,stroke:#999
+    style new fill:#d4edda,stroke:#28a745
+    style embed fill:#fff3cd,stroke:#ffc107
+```
+
+### Data Flow / Flusso Dati
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Cobra as Cobra CLI
+    participant Vault as FileVault
+    participant Config as LoadConfig
+    participant Guard as Guardrails
+    participant Runner as Runner (Claude/OH)
+
+    User->>Cobra: forgia exec SDD-001.md
+    Cobra->>Vault: Open(dir)
+    Cobra->>Config: LoadConfig(ctx, dir)
+    Cobra->>Vault: GetSDD(ctx, fd, sdd)
+    Cobra->>Guard: Enforce(ctx, mode, opts)
+    alt violations
+        Guard-->>Cobra: []Violation
+        Cobra-->>User: blocked: violation details
+    else clean
+        Cobra->>Runner: Execute(ctx, sdd, execOpts)
+        Runner->>Runner: build system context
+        Runner->>Runner: invoke claude/openhands
+        Runner-->>Cobra: ExecResult
+        Cobra->>Vault: UpdateSDD (work log)
+        Cobra-->>User: done (duration, status)
+    end
+```
+
+## Interfaces / Interfacce
+
+| Component / Componente | Input | Output | Protocol / Protocollo |
+|------------------------|-------|--------|-----------------------|
+| `cmd/init.go` | `--dir` flag, embedded templates | scaffolded `.forgia/` | FileVault.InitVault() |
+| `cmd/status.go` | vault dir | formatted table (FDs, SDDs, board) | FileVault.ListFDs/ListSDDs |
+| `cmd/doctor.go` | vault dir, system PATH | health report | exec.LookPath, Config, MCP.Healthy |
+| `cmd/validate.go` | SDD file path or FD dir | pass/fail + violations | Guardrails.Enforce, frontmatter parse |
+| `cmd/exec.go` | SDD file, `--runner`, `--dry-run`, `--mode` | ExecResult + work log update | Runner.Execute, Guardrails.Enforce |
+| `cmd/batch.go` | FD dir, `--runner`, `--dry-run` | sequential ExecResults | Runner.Execute per SDD |
+| `cmd/watch.go` | FD dir, `--debounce` | auto-exec on new SDDs | fsnotify + Runner.Execute |
+| `cmd/skill.go` | skill name, args | Claude output | embedded markdown + Claude CLI |
+| `embed/templates` | `go:embed modules/vault-template` | `embed.FS` | compile-time |
+| `embed/commands` | `go:embed modules/claude-commands` | `embed.FS` | compile-time |
+
+## Planned SDDs / SDD Previsti
+
+1. SDD-001: `go:embed` scaffold — embed vault templates + slash commands, expose via `internal/embed` package. Must export `VaultTemplateFS()` and `SlashCommandFS()` returning `fs.FS`
+2. SDD-002: `forgia init` — Cobra command, wire InitVault + templates + stack detection
+3. SDD-003: `forgia status` + `forgia doctor` — read-only commands, vault + board + beads
+4. SDD-004: `forgia validate` — SDD validation, frontmatter checks, guardrails pre-check
+5. SDD-005: Claude runner — concrete Runner implementation, system context builder, file monitor
+6. SDD-006: `forgia exec` + `forgia batch` — execution commands, guardrails enforcement, work log update
+7. SDD-007: `forgia watch` — fsnotify watcher, debounce, auto-exec
+8. SDD-008: `forgia skill` — skill registry, embedded markdown loader, Claude invocation
+9. SDD-009: Bash deprecation — add banner to bin/forgia, update install.sh + README, E2E migration
+
+## Constraints / Vincoli
+
+- Go 1.25+ — use `iter.Seq`, `slog`, `testing/synctest`
+- Context propagation: all I/O functions take `ctx context.Context` as first parameter
+- Structured logging: `slog.InfoContext(ctx, ...)`, never bare `slog.Info`
+- Error wrapping: always `fmt.Errorf("context: %w", err)`
+- Compile-time interface checks: `var _ Interface = (*Struct)(nil)`
+- Type assertions: always comma-ok pattern
+- Tests: table-driven, `t.Helper()`, `t.TempDir()`
+- No `init()` — explicit initialization only
+- Guardrails are absolute — deny.toml enforced at runtime
+- Spec first, code second — each SDD must be approved before execution
+- Commits: `feat(FD-001): SDD-NNN — description` + `Signed-off-by` + `Co-Authored-By`
+
+## Verification / Verifica
+
+- [ ] `go build ./...` produces single binary with all commands
+- [ ] `forgia init` scaffolds identical vault structure as Bash version
+- [ ] `forgia status` output matches Bash version (format may differ)
+- [ ] `forgia doctor` checks all: vault, git, docker, claude, bd, fswatch, yq, MCP
+- [ ] `forgia validate` catches same errors as Bash validate-sdd.sh
+- [ ] `forgia exec` runs SDDs with Claude runner (constitution + guardrails context)
+- [ ] `forgia exec --dry-run` simulates without modifying files
+- [ ] `forgia exec --mode=guard` enforces boundaries from SDD
+- [ ] `forgia batch` executes all pending SDDs in dependency order
+- [ ] `forgia watch` auto-executes new SDDs on file change
+- [ ] `forgia skill fd-status` lists FDs from embedded command
+- [ ] E2E tests pass against Go binary (not Bash)
+- [ ] Cross-compile: linux/darwin × amd64/arm64
+- [ ] `bin/forgia` shows deprecation banner pointing to Go binary
+- [ ] All existing 100+ Go tests still pass
+- [ ] No regression in CI (test + build + E2E)
+
+## Notes / Note
+
+- Upstream: Deepzima/forgia#63
+- Context files read: CONTRIBUTING.md, .forgia/constitution.md, .forgia/dev-guide/lang/go.md
+- Dependencies ready: FileVault (#48), Config (#49), Guardrails (#52), Board (#35), MCP (#55), Runner interface (#41)
+- ferruvich's PRs #61 (arch skills) and #62 (sdd-dry-run) add more slash commands — embed those too after merge
+- The Bash E2E tests (`tests/e2e*.sh`) should be ported to Go integration tests progressively

--- a/.forgia/fd/_templates/fd-template.md
+++ b/.forgia/fd/_templates/fd-template.md
@@ -1,0 +1,111 @@
+---
+id: "{{ID}}"
+title: "{{TITLE}}"
+status: planned
+priority: medium
+effort: medium
+impact: medium
+author: "{{AUTHOR}}"
+assignee: ""
+created: "{{DATE}}"
+reviewed: false
+reviewer: ""
+tags: []
+---
+
+# {{ID}}: {{TITLE}}
+
+## Problem / Problema
+
+<!-- EN: Describe the problem or need. What's broken? What's missing? Why does this matter? -->
+<!-- IT: Descrivi il problema o la necessita'. Cosa non funziona? Cosa manca? Perche' serve? -->
+
+## Solutions Considered / Soluzioni Considerate
+
+### Option A / Opzione A
+
+- **Pro:**
+- **Con / Contro:**
+
+### Option B (chosen) / Opzione B (scelta)
+
+- **Pro:**
+- **Con / Contro:**
+
+## Architecture / Architettura
+
+<!-- EN: MANDATORY — This diagram must show where this feature integrates in the existing system.
+     Include: existing components (grey), new components (green), data flow, protocols.
+     This is NOT optional — /fd-review will REJECT the FD without a filled diagram. -->
+<!-- IT: OBBLIGATORIO — Questo diagramma deve mostrare dove si integra la feature nel sistema esistente.
+     Includere: componenti esistenti (grigio), nuovi componenti (verde), flusso dati, protocolli.
+     NON e' opzionale — /fd-review RIFIUTERA' il FD senza un diagramma compilato. -->
+
+### Integration Context / Contesto di Integrazione
+
+```mermaid
+flowchart TD
+    subgraph existing ["Existing System / Sistema Esistente"]
+        A[Component A]
+        B[Component B]
+    end
+
+    subgraph new ["New / Nuovo"]
+        C[New Component]
+    end
+
+    A -->|protocol| C
+    C -->|protocol| B
+
+    style existing fill:#f0f0f0,stroke:#999
+    style new fill:#d4edda,stroke:#28a745
+```
+
+### Data Flow / Flusso Dati
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant NewComponent
+    participant ExistingService
+
+    User->>NewComponent: request
+    NewComponent->>ExistingService: call
+    ExistingService-->>NewComponent: response
+    NewComponent-->>User: result
+```
+
+## Interfaces / Interfacce
+
+<!-- EN: Define interfaces between components that will become separate SDDs -->
+<!-- IT: Definisci le interfacce tra i componenti che verranno generati come SDD separati -->
+
+| Component / Componente | Input | Output | Protocol / Protocollo |
+|------------------------|-------|--------|-----------------------|
+| | | | |
+
+## Planned SDDs / SDD Previsti
+
+<!-- EN: How many SDDs will be generated from this FD? One per component/service -->
+<!-- IT: Quanti SDD verranno generati da questo FD? Uno per componente/servizio -->
+
+1. SDD-001: <!-- component 1 / componente 1 -->
+2. SDD-002: <!-- component 2 / componente 2 -->
+
+## Constraints / Vincoli
+
+- <!-- technical, time, budget constraints / vincoli tecnici, di tempo, di budget -->
+
+## Verification / Verifica
+
+- [ ] Problem clearly defined / Problema chiaramente definito
+- [ ] At least 2 solutions with pros/cons / Almeno 2 soluzioni con pro/contro
+- [ ] Architecture diagram present / Diagramma architetturale presente
+- [ ] Interfaces defined / Interfacce tra componenti definite
+- [ ] SDDs listed / SDD previsti elencati
+- [ ] Review completed / Review completata (`/fd-review`)
+
+## Notes / Note
+
+<!-- EN: Additional notes, links, references -->
+<!-- IT: Note aggiuntive, link, riferimenti -->

--- a/.forgia/guardrails/deny.toml
+++ b/.forgia/guardrails/deny.toml
@@ -1,0 +1,125 @@
+# Forgia Guardrails — Deny List
+# Patterns the agent must NEVER access during SDD execution.
+# Loaded by runners and injected into agent prompts.
+#
+# Syntax: glob patterns, one per line in the array.
+# These are fail-closed — if in doubt, deny.
+
+[read]
+# Files the agent must NEVER read or include in context
+patterns = [
+  # Secrets and environment
+  "**/.env",
+  "**/.env.*",
+  "!**/.env.example",
+  "!**/.env.template",
+
+  # Certificates and keys
+  "**/*.pem",
+  "**/*.key",
+  "**/*.p12",
+  "**/*.pfx",
+  "**/*.jks",
+  "**/*.keystore",
+
+  # Cloud credentials
+  "**/.aws/credentials",
+  "**/.aws/config",
+  "**/.azure/**",
+  "**/.gcloud/**",
+
+  # Auth tokens and configs
+  "**/.netrc",
+  "**/.npmrc",
+  "**/.pypirc",
+  "**/.docker/config.json",
+  "**/credentials.json",
+
+  # Kubernetes
+  "**/kubeconfig",
+  "**/kubeconfig.*",
+
+  # SSH and GPG
+  "**/.ssh/id_*",
+  "**/.ssh/*key*",
+  "**/.gnupg/**",
+
+  # Password stores
+  "**/.password-store/**",
+  "**/.vaults/**",
+
+  # macOS keychain
+  "**/*.keychain",
+  "**/*.keychain-db",
+
+  # Terraform state (contains secrets)
+  "**/*.tfstate",
+  "**/*.tfstate.backup",
+]
+
+[execute]
+# Commands the agent must NEVER run
+patterns = [
+  # Read private keys
+  "cat ~/.ssh/id_*",
+  "cat ~/.ssh/*key*",
+  "base64 ~/.ssh/*",
+  "xxd ~/.ssh/*",
+
+  # GPG secrets
+  "cat ~/.gnupg/*",
+  "base64 ~/.gnupg/*",
+  "xxd ~/.gnupg/*",
+  "gpg --export-secret*",
+
+  # Password managers
+  "pass show*",
+  "pass *",
+  "bw get *",
+  "bw list *",
+  "op item get *",
+
+  # Environment secrets enumeration
+  "echo $ANTHROPIC_API_KEY*",
+  "echo $OPENAI_API_KEY*",
+  "echo $GEMINI_API_KEY*",
+  "echo $GITHUB_TOKEN*",
+  "echo $AWS_SECRET*",
+  "env | grep -i key*",
+  "env | grep -i token*",
+  "env | grep -i secret*",
+  "env | grep -i password*",
+
+  # Cloud credentials
+  "cat ~/.aws/credentials*",
+  "cat ~/.azure/*",
+  "cat ~/.gcloud/*",
+
+  # macOS keychain
+  "security find-generic-password*",
+  "security find-internet-password*",
+
+  # Certificates
+  "cat *.pem",
+  "cat *.key",
+  "cat *.p12",
+]
+
+[write]
+# Files the agent must NEVER create or modify
+patterns = [
+  # Secrets
+  "**/.env",
+  "**/.env.*",
+  "!**/.env.example",
+
+  # Forgia meta (immutable)
+  ".forgia/constitution.md",
+  ".forgia/config.toml",
+  ".forgia/guardrails/deny.toml",
+
+  # Certificates
+  "**/*.pem",
+  "**/*.key",
+  "**/*.p12",
+]

--- a/.forgia/guardrails/ignore
+++ b/.forgia/guardrails/ignore
@@ -1,0 +1,71 @@
+# Forgia Ignore — files excluded from agent context
+# Similar to .claudeignore / .codexignore but project-specific.
+# These files will not be loaded into the agent's context window.
+
+# Secrets and credentials
+.env
+.env.*
+!.env.example
+!.env.template
+*.pem
+*.key
+*.p12
+*.pfx
+*.jks
+*.keystore
+credentials.json
+
+# SSH and GPG
+.ssh/id_*
+.ssh/*key*
+.ssh/authorized_keys
+.gnupg/
+
+# Password stores
+.password-store/
+.vaults/
+*.vc
+
+# Cloud credentials
+.aws/credentials
+.aws/config
+.azure/
+.gcloud/
+
+# Kubernetes
+kubeconfig
+kubeconfig.*
+
+# macOS
+*.keychain
+*.keychain-db
+
+# Auth tokens
+.netrc
+.npmrc
+.pypirc
+.docker/config.json
+
+# Terraform state
+*.tfstate
+*.tfstate.backup
+
+# Build artifacts (save context window)
+node_modules/
+target/
+dist/
+build/
+__pycache__/
+*.pyc
+.venv/
+venv/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/.forgia/ops/_templates/ops-task.md
+++ b/.forgia/ops/_templates/ops-task.md
@@ -1,0 +1,41 @@
+---
+id: "OPS-{{ID}}"
+title: "{{TITLE}}"
+category: dev|infra|review|ops
+priority: high|medium|low
+status: active
+owner: deepzima|claude
+created: "{{DATE}}"
+due: ""
+fd: ""
+sdd: ""
+tags: []
+---
+
+# OPS-{{ID}}: {{TITLE}}
+
+## What to Do / Cosa Fare
+
+<!-- EN: Describe the concrete action -->
+<!-- IT: Descrivi l'azione concreta -->
+
+## Context / Contesto
+
+<!-- EN: Why is this needed? Link to FD, SDD, issue -->
+<!-- IT: Perche' serve? Link a FD, SDD, issue -->
+
+## Checklist
+
+- [ ] Step 1
+- [ ] Step 2
+- [ ] Step 3
+
+## Expected Output / Output Atteso
+
+<!-- EN: What do we expect as a result? -->
+<!-- IT: Cosa ci aspettiamo come risultato? -->
+
+## Notes / Note
+
+<!-- EN: Annotations, results, lessons learned -->
+<!-- IT: Annotazioni, risultati, lezioni apprese -->

--- a/.forgia/sdd/FD-001/SDD-001-go-embed-scaffold.md
+++ b/.forgia/sdd/FD-001/SDD-001-go-embed-scaffold.md
@@ -1,0 +1,118 @@
+---
+id: "SDD-001"
+fd: "FD-001"
+title: "go:embed scaffold — vault templates + slash commands"
+status: planned
+agent: ""
+assigned_to: ""
+created: "2026-03-28"
+started: ""
+completed: ""
+tags: [go, embed, templates]
+---
+
+# SDD-001: go:embed scaffold — vault templates + slash commands
+
+> Parent FD: [[FD-001]]
+
+## Scope
+
+Create `internal/embedded/` package that uses `go:embed` to bundle:
+1. All vault template files from `modules/vault-template/` (config.toml, constitution.md, fd templates, sdd templates, dev-guide, guardrails, ops)
+2. All slash command markdown files from `modules/claude-commands/` (fd-new, fd-review, fd-sdd, fd-close, fd-explore, fd-verify, fd-status, fd-deep, sdd-status, sdd-assign, project-init)
+
+The package must export two functions:
+- `VaultTemplateFS() fs.FS` — returns the embedded vault template filesystem
+- `SlashCommandFS() fs.FS` — returns the embedded slash command filesystem
+
+This eliminates the runtime dependency on the `modules/` directory. The Go binary becomes fully self-contained.
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| `VaultTemplateFS()` | `func() fs.FS` | Returns embedded vault templates |
+| `SlashCommandFS()` | `func() fs.FS` | Returns embedded slash commands |
+| `ListSlashCommands()` | `func() []string` | Returns list of available command names |
+| `ReadSlashCommand(name)` | `func(string) ([]byte, error)` | Returns content of a specific command |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Go 1.25+
+- Framework: stdlib `embed`, `io/fs`
+- Dependencies / Dipendenze: none (stdlib only)
+- Patterns / Pattern: `//go:embed` directives, `fs.FS` interface
+- The `go:embed` directives MUST be in the same package as the embedded files or use relative paths from the Go file location. If `internal/embedded/` is the package, the `modules/` dir must be reachable. Alternative: place the `go:embed` file at repo root and re-export.
+
+## Best Practices
+
+- Error handling: `ReadSlashCommand` returns error if command not found
+- Naming: package name `embedded`, functions are self-documenting
+- Style: no exported types, just functions returning `fs.FS`
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Unit | VaultTemplateFS contains expected files (config.toml, constitution.md, fd template, sdd template) | 100% of expected files |
+| Unit | SlashCommandFS contains all 11+ commands | all known commands |
+| Unit | ListSlashCommands returns correct names | all names |
+| Unit | ReadSlashCommand returns content for valid name, error for invalid | both paths |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `internal/embedded/` package exists with `go:embed` directives
+- [ ] `VaultTemplateFS()` returns fs.FS containing all files from `modules/vault-template/`
+- [ ] `SlashCommandFS()` returns fs.FS containing all files from `modules/claude-commands/`
+- [ ] `ListSlashCommands()` returns names of all embedded commands (without .md extension)
+- [ ] `ReadSlashCommand("fd-review")` returns the markdown content
+- [ ] `ReadSlashCommand("nonexistent")` returns error
+- [ ] `go build ./...` succeeds — embedded files compile into binary
+- [ ] Binary size increase is reasonable (< 500KB for templates + commands)
+- [ ] All existing tests still pass
+
+## Context / Contesto
+
+- [ ] `modules/vault-template/` — directory tree to embed
+- [ ] `modules/claude-commands/` — markdown files to embed
+- [ ] Go `embed` docs: https://pkg.go.dev/embed
+- [ ] `internal/skill/skill.go` — existing Skill interface (for future integration)
+
+## Constitution Check
+
+- [x] Respects code standards (stdlib only, no external deps)
+- [x] Respects commit conventions (`feat(FD-001): SDD-001`)
+- [x] No hardcoded secrets
+- [x] Tests defined and sufficient
+
+## Guardrails
+
+From `.forgia/guardrails/deny.toml`: no deny patterns are relevant to this SDD. The embedded files are templates, not secrets.
+
+---
+
+## Work Log / Diario di Lavoro
+
+### Agent / Agente
+
+- **Executor**: <!-- openhands | claude-code | manual | name -->
+- **Started**: <!-- timestamp -->
+- **Completed**: <!-- timestamp -->
+- **Duration / Durata**: <!-- total time -->
+
+### Decisions / Decisioni
+
+1. <!-- decision 1: what and why -->
+
+### Output
+
+- **Commit(s)**: <!-- hash -->
+- **PR**: <!-- link -->
+- **Files created/modified**:
+  - `path/to/file`
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**:
+- **What didn't / Cosa non ha funzionato**:
+- **Suggestions for future FDs / Suggerimenti per FD futuri**:

--- a/.forgia/sdd/FD-001/SDD-002-forgia-init.md
+++ b/.forgia/sdd/FD-001/SDD-002-forgia-init.md
@@ -1,0 +1,128 @@
+---
+id: "SDD-002"
+fd: "FD-001"
+title: "forgia init — Cobra command with embedded templates"
+status: planned
+agent: ""
+assigned_to: ""
+created: "2026-03-28"
+started: ""
+completed: ""
+tags: [go, cli, init, cobra]
+---
+
+# SDD-002: forgia init — Cobra command with embedded templates
+
+> Parent FD: [[FD-001]]
+
+## Scope
+
+Create `cmd/forgia/cmd/init.go` — Cobra command that scaffolds `.forgia/` vault using embedded templates from SDD-001.
+
+Behavior must match current Bash `cmd_init()` in `bin/forgia`:
+1. Create `.forgia/` directory structure
+2. Copy templates from `embedded.VaultTemplateFS()` (not from filesystem `modules/`)
+3. Auto-detect project stack (Go, Rust, Python, Node, Shell) by checking for `go.mod`, `Cargo.toml`, `pyproject.toml`, `package.json`
+4. Copy matching language conventions from embedded templates
+5. Initialize Beads if `bd` is available (via `beads.Client`)
+6. Initialize Knowledge layer if codebase-memory-mcp is available
+7. Create architecture templates (DDD)
+8. Create `.gitignore` for `.forgia/` (exclude logs, run, beads)
+9. Create `.github/CODEOWNERS` if not exists
+10. Print summary of created files and next steps
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| `initCmd` | `*cobra.Command` | Registered as subcommand of rootCmd |
+| `--dir` flag | `string` | Target directory (default: current dir) |
+| `embedded.VaultTemplateFS()` | `fs.FS` | Source of template files (from SDD-001) |
+| `vault.InitVault(dir)` | existing | Creates directory structure |
+| `beads.Client.Available()` | existing | Check if bd is installed |
+| `config.LoadConfig()` | existing | Not needed for init (config doesn't exist yet) |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Go 1.25+
+- Framework: Cobra, `io/fs` for walking embedded templates
+- Dependencies / Dipendenze: `internal/embedded` (SDD-001), `internal/vault`, `internal/beads`
+- Patterns / Pattern: `fs.WalkDir` to copy from embed.FS to disk, `os.MkdirAll` for directories
+- Must be idempotent: running init twice should skip existing files (not overwrite)
+- Must NOT import `internal/guardrails` or `internal/board` (not needed at init time)
+
+## Best Practices
+
+- Error handling: wrap all errors with context, fail on first critical error, warn on optional failures (beads, knowledge)
+- Naming: `initCmd` (unexported, registered in `init()` — WAIT: no init(). Register in package-level var or in root.go)
+- Style: use `slog.InfoContext` for all progress messages, structured output
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Unit | Init creates all expected directories | all dirs |
+| Unit | Init copies templates from embedded FS | config.toml, constitution, fd template, sdd template |
+| Unit | Init detects Go stack (go.mod present) | go.md copied |
+| Unit | Init is idempotent (second run skips existing) | no overwrite |
+| Unit | Init with --dir flag works in custom directory | alternate path |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `forgia init` scaffolds `.forgia/` identical to Bash version
+- [ ] Templates come from embedded FS, not filesystem `modules/`
+- [ ] Stack detection works for Go, Rust, Python, Node
+- [ ] Idempotent: existing files not overwritten
+- [ ] Beads init runs if `bd` available (graceful skip if not)
+- [ ] `--dir` flag changes target directory
+- [ ] Progress output via slog (not bare fmt.Println)
+- [ ] `go build ./...` succeeds
+- [ ] 5+ tests pass
+
+## Context / Contesto
+
+- [ ] `bin/forgia` lines 88-340 — current Bash `cmd_init()` implementation
+- [ ] `internal/vault/file_vault.go` — `InitVault()` function
+- [ ] `internal/embedded/` — from SDD-001
+- [ ] `modules/vault-template/` — reference for expected output structure
+- [ ] `cmd/forgia/cmd/root.go` — where to register the command
+- [ ] `cmd/forgia/cmd/sync.go` — reference for Cobra command pattern in this project
+
+## Constitution Check
+
+- [x] Respects code standards
+- [x] Respects commit conventions
+- [x] No hardcoded secrets
+- [x] Tests defined and sufficient
+
+## Guardrails
+
+Init creates `.forgia/guardrails/deny.toml` from embedded template. It does NOT read/write any denied files. The `constitution.md` and `config.toml` it creates are NEW files (not modifying existing protected ones).
+
+---
+
+## Work Log / Diario di Lavoro
+
+### Agent / Agente
+
+- **Executor**: <!-- openhands | claude-code | manual | name -->
+- **Started**: <!-- timestamp -->
+- **Completed**: <!-- timestamp -->
+- **Duration / Durata**: <!-- total time -->
+
+### Decisions / Decisioni
+
+1. <!-- decision 1: what and why -->
+
+### Output
+
+- **Commit(s)**: <!-- hash -->
+- **PR**: <!-- link -->
+- **Files created/modified**:
+  - `path/to/file`
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**:
+- **What didn't / Cosa non ha funzionato**:
+- **Suggestions for future FDs / Suggerimenti per FD futuri**:

--- a/.forgia/sdd/FD-001/SDD-003-forgia-status-doctor.md
+++ b/.forgia/sdd/FD-001/SDD-003-forgia-status-doctor.md
@@ -1,0 +1,138 @@
+---
+id: "SDD-003"
+fd: "FD-001"
+title: "forgia status + forgia doctor — read-only vault commands"
+status: planned
+agent: ""
+assigned_to: ""
+created: "2026-03-28"
+started: ""
+completed: ""
+tags: [go, cli, status, doctor, cobra]
+---
+
+# SDD-003: forgia status + forgia doctor — read-only vault commands
+
+> Parent FD: [[FD-001]]
+
+## Scope
+
+Create two Cobra commands:
+
+### `forgia status` (`cmd/forgia/cmd/status.go`)
+Read-only dashboard showing:
+- All FDs with status, priority, author (table format)
+- All SDDs per FD with status (nested under FD)
+- Board connection status (if configured in config.toml)
+- Beads status (if available)
+- Knowledge layer status (if codebase-memory-mcp configured)
+
+### `forgia doctor` (`cmd/forgia/cmd/doctor.go`)
+Health check showing:
+- Vault: `.forgia/` exists and is valid (config.toml parseable, constitution exists)
+- Git: `git` available, repo initialized
+- Docker: `docker` available (optional)
+- Claude: `claude` CLI available
+- Beads: `bd` available, database connected
+- fswatch: available (optional, for watch command)
+- yq: available (optional, for YAML validation)
+- MCP providers: healthy (if configured)
+- Guardrails: deny.toml parseable
+
+Each check outputs pass/fail/skip with clear messages.
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| `statusCmd` | `*cobra.Command` | `forgia status` |
+| `doctorCmd` | `*cobra.Command` | `forgia doctor` |
+| `vault.Open(dir)` | existing | Open vault for reading |
+| `vault.ListFDs(ctx)` | existing | Get all FDs |
+| `vault.ListSDDs(ctx, fdID)` | existing | Get SDDs for an FD |
+| `config.LoadConfig(ctx, dir)` | existing | Load config for board/beads settings |
+| `board.Resolve(ctx, provider, owner, number)` | existing | Check board connectivity |
+| `beads.Client.Available()` | existing | Check beads |
+| `exec.LookPath(name)` | stdlib | Check tool availability |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Go 1.25+
+- Framework: Cobra, `text/tabwriter` for aligned output
+- Dependencies / Dipendenze: `internal/vault`, `internal/config`, `internal/board`, `internal/beads`
+- Patterns / Pattern: both commands are read-only — NEVER modify vault files
+- `status` must work even if config.toml is missing (just skip board/beads sections)
+- `doctor` must not panic on missing tools — report and continue
+
+## Best Practices
+
+- Error handling: `status` returns error only if vault cannot be opened. Missing board/beads are warnings, not errors. `doctor` always returns exit 0 (it reports issues, doesn't fail on them).
+- Naming: clear section headers in output
+- Style: `slog.InfoContext` for structured output, `tabwriter` for tables
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Unit | Status with empty vault shows "no FDs" | empty case |
+| Unit | Status with FDs shows correct table | table format |
+| Unit | Doctor detects git (always present in CI) | pass case |
+| Unit | Doctor reports missing optional tools as skip | skip case |
+| Unit | Status works without config.toml | graceful degradation |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `forgia status` lists all FDs with status in table format
+- [ ] `forgia status` shows SDDs nested under each FD
+- [ ] `forgia status` shows board status when configured (skip when not)
+- [ ] `forgia status` works with empty vault (no FDs)
+- [ ] `forgia doctor` checks: vault, git, docker, claude, bd, fswatch, yq
+- [ ] `forgia doctor` reports pass/fail/skip per tool
+- [ ] `forgia doctor` validates config.toml is parseable
+- [ ] `forgia doctor` validates deny.toml is parseable
+- [ ] Both commands are strictly read-only
+- [ ] `go build ./...` succeeds
+- [ ] 5+ tests pass
+
+## Context / Contesto
+
+- [ ] `bin/forgia` `cmd_status()` — Bash implementation
+- [ ] `bin/forgia` `cmd_doctor()` — Bash implementation
+- [ ] `internal/vault/file_vault.go` — ListFDs, ListSDDs
+- [ ] `internal/config/config.go` — LoadConfig
+- [ ] `cmd/forgia/cmd/sync.go` — reference for vault opening pattern
+
+## Constitution Check
+
+- [x] Respects code standards
+- [x] Respects commit conventions
+- [x] No hardcoded secrets
+- [x] Tests defined and sufficient
+
+---
+
+## Work Log / Diario di Lavoro
+
+### Agent / Agente
+
+- **Executor**: <!-- openhands | claude-code | manual | name -->
+- **Started**: <!-- timestamp -->
+- **Completed**: <!-- timestamp -->
+- **Duration / Durata**: <!-- total time -->
+
+### Decisions / Decisioni
+
+1. <!-- decision 1: what and why -->
+
+### Output
+
+- **Commit(s)**: <!-- hash -->
+- **PR**: <!-- link -->
+- **Files created/modified**:
+  - `path/to/file`
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**:
+- **What didn't / Cosa non ha funzionato**:
+- **Suggestions for future FDs / Suggerimenti per FD futuri**:

--- a/.forgia/sdd/FD-001/SDD-004-forgia-validate.md
+++ b/.forgia/sdd/FD-001/SDD-004-forgia-validate.md
@@ -1,0 +1,123 @@
+---
+id: "SDD-004"
+fd: "FD-001"
+title: "forgia validate — SDD validation with guardrails"
+status: planned
+agent: ""
+assigned_to: ""
+created: "2026-03-28"
+started: ""
+completed: ""
+tags: [go, cli, validate, guardrails, cobra]
+---
+
+# SDD-004: forgia validate — SDD validation with guardrails
+
+> Parent FD: [[FD-001]]
+
+## Scope
+
+Create `cmd/forgia/cmd/validate.go` — Cobra command that validates SDD files before execution.
+
+Two modes:
+1. **Single file**: `forgia validate path/to/SDD-001.md`
+2. **FD directory**: `forgia validate FD-001` (validates all SDDs in `.forgia/sdd/FD-001/`)
+
+Validation checks:
+1. **Frontmatter**: required fields present (id, fd, title, status)
+2. **Sections**: required sections exist (Scope, Interfaces, Constraints, Test Requirements, Acceptance Criteria, Context, Constitution Check, Work Log)
+3. **Guardrails pre-check**: SDD scope/context files don't reference paths denied in deny.toml
+4. **Boundaries pre-check**: if SDD has `boundaries.write_dirs`, verify they exist
+5. **Parent FD exists**: the referenced FD file is present in the vault
+
+Output: clear pass/fail per check, exit 0 if all pass, exit 1 if any fail.
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| `validateCmd` | `*cobra.Command` | `forgia validate <sdd-file|FD-NNN>` |
+| `vault.Open(dir)` | existing | Open vault |
+| `vault.GetSDD(ctx, fd, sdd)` | existing | Parse SDD frontmatter |
+| `guardrails.Parse(data)` | existing | Load deny.toml |
+| `guardrails.CheckFilePaths(ctx, paths)` | existing | Check context files against deny list |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Go 1.25+
+- Framework: Cobra
+- Dependencies / Dipendenze: `internal/vault`, `internal/guardrails`
+- Patterns / Pattern: Read-only (never modify SDD files during validation)
+- Must handle both `.md` frontmatter and `.yaml` SDD formats
+- Replaces `modules/runners/validate-sdd.sh`
+
+## Best Practices
+
+- Error handling: collect ALL validation errors (don't stop at first), report them all at the end
+- Naming: `validateSDD(ctx, v, sddPath) []ValidationError`
+- Style: each error has a category (frontmatter, section, guardrail, boundary) and clear message
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Unit | Valid SDD passes all checks | happy path |
+| Unit | Missing frontmatter field fails | each required field |
+| Unit | Missing section fails | each required section |
+| Unit | SDD referencing denied path fails guardrail check | deny.toml integration |
+| Unit | FD directory mode validates all SDDs | batch mode |
+| Unit | Nonexistent file returns error | error path |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `forgia validate SDD-001.md` validates single file
+- [ ] `forgia validate FD-001` validates all SDDs in directory
+- [ ] Missing frontmatter fields reported as errors
+- [ ] Missing sections reported as errors
+- [ ] Guardrail violations detected in SDD context paths
+- [ ] Exit code 0 on success, 1 on failure
+- [ ] Output lists all errors (not just first)
+- [ ] `go build ./...` succeeds
+- [ ] 6+ tests pass
+
+## Context / Contesto
+
+- [ ] `modules/runners/validate-sdd.sh` — Bash validation to replicate
+- [ ] `internal/vault/sdd.go` — SDD type and frontmatter fields
+- [ ] `internal/guardrails/guardrails.go` — Parse, CheckFilePaths
+- [ ] `cmd/forgia/cmd/sync.go` — reference for vault opening pattern
+
+## Constitution Check
+
+- [x] Respects code standards
+- [x] Respects commit conventions
+- [x] No hardcoded secrets
+- [x] Tests defined and sufficient
+
+---
+
+## Work Log / Diario di Lavoro
+
+### Agent / Agente
+
+- **Executor**: <!-- openhands | claude-code | manual | name -->
+- **Started**: <!-- timestamp -->
+- **Completed**: <!-- timestamp -->
+- **Duration / Durata**: <!-- total time -->
+
+### Decisions / Decisioni
+
+1. <!-- decision 1: what and why -->
+
+### Output
+
+- **Commit(s)**: <!-- hash -->
+- **PR**: <!-- link -->
+- **Files created/modified**:
+  - `path/to/file`
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**:
+- **What didn't / Cosa non ha funzionato**:
+- **Suggestions for future FDs / Suggerimenti per FD futuri**:

--- a/.forgia/sdd/FD-001/SDD-005-claude-runner.md
+++ b/.forgia/sdd/FD-001/SDD-005-claude-runner.md
@@ -1,0 +1,132 @@
+---
+id: "SDD-005"
+fd: "FD-001"
+title: "Claude runner — concrete Runner implementation"
+status: planned
+agent: ""
+assigned_to: ""
+created: "2026-03-28"
+started: ""
+completed: ""
+tags: [go, runner, claude, subprocess]
+---
+
+# SDD-005: Claude runner — concrete Runner implementation
+
+> Parent FD: [[FD-001]]
+
+## Scope
+
+Create `internal/runner/claude.go` — concrete implementation of the `Runner` interface that executes SDDs via the `claude` CLI.
+
+Responsibilities:
+1. **System context builder**: assemble constitution + guardrails + dev-guide principles + lang conventions into a single context string (replaces `_build_system_context()` from Bash)
+2. **Claude CLI invocation**: call `claude --dangerously-skip-permissions --max-turns N --append-system-prompt <context> -p <task>` via `exec.CommandContext`
+3. **File monitor**: background goroutine that watches `git status --short` every 5s and logs new/modified files (replaces Bash background monitor)
+4. **Execution logging**: write log file to `.forgia/logs/exec-SDD-NNN-<timestamp>.log` and JSON report to `.forgia/logs/exec-SDD-NNN-<timestamp>.json`
+5. **ExecResult**: populate with duration, exit code, status, files changed
+
+Does NOT implement OpenHands runner (out of scope, follow-up).
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| `ClaudeRunner` | `struct` implementing `Runner` | `Name() string`, `Execute(ctx, sdd, opts) (*ExecResult, error)` |
+| `var _ Runner = (*ClaudeRunner)(nil)` | compile-time check | Interface satisfaction |
+| `BuildSystemContext(v vault.Vault)` | `func(vault.Vault) (string, error)` | Exported helper to build context from vault |
+| `ExecOpts.AutoApprove` | `bool` | Maps to `--dangerously-skip-permissions` |
+| `ExecOpts.MaxTurns` | `int` | Maps to `--max-turns` |
+| `ExecOpts.DryRun` | `bool` | If true, delegate to DryRunRunner |
+| `ExecOpts.GuardrailMode` | `guardrails.Mode` | Passed to Enforce before exec |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Go 1.25+
+- Framework: `os/exec`, `context`
+- Dependencies / Dipendenze: `internal/vault`, `internal/guardrails`, `internal/process`, `internal/embedded` (for dev-guide if needed)
+- Patterns / Pattern:
+  - Use `exec.CommandContext(ctx, ...)` — NOT `exec.Command`
+  - SIGTERM → 5s → SIGKILL on cancellation (use `internal/process.Spawn` pattern)
+  - File monitor uses separate goroutine with `done` channel, stopped on exec complete
+  - Log file and JSON report written even on failure
+- `claude` CLI must be checked with `exec.LookPath` before execution
+
+## Best Practices
+
+- Error handling: wrap `exec.Command` errors with context, capture stderr separately
+- Naming: `ClaudeRunner`, `BuildSystemContext`, `fileMonitor`
+- Style: `slog.InfoContext` for progress, structured JSON report via `encoding/json`
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Unit | BuildSystemContext reads constitution + guardrails + dev-guide | context assembly |
+| Unit | ClaudeRunner.Name() returns "claude" | trivial |
+| Unit | ExecResult populated correctly on mock execution | result fields |
+| Unit | File monitor detects new files in git status | monitor goroutine |
+| Unit | ClaudeRunner fails gracefully when claude CLI not found | LookPath error |
+| Integration | Execute with real claude CLI (skip in CI) | optional, manual |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `ClaudeRunner` implements `Runner` interface (compile-time check)
+- [ ] `BuildSystemContext` assembles constitution + guardrails + dev-guide
+- [ ] Claude CLI invoked with `--append-system-prompt` and `-p` flags
+- [ ] `--dangerously-skip-permissions` used when `AutoApprove=true`
+- [ ] `--max-turns` passed from config
+- [ ] Log file written to `.forgia/logs/`
+- [ ] JSON report written with duration, exit code, status
+- [ ] File monitor shows created/modified files during execution
+- [ ] Graceful failure when `claude` not installed (clear error message)
+- [ ] `go build ./...` succeeds
+- [ ] 5+ tests pass
+
+## Context / Contesto
+
+- [ ] `modules/runners/claude.sh` — Bash runner to replicate (198 lines)
+- [ ] `internal/runner/runner.go` — Runner interface definition
+- [ ] `internal/runner/dryrun.go` — DryRunRunner (reference implementation)
+- [ ] `internal/process/spawn.go` — Spawn pattern with SIGTERM/SIGKILL
+- [ ] `internal/vault/file_vault.go` — Constitution(), GuardrailsRaw()
+- [ ] `internal/guardrails/guardrails.go` — Parse, Enforce
+
+## Constitution Check
+
+- [x] Respects code standards
+- [x] Respects commit conventions
+- [x] No hardcoded secrets (system context built from vault files, not hardcoded)
+- [x] Tests defined and sufficient
+
+## Guardrails
+
+The runner itself enforces guardrails before execution via `guardrails.Enforce()`. The system context includes deny.toml content so Claude is aware of restrictions.
+
+---
+
+## Work Log / Diario di Lavoro
+
+### Agent / Agente
+
+- **Executor**: <!-- openhands | claude-code | manual | name -->
+- **Started**: <!-- timestamp -->
+- **Completed**: <!-- timestamp -->
+- **Duration / Durata**: <!-- total time -->
+
+### Decisions / Decisioni
+
+1. <!-- decision 1: what and why -->
+
+### Output
+
+- **Commit(s)**: <!-- hash -->
+- **PR**: <!-- link -->
+- **Files created/modified**:
+  - `path/to/file`
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**:
+- **What didn't / Cosa non ha funzionato**:
+- **Suggestions for future FDs / Suggerimenti per FD futuri**:

--- a/.forgia/sdd/FD-001/SDD-006-forgia-exec-batch.md
+++ b/.forgia/sdd/FD-001/SDD-006-forgia-exec-batch.md
@@ -1,0 +1,143 @@
+---
+id: "SDD-006"
+fd: "FD-001"
+title: "forgia exec + forgia batch — execution commands"
+status: planned
+agent: ""
+assigned_to: ""
+created: "2026-03-28"
+started: ""
+completed: ""
+tags: [go, cli, exec, batch, cobra]
+---
+
+# SDD-006: forgia exec + forgia batch — execution commands
+
+> Parent FD: [[FD-001]]
+
+## Scope
+
+Create two Cobra commands:
+
+### `forgia exec` (`cmd/forgia/cmd/exec.go`)
+Execute a single SDD:
+1. Open vault, load config
+2. Parse SDD file (frontmatter + body)
+3. Pre-exec validation (delegate to SDD-004 validate logic)
+4. Load guardrails, enforce in configured mode
+5. Resolve runner from config or `--runner` flag
+6. Call `runner.Execute(ctx, sdd, opts)`
+7. Post-exec: update SDD work log with results
+8. Post-exec: update Beads task status if available
+9. Report: duration, exit code, files changed
+
+Flags: `--runner=claude|openhands`, `--dry-run`, `--mode=off|careful|freeze|guard`
+
+### `forgia batch` (`cmd/forgia/cmd/batch.go`)
+Execute all pending SDDs for an FD:
+1. Open vault, list SDDs in `.forgia/sdd/FD-NNN/`
+2. Filter: only `status: planned` or `status: validated`
+3. Order: by SDD number (SDD-001 before SDD-002), or by Beads dependency (`bd ready`) if available
+4. Sequential execution: call exec logic for each SDD, stop on failure
+5. Summary: N succeeded, M failed, K skipped
+
+Flags: same as exec + `--continue-on-error`
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| `execCmd` | `*cobra.Command` | `forgia exec <sdd-file> [flags]` |
+| `batchCmd` | `*cobra.Command` | `forgia batch <FD-NNN> [flags]` |
+| `runner.Runner` | existing interface | Execute(ctx, sdd, opts) |
+| `runner.ClaudeRunner` | from SDD-005 | Concrete runner |
+| `guardrails.Enforce()` | from SDD-004/existing | Pre-exec check |
+| `vault.UpdateSDD()` | existing | Write work log |
+| `beads.Client` | existing | Task status update |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Go 1.25+
+- Framework: Cobra
+- Dependencies / Dipendenze: `internal/vault`, `internal/config`, `internal/guardrails`, `internal/runner` (SDD-005), `internal/beads`
+- Patterns / Pattern:
+  - exec and batch share core logic — extract `runSDD(ctx, v, cfg, sdd, opts) error` helper
+  - batch uses sequential execution (parallel is #15, out of scope)
+  - `--dry-run` delegates to `runner.DryRunRunner`
+  - Work log update: set executor, started, completed, duration in SDD file
+
+## Best Practices
+
+- Error handling: exec returns the runner's exit code as process exit code. Batch aggregates results.
+- Naming: `runSDD` for shared logic, `execCmd`/`batchCmd` for Cobra commands
+- Style: progress output during execution (file monitor from SDD-005)
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Unit | Exec with mock runner succeeds | happy path |
+| Unit | Exec fails on invalid SDD (validation gate) | validation integration |
+| Unit | Exec fails on guardrail violation | guardrails integration |
+| Unit | Batch collects all pending SDDs in order | ordering |
+| Unit | Batch stops on first failure (default) | stop behavior |
+| Unit | Batch continues on error with --continue-on-error | flag behavior |
+| Unit | --dry-run flag routes to DryRunRunner | flag routing |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `forgia exec SDD.md` executes a single SDD
+- [ ] `forgia exec SDD.md --dry-run` simulates without modifying files
+- [ ] `forgia exec SDD.md --mode=guard` enforces boundaries
+- [ ] `forgia exec` validates SDD before execution (rejects invalid)
+- [ ] `forgia exec` updates SDD work log after execution
+- [ ] `forgia batch FD-001` executes all pending SDDs sequentially
+- [ ] `forgia batch` respects dependency order (if Beads available)
+- [ ] `forgia batch --continue-on-error` doesn't stop on first failure
+- [ ] Exit codes propagated correctly
+- [ ] `go build ./...` succeeds
+- [ ] 7+ tests pass
+
+## Context / Contesto
+
+- [ ] `bin/forgia` `cmd_exec()` — Bash exec implementation
+- [ ] `bin/forgia` `cmd_batch()` — Bash batch implementation
+- [ ] `internal/runner/claude.go` — from SDD-005
+- [ ] `internal/runner/dryrun.go` — existing DryRunRunner
+- [ ] `internal/guardrails/guardrails.go` — Enforce()
+- [ ] `cmd/forgia/cmd/sync.go` — reference for vault/config wiring
+
+## Constitution Check
+
+- [x] Respects code standards
+- [x] Respects commit conventions
+- [x] No hardcoded secrets
+- [x] Tests defined and sufficient
+
+---
+
+## Work Log / Diario di Lavoro
+
+### Agent / Agente
+
+- **Executor**: <!-- openhands | claude-code | manual | name -->
+- **Started**: <!-- timestamp -->
+- **Completed**: <!-- timestamp -->
+- **Duration / Durata**: <!-- total time -->
+
+### Decisions / Decisioni
+
+1. <!-- decision 1: what and why -->
+
+### Output
+
+- **Commit(s)**: <!-- hash -->
+- **PR**: <!-- link -->
+- **Files created/modified**:
+  - `path/to/file`
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**:
+- **What didn't / Cosa non ha funzionato**:
+- **Suggestions for future FDs / Suggerimenti per FD futuri**:

--- a/.forgia/sdd/FD-001/SDD-007-forgia-watch.md
+++ b/.forgia/sdd/FD-001/SDD-007-forgia-watch.md
@@ -1,0 +1,122 @@
+---
+id: "SDD-007"
+fd: "FD-001"
+title: "forgia watch — fsnotify watcher with auto-exec"
+status: planned
+agent: ""
+assigned_to: ""
+created: "2026-03-28"
+started: ""
+completed: ""
+tags: [go, cli, watch, fsnotify, cobra]
+---
+
+# SDD-007: forgia watch — fsnotify watcher with auto-exec
+
+> Parent FD: [[FD-001]]
+
+## Scope
+
+Create `cmd/forgia/cmd/watch.go` — Cobra command that watches `.forgia/sdd/FD-NNN/` for new or modified SDD files and auto-executes them.
+
+Behavior:
+1. Open vault, load config
+2. Set up `fsnotify` watcher on `.forgia/sdd/<FD-NNN>/` directory
+3. On file create/modify events: debounce for N seconds (configurable, default 5s)
+4. After debounce: check if the SDD has `status: planned` — if yes, execute via `runSDD()` (shared logic from SDD-006)
+5. After execution: update SDD status to done/failed
+6. Continue watching for more events
+7. Ctrl+C (SIGINT/SIGTERM) gracefully stops the watcher
+
+Flags: `--runner`, `--debounce=5s`, `--mode`
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| `watchCmd` | `*cobra.Command` | `forgia watch <FD-NNN> [flags]` |
+| `--debounce` | `time.Duration` | Debounce period (default 5s) |
+| `fsnotify.Watcher` | external | File system watcher |
+| `runSDD()` | from SDD-006 | Shared exec logic |
+| `process.ShutdownManager` | existing | Graceful shutdown |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Go 1.25+
+- Framework: Cobra, `github.com/fsnotify/fsnotify`
+- Dependencies / Dipendenze: `internal/vault`, `internal/config`, `internal/runner` (SDD-005), `internal/process`, fsnotify
+- Patterns / Pattern:
+  - Debounce with `time.AfterFunc` reset on each event
+  - Context cancellation for graceful shutdown
+  - Only trigger on `.md` and `.yaml` files (ignore temp files, .swp, etc.)
+  - Filter: only process SDDs with `status: planned`
+
+## Best Practices
+
+- Error handling: log watcher errors but continue watching (don't exit on transient errors)
+- Naming: `watchCmd`, `debounceExec`
+- Style: clear terminal output showing "Watching...", "Found SDD...", "Executing..."
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Unit | Debounce logic: multiple events within window produce single exec | timer reset |
+| Unit | File filter: .md triggers, .swp ignored | filter logic |
+| Unit | Graceful shutdown on context cancel | shutdown path |
+| Unit | Only planned SDDs trigger execution | status filter |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `forgia watch FD-001` starts watching the SDD directory
+- [ ] New SDD file with `status: planned` triggers execution after debounce
+- [ ] Modified SDD with `status: planned` triggers execution
+- [ ] SDD with `status: done` is ignored
+- [ ] `--debounce` flag configures wait time
+- [ ] Ctrl+C stops gracefully (no zombie processes)
+- [ ] Temporary files (.swp, ~, .tmp) are ignored
+- [ ] `go build ./...` succeeds
+- [ ] 4+ tests pass
+
+## Context / Contesto
+
+- [ ] `bin/forgia` `cmd_watch()` — Bash watch implementation
+- [ ] `internal/process/signals.go` — ShutdownManager
+- [ ] `internal/process/spawn.go` — Spawn with context cancellation
+- [ ] `cmd/forgia/cmd/exec.go` — runSDD shared logic (from SDD-006)
+- [ ] fsnotify docs: https://pkg.go.dev/github.com/fsnotify/fsnotify
+
+## Constitution Check
+
+- [x] Respects code standards
+- [x] Respects commit conventions
+- [x] No hardcoded secrets
+- [x] Tests defined and sufficient
+
+---
+
+## Work Log / Diario di Lavoro
+
+### Agent / Agente
+
+- **Executor**: <!-- openhands | claude-code | manual | name -->
+- **Started**: <!-- timestamp -->
+- **Completed**: <!-- timestamp -->
+- **Duration / Durata**: <!-- total time -->
+
+### Decisions / Decisioni
+
+1. <!-- decision 1: what and why -->
+
+### Output
+
+- **Commit(s)**: <!-- hash -->
+- **PR**: <!-- link -->
+- **Files created/modified**:
+  - `path/to/file`
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**:
+- **What didn't / Cosa non ha funzionato**:
+- **Suggestions for future FDs / Suggerimenti per FD futuri**:

--- a/.forgia/sdd/FD-001/SDD-008-forgia-skill.md
+++ b/.forgia/sdd/FD-001/SDD-008-forgia-skill.md
@@ -1,0 +1,136 @@
+---
+id: "SDD-008"
+fd: "FD-001"
+title: "forgia skill — skill registry + embedded command loader"
+status: planned
+agent: ""
+assigned_to: ""
+created: "2026-03-28"
+started: ""
+completed: ""
+tags: [go, cli, skill, embed, cobra]
+---
+
+# SDD-008: forgia skill — skill registry + embedded command loader
+
+> Parent FD: [[FD-001]]
+
+## Scope
+
+Create `cmd/forgia/cmd/skill.go` and wire `internal/skill/` to the embedded slash commands from SDD-001.
+
+### `forgia skill <name> [args]`
+Execute an embedded slash command via Claude CLI:
+1. Look up command by name in `embedded.SlashCommandFS()`
+2. Read the markdown content
+3. Build system context (constitution + guardrails + dev-guide) using `runner.BuildSystemContext()` from SDD-005
+4. Replace `$ARGUMENTS` placeholder in the markdown with the provided args
+5. Invoke Claude CLI with the command as task prompt + system context
+6. Stream output to terminal
+
+### `forgia skills`
+List all available slash commands with descriptions (first line of each markdown file).
+
+### Skill Registry (`internal/skill/registry.go`)
+Wire the existing `Skill` interface to embedded commands:
+- `EmbeddedSkill` struct: loads from `embed.FS`, implements `Skill` interface
+- `Registry.LoadEmbedded(fs.FS)` — populate registry from embedded filesystem
+- `Registry.Get(name)` — lookup by name
+- `Registry.List()` — all registered skills
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| `skillCmd` | `*cobra.Command` | `forgia skill <name> [args]` |
+| `skillsCmd` | `*cobra.Command` | `forgia skills` (list) |
+| `EmbeddedSkill` | `struct` implementing `Skill` | Wraps a markdown file |
+| `Registry.LoadEmbedded(fs)` | `func(fs.FS) error` | Populates registry |
+| `Registry.Get(name)` | `func(string) (Skill, error)` | Lookup |
+| `Registry.List()` | `func() []Skill` | All skills |
+| `embedded.SlashCommandFS()` | from SDD-001 | Source of commands |
+| `runner.BuildSystemContext()` | from SDD-005 | Context builder |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Go 1.25+
+- Framework: Cobra, `io/fs`
+- Dependencies / Dipendenze: `internal/embedded` (SDD-001), `internal/skill`, `internal/runner` (SDD-005), `internal/vault`
+- Patterns / Pattern:
+  - Skills are invoked via Claude CLI (same as current slash commands)
+  - `$ARGUMENTS` placeholder in markdown is replaced before invocation
+  - Some skills may become native Go in the future (fd-status, sdd-status) — the registry should support both embedded and native skills
+- Read-only: `forgia skills` never modifies anything
+- `forgia skill` may modify vault files (e.g., `/fd-new` creates files) — this is expected
+
+## Best Practices
+
+- Error handling: unknown skill name → clear error with list of available skills
+- Naming: `EmbeddedSkill`, `NativeSkill` (future), `Registry`
+- Style: `forgia skills` output in table format (name, first-line description)
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Unit | Registry.LoadEmbedded loads all commands from test FS | loading |
+| Unit | Registry.Get returns correct skill | lookup |
+| Unit | Registry.Get returns error for unknown name | error path |
+| Unit | Registry.List returns all skills | list |
+| Unit | EmbeddedSkill.Content() returns markdown with args substituted | substitution |
+| Unit | skillsCmd lists all skills | CLI integration |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `forgia skills` lists all embedded slash commands
+- [ ] `forgia skill fd-status` executes the fd-status command via Claude
+- [ ] `forgia skill fd-new "some description"` passes args correctly
+- [ ] Unknown skill name returns helpful error with available skills list
+- [ ] System context (constitution + guardrails) automatically included
+- [ ] `EmbeddedSkill` implements existing `Skill` interface
+- [ ] `Registry` populated from `embedded.SlashCommandFS()`
+- [ ] `go build ./...` succeeds
+- [ ] 6+ tests pass
+
+## Context / Contesto
+
+- [ ] `internal/skill/skill.go` — existing Skill interface and Registry
+- [ ] `modules/claude-commands/` — current markdown slash commands
+- [ ] `internal/embedded/` — from SDD-001
+- [ ] `internal/runner/claude.go` — from SDD-005 (BuildSystemContext)
+- [ ] Current usage: commands are installed to `~/.claude/commands/` — this replaces that with embedded execution
+
+## Constitution Check
+
+- [x] Respects code standards
+- [x] Respects commit conventions
+- [x] No hardcoded secrets
+- [x] Tests defined and sufficient
+
+---
+
+## Work Log / Diario di Lavoro
+
+### Agent / Agente
+
+- **Executor**: <!-- openhands | claude-code | manual | name -->
+- **Started**: <!-- timestamp -->
+- **Completed**: <!-- timestamp -->
+- **Duration / Durata**: <!-- total time -->
+
+### Decisions / Decisioni
+
+1. <!-- decision 1: what and why -->
+
+### Output
+
+- **Commit(s)**: <!-- hash -->
+- **PR**: <!-- link -->
+- **Files created/modified**:
+  - `path/to/file`
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**:
+- **What didn't / Cosa non ha funzionato**:
+- **Suggestions for future FDs / Suggerimenti per FD futuri**:

--- a/.forgia/sdd/FD-001/SDD-009-bash-deprecation.md
+++ b/.forgia/sdd/FD-001/SDD-009-bash-deprecation.md
@@ -1,0 +1,139 @@
+---
+id: "SDD-009"
+fd: "FD-001"
+title: "Bash deprecation — banner, install.sh, README, E2E migration"
+status: planned
+agent: ""
+assigned_to: ""
+created: "2026-03-28"
+started: ""
+completed: ""
+tags: [go, bash, deprecation, docs]
+---
+
+# SDD-009: Bash deprecation — banner, install.sh, README, E2E migration
+
+> Parent FD: [[FD-001]]
+
+## Scope
+
+Final step: deprecate the Bash CLI and point everything to the Go binary.
+
+### 1. Deprecation banner in `bin/forgia`
+Add at the top of `bin/forgia` (after shebang):
+```bash
+echo "⚠  bin/forgia is DEPRECATED. Use the Go binary: go install github.com/Deepzima/forgia/cmd/forgia@latest" >&2
+echo "   Or: mise run go:build && build/forgia <command>" >&2
+echo "" >&2
+```
+Keep the Bash CLI functional for 1 release cycle.
+
+### 2. Update `install.sh`
+- Primary installation: download Go binary from GitHub Releases
+- Remove `bin/forgia` from PATH setup
+- Keep `modules/claude-commands/` install for backward compatibility (users who haven't updated)
+
+### 3. Update `README.md`
+- Quick Start: use Go binary commands
+- Replace `bin/forgia` references with `forgia` (Go binary)
+- Add "Migration from Bash CLI" section
+
+### 4. Update `mise.toml`
+- `mise run forgia:*` tasks point to Go binary instead of `bin/forgia`
+- Keep `mise run test` for E2E (but note it tests Go binary now)
+
+### 5. E2E test migration
+- Update `tests/e2e-beads-autospec.sh` to test Go binary instead of `bin/forgia`
+- `FORGIA` variable points to `build/forgia` instead of `$ROOT_DIR/bin/forgia`
+- Add new E2E tests for Go-only features (skill, validate improvements)
+
+### 6. Remove Bash runner
+- Delete `modules/runners/validate-sdd.sh` (replaced by Go `forgia validate`)
+- Keep `modules/runners/claude.sh` for now (Go runner is SDD-005, but may need fallback)
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| `bin/forgia` | Bash script | Add deprecation banner |
+| `install.sh` | Bash script | Switch to Go binary download |
+| `README.md` | Markdown | Update Quick Start and references |
+| `mise.toml` | TOML | Point tasks to Go binary |
+| `tests/e2e*.sh` | Bash tests | Use Go binary |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Bash (modifications), Markdown (docs)
+- Dependencies / Dipendenze: all SDD-001 through SDD-008 must be complete
+- Patterns / Pattern: deprecation, not removal — keep bin/forgia functional
+- DO NOT delete `modules/claude-commands/` — they're still the source for `go:embed`
+- DO NOT delete `modules/vault-template/` — they're still the source for `go:embed`
+
+## Best Practices
+
+- Error handling: deprecation banner goes to stderr (not stdout) to not break piped output
+- Naming: n/a
+- Style: clear, actionable deprecation message with migration instructions
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| E2E | All existing e2e tests pass with Go binary | regression |
+| E2E | `forgia init` + `forgia status` + `forgia validate` round-trip | integration |
+| Unit | Deprecation banner appears when running bin/forgia | banner present |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `bin/forgia` shows deprecation banner on every invocation
+- [ ] `install.sh` downloads Go binary from GitHub Releases
+- [ ] `README.md` Quick Start uses Go binary
+- [ ] `mise.toml` tasks use Go binary
+- [ ] E2E tests pass against Go binary
+- [ ] `modules/runners/validate-sdd.sh` removed
+- [ ] No functionality regression
+- [ ] `go build ./...` still succeeds
+
+## Context / Contesto
+
+- [ ] `bin/forgia` — current Bash CLI (add banner)
+- [ ] `install.sh` — current installer
+- [ ] `README.md` — current docs
+- [ ] `mise.toml` — task definitions
+- [ ] `tests/e2e*.sh` — E2E test files
+- [ ] `modules/runners/validate-sdd.sh` — to delete
+
+## Constitution Check
+
+- [x] Respects code standards
+- [x] Respects commit conventions
+- [x] No hardcoded secrets
+- [x] Tests defined and sufficient
+
+---
+
+## Work Log / Diario di Lavoro
+
+### Agent / Agente
+
+- **Executor**: <!-- openhands | claude-code | manual | name -->
+- **Started**: <!-- timestamp -->
+- **Completed**: <!-- timestamp -->
+- **Duration / Durata**: <!-- total time -->
+
+### Decisions / Decisioni
+
+1. <!-- decision 1: what and why -->
+
+### Output
+
+- **Commit(s)**: <!-- hash -->
+- **PR**: <!-- link -->
+- **Files created/modified**:
+  - `path/to/file`
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**:
+- **What didn't / Cosa non ha funzionato**:
+- **Suggestions for future FDs / Suggerimenti per FD futuri**:

--- a/.forgia/sdd/_templates/sdd-template.md
+++ b/.forgia/sdd/_templates/sdd-template.md
@@ -1,0 +1,121 @@
+---
+id: "{{SDD_ID}}"
+fd: "{{FD_ID}}"
+title: "{{TITLE}}"
+status: planned
+agent: ""
+assigned_to: ""
+created: "{{DATE}}"
+started: ""
+completed: ""
+tags: []
+---
+
+# {{SDD_ID}}: {{TITLE}}
+
+> Parent FD: [[{{FD_ID}}]]
+
+## Scope
+
+<!-- EN: What to build. Derived from the FD. Precise, unambiguous. -->
+<!-- IT: Cosa costruire. Derivato dal FD. Preciso, non ambiguo. -->
+
+## Interfaces / Interfacce
+
+<!-- EN: Input/output, types, traits, API endpoints, schema -->
+<!-- IT: Input/output, tipi, trait, API endpoint, schema -->
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| | | |
+
+## Constraints / Vincoli
+
+<!-- EN: Language, framework, versions, required patterns, dependencies -->
+<!-- IT: Linguaggio, framework, versioni, pattern obbligatori, dipendenze -->
+
+- Language / Linguaggio:
+- Framework:
+- Dependencies / Dipendenze:
+- Patterns / Pattern:
+
+## Best Practices
+
+<!-- EN: Error handling, naming, style specific to this component -->
+<!-- IT: Error handling, naming, style specifici per questo componente -->
+
+- Error handling:
+- Naming:
+- Style:
+
+## Test Requirements
+
+<!-- EN: What to test, expected coverage, test types -->
+<!-- IT: Cosa testare, coverage atteso, tipi di test -->
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Unit | | |
+| Integration | | |
+| E2E | | |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+<!-- EN: When the work is "done". Each criterion must be verifiable. -->
+<!-- IT: Quando il lavoro e' "done". Ogni criterio deve essere verificabile. -->
+
+- [ ] <!-- criterion 1 / criterio 1 -->
+- [ ] <!-- criterion 2 / criterio 2 -->
+- [ ] <!-- criterion 3 / criterio 3 -->
+
+## Context / Contesto
+
+<!-- EN: Files to read, docs to consult, existing code to understand -->
+<!-- IT: File da leggere, doc da consultare, codice esistente da capire -->
+
+- [ ] `path/to/file`
+- [ ] `docs/reference`
+
+## Constitution Check
+
+<!-- EN: Verify this SDD respects the project constitution -->
+<!-- IT: Verifica che questo SDD rispetti la constitution del progetto -->
+
+- [ ] Respects code standards / Rispetta le code standards
+- [ ] Respects commit conventions / Rispetta le commit conventions
+- [ ] No hardcoded secrets / Nessun secret hardcoded
+- [ ] Tests defined and sufficient / Test definiti e sufficienti
+
+---
+
+## Work Log / Diario di Lavoro
+
+> EN: This section is **mandatory**. Must be filled by the agent or developer during and after execution.
+> IT: Questa sezione e' **obbligatoria**. Deve essere compilata dall'agent o dallo sviluppatore durante e dopo l'esecuzione.
+
+### Agent / Agente
+
+- **Executor**: <!-- openhands | claude-code | manual | name -->
+- **Started**: <!-- timestamp -->
+- **Completed**: <!-- timestamp -->
+- **Duration / Durata**: <!-- total time -->
+
+### Decisions / Decisioni
+
+<!-- EN: Deviations from plan, problems encountered, choices made during implementation -->
+<!-- IT: Deviazioni dal piano, problemi incontrati, scelte fatte durante l'implementazione -->
+
+1. <!-- decision 1: what and why / decisione 1: cosa e perche' -->
+
+### Output
+
+- **Commit(s)**: <!-- hash -->
+- **PR**: <!-- link -->
+- **Files created/modified**:
+  - `path/to/file`
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**:
+- **What didn't / Cosa non ha funzionato**:
+- **Suggestions for future FDs / Suggerimenti per FD futuri**:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ modules/openhands/config.toml
 
 # Go build output
 build/
+
+# Dolt database files (added by bd init)
+.dolt/
+*.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,150 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work atomically
+bd close <id>         # Complete work
+bd dolt push          # Push beads data to remote
+```
+
+## Non-Interactive Shell Commands
+
+**ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.
+
+Shell commands like `cp`, `mv`, and `rm` may be aliased to include `-i` (interactive) mode on some systems, causing the agent to hang indefinitely waiting for y/n input.
+
+**Use these forms instead:**
+```bash
+# Force overwrite without prompting
+cp -f source dest           # NOT: cp source dest
+mv -f source dest           # NOT: mv source dest
+rm -f file                  # NOT: rm file
+
+# For recursive operations
+rm -rf directory            # NOT: rm -r directory
+cp -rf source dest          # NOT: cp -r source dest
+```
+
+**Other commands that may prompt:**
+- `scp` - use `-o BatchMode=yes` for non-interactive
+- `ssh` - use `-o BatchMode=yes` to fail instead of prompting
+- `apt-get` - use `-y` flag
+- `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
+
+<!-- BEGIN BEADS INTEGRATION -->
+## Issue Tracking with bd (beads)
+
+**IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
+
+### Why bd?
+
+- Dependency-aware: Track blockers and relationships between issues
+- Version-controlled: Built on Dolt with cell-level merge
+- Agent-optimized: JSON output, ready work detection, discovered-from links
+- Prevents duplicate tracking systems and confusion
+
+### Quick Start
+
+**Check for ready work:**
+
+```bash
+bd ready --json
+```
+
+**Create new issues:**
+
+```bash
+bd create "Issue title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
+bd create "Issue title" --description="What this issue is about" -p 1 --deps discovered-from:bd-123 --json
+```
+
+**Claim and update:**
+
+```bash
+bd update <id> --claim --json
+bd update bd-42 --priority 1 --json
+```
+
+**Complete work:**
+
+```bash
+bd close bd-42 --reason "Completed" --json
+```
+
+### Issue Types
+
+- `bug` - Something broken
+- `feature` - New functionality
+- `task` - Work item (tests, docs, refactoring)
+- `epic` - Large feature with subtasks
+- `chore` - Maintenance (dependencies, tooling)
+
+### Priorities
+
+- `0` - Critical (security, data loss, broken builds)
+- `1` - High (major features, important bugs)
+- `2` - Medium (default, nice-to-have)
+- `3` - Low (polish, optimization)
+- `4` - Backlog (future ideas)
+
+### Workflow for AI Agents
+
+1. **Check ready work**: `bd ready` shows unblocked issues
+2. **Claim your task atomically**: `bd update <id> --claim`
+3. **Work on it**: Implement, test, document
+4. **Discover new work?** Create linked issue:
+   - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
+5. **Complete**: `bd close <id> --reason "Done"`
+
+### Auto-Sync
+
+bd automatically syncs with git:
+
+- Exports to `.beads/issues.jsonl` after changes (5s debounce)
+- Imports from JSONL when newer (e.g., after `git pull`)
+- No manual export/import needed!
+
+### Important Rules
+
+- ✅ Use bd for ALL task tracking
+- ✅ Always use `--json` flag for programmatic use
+- ✅ Link discovered work with `discovered-from` dependencies
+- ✅ Check `bd ready` before asking "what should I work on?"
+- ❌ Do NOT create markdown TODO lists
+- ❌ Do NOT use external issue trackers
+- ❌ Do NOT duplicate tracking systems
+
+For more details, see README.md and docs/QUICKSTART.md.
+
+## Landing the Plane (Session Completion)
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+
+<!-- END BEADS INTEGRATION -->

--- a/bin/forgia
+++ b/bin/forgia
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# ============================================================
+# DEPRECATED — Use the Go binary instead:
+#   go install github.com/Deepzima/forgia/cmd/forgia@latest
+#   Or: mise run go:build && build/forgia <command>
+#
+# This Bash CLI will be removed in a future release.
+# ============================================================
+echo "WARNING: bin/forgia is DEPRECATED. Use the Go binary: build/forgia or go install github.com/Deepzima/forgia/cmd/forgia@latest" >&2
+echo "" >&2
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VAULT_DIR=".forgia"
 

--- a/cmd/forgia/cmd/doctor.go
+++ b/cmd/forgia/cmd/doctor.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os/exec"
+
+	"github.com/Deepzima/forgia/internal/config"
+	"github.com/Deepzima/forgia/internal/guardrails"
+	"github.com/Deepzima/forgia/internal/vault"
+	"github.com/spf13/cobra"
+)
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Check system health",
+	Long:  "Verifies vault, tools, and configuration are set up correctly.",
+	RunE:  runDoctor,
+}
+
+func init() {
+	rootCmd.AddCommand(doctorCmd)
+}
+
+type checkResult struct {
+	name   string
+	status string // "pass", "fail", "skip"
+	detail string
+}
+
+func runDoctor(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	logger := slog.With("command", "doctor")
+
+	fmt.Println("=== Forgia Doctor ===")
+	fmt.Println()
+
+	var results []checkResult
+
+	// 1. Vault exists and is valid.
+	results = append(results, checkVault(ctx))
+
+	// 2. Config parseable.
+	results = append(results, checkConfig(ctx))
+
+	// 3. Guardrails parseable.
+	results = append(results, checkGuardrails(ctx))
+
+	// 4. Required tools.
+	results = append(results, checkTool("git", true))
+	results = append(results, checkTool("claude", true))
+
+	// 5. Optional tools.
+	results = append(results, checkTool("docker", false))
+	results = append(results, checkTool("bd", false))
+	results = append(results, checkTool("fswatch", false))
+	results = append(results, checkTool("yq", false))
+
+	// Print results.
+	var failures int
+	for _, r := range results {
+		icon := "✓"
+		if r.status == "fail" {
+			icon = "✗"
+			failures++
+		} else if r.status == "skip" {
+			icon = "○"
+		}
+		if r.detail != "" {
+			fmt.Printf("  %s %s — %s\n", icon, r.name, r.detail)
+		} else {
+			fmt.Printf("  %s %s\n", icon, r.name)
+		}
+	}
+
+	fmt.Println()
+	if failures > 0 {
+		fmt.Printf("%d issue(s) found.\n", failures)
+		logger.WarnContext(ctx, "doctor found issues", "failures", failures)
+	} else {
+		fmt.Println("All checks passed.")
+	}
+
+	// Doctor always exits 0 — it reports, doesn't fail.
+	return nil
+}
+
+func checkVault(ctx context.Context) checkResult {
+	_, err := vault.Open(".")
+	if err != nil {
+		return checkResult{"vault", "fail", "not found — run 'forgia init'"}
+	}
+	return checkResult{"vault", "pass", ".forgia/ found and valid"}
+}
+
+func checkConfig(ctx context.Context) checkResult {
+	_, err := config.LoadConfig(ctx, ".forgia")
+	if err != nil {
+		return checkResult{"config", "fail", fmt.Sprintf("config.toml: %v", err)}
+	}
+	return checkResult{"config", "pass", "config.toml parsed"}
+}
+
+func checkGuardrails(ctx context.Context) checkResult {
+	v, err := vault.Open(".")
+	if err != nil {
+		return checkResult{"guardrails", "skip", "vault not available"}
+	}
+	data, err := v.GuardrailsRaw(ctx)
+	if err != nil {
+		return checkResult{"guardrails", "fail", fmt.Sprintf("deny.toml: %v", err)}
+	}
+	_, err = guardrails.Parse(data)
+	if err != nil {
+		return checkResult{"guardrails", "fail", fmt.Sprintf("deny.toml parse: %v", err)}
+	}
+	return checkResult{"guardrails", "pass", "deny.toml parsed"}
+}
+
+func checkTool(name string, required bool) checkResult {
+	_, err := exec.LookPath(name)
+	if err != nil {
+		if required {
+			return checkResult{name, "fail", "not found in PATH"}
+		}
+		return checkResult{name, "skip", "not found (optional)"}
+	}
+	return checkResult{name, "pass", ""}
+}

--- a/cmd/forgia/cmd/exec.go
+++ b/cmd/forgia/cmd/exec.go
@@ -2,85 +2,180 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/Deepzima/forgia/internal/config"
+	"github.com/Deepzima/forgia/internal/guardrails"
 	"github.com/Deepzima/forgia/internal/runner"
 	"github.com/Deepzima/forgia/internal/vault"
 	"github.com/spf13/cobra"
 )
 
-var execDryRun bool
-var execRunner string
+var (
+	execDryRun bool
+	execRunner string
+	execMode   string
+)
 
 var execCmd = &cobra.Command{
-	Use:   "exec <sdd-file> [--runner=claude|openhands] [--dry-run]",
+	Use:   "exec <sdd-file>",
 	Short: "Execute an SDD (or simulate with --dry-run)",
-	Long:  "Execute an SDD using the specified runner. With --dry-run, runs a feasibility simulation via Claude without modifying any files.",
+	Long:  "Validates, checks guardrails, then executes an SDD via the configured runner.",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		sddFile := args[0]
-
-		if _, err := os.Stat(sddFile); os.IsNotExist(err) {
-			return fmt.Errorf("SDD non trovato: %s", sddFile)
-		}
-
-		if execDryRun {
-			if execRunner != "" {
-				fmt.Fprintln(cmd.OutOrStdout(), "Nota: --runner ignorato durante dry-run (la simulazione usa Claude)")
-			}
-			return runExecDryRun(cmd, sddFile)
-		}
-
-		// Normal execution
-		resolvedRunner := execRunner
-		if resolvedRunner == "" {
-			resolvedRunner = "claude"
-		}
-
-		r, err := runner.Resolve(resolvedRunner)
-		if err != nil {
-			return err
-		}
-
-		sdd := &vault.SDD{FilePath: sddFile}
-		result, err := r.Execute(cmd.Context(), sdd, runner.ExecOptions{})
-		if err != nil {
-			return fmt.Errorf("esecuzione fallita: %w", err)
-		}
-
-		if result.ExitCode != 0 {
-			return fmt.Errorf("runner terminato con codice %d", result.ExitCode)
-		}
-		return nil
+		return execSDD(cmd, args[0])
 	},
 }
 
-func runExecDryRun(cmd *cobra.Command, sddFile string) error {
-	slashCmd := filepath.Join("modules", "claude-commands", "sdd-dry-run.md")
-	if _, err := os.Stat(slashCmd); os.IsNotExist(err) {
-		return fmt.Errorf("sdd-dry-run.md non trovato — esegui prima SDD-001 di FD-012")
+func init() {
+	execCmd.Flags().BoolVar(&execDryRun, "dry-run", false, "Simulate execution without modifying files")
+	execCmd.Flags().StringVar(&execRunner, "runner", "", "Runner backend (claude, dry-run)")
+	execCmd.Flags().StringVar(&execMode, "mode", "", "Guardrail mode (off, careful, freeze, guard)")
+	rootCmd.AddCommand(execCmd)
+}
+
+// execSDD is the shared execution logic used by both exec and batch commands.
+func execSDD(cmd *cobra.Command, sddFile string) error {
+	ctx := cmd.Context()
+	logger := slog.With("command", "exec")
+
+	if _, err := os.Stat(sddFile); os.IsNotExist(err) {
+		return fmt.Errorf("SDD not found: %s", sddFile)
 	}
 
-	sdd := &vault.SDD{FilePath: sddFile}
+	// Open vault.
+	v, err := vault.Open(".")
+	if err != nil {
+		return fmt.Errorf("vault: %w", err)
+	}
 
-	result, err := runner.DryRun(cmd.Context(), sdd, runner.DryRunOptions{
-		SlashCommandPath: slashCmd,
-	})
+	// Load config.
+	cfg, err := config.LoadConfig(ctx, v.Dir())
+	if err != nil {
+		logger.WarnContext(ctx, "config not loaded, using defaults", "error", err)
+	}
+
+	// Pre-exec validation.
+	gData, _ := v.GuardrailsRaw(ctx)
+	g, _ := guardrails.Parse(gData)
+	if g == nil {
+		g = &guardrails.Guardrails{}
+	}
+
+	errors := validateSDD(ctx, v, g, sddFile)
+	if len(errors) > 0 {
+		fmt.Println("Validation failed:")
+		for _, e := range errors {
+			fmt.Printf("  %s\n", e)
+		}
+		return fmt.Errorf("validation failed: %d error(s)", len(errors))
+	}
+
+	// Build SDD struct.
+	data, _ := os.ReadFile(sddFile)
+	content := string(data)
+	sddID := strings.Trim(extractFrontmatterValue(content, "id:"), "\"' ")
+	fdID := strings.Trim(extractFrontmatterValue(content, "fd:"), "\"' ")
+
+	sdd, err := v.GetSDD(ctx, fdID, sddID)
+	if err != nil {
+		sdd = &vault.SDD{ID: sddID, FD: fdID, FilePath: sddFile}
+	}
+
+	// Dry-run path.
+	if execDryRun {
+		slashCmd := filepath.Join("modules", "claude-commands", "sdd-dry-run.md")
+		if _, err := os.Stat(slashCmd); os.IsNotExist(err) {
+			// Fallback: use DryRunRunner.
+			r := runner.NewDryRunRunner()
+			result, err := r.Execute(ctx, sdd, runner.ExecOptions{})
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Dry-run: %s — %s\n", result.SDD, result.Status)
+			return nil
+		}
+		result, err := runner.DryRun(ctx, sdd, runner.DryRunOptions{SlashCommandPath: slashCmd})
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), result.ReportText)
+		if !result.IsGo() {
+			return fmt.Errorf("dry-run: NO-GO")
+		}
+		return nil
+	}
+
+	// Guardrails enforcement.
+	mode := guardrails.ParseMode(execMode)
+	if mode != guardrails.ModeOff {
+		violations := g.Enforce(ctx, mode, guardrails.EnforceOpts{
+			WriteDirs:     sdd.Boundaries.WriteDirs,
+			ForbiddenDirs: sdd.Boundaries.ForbiddenDirs,
+		})
+		if len(violations) > 0 {
+			fmt.Println("Guardrail violations:")
+			for _, v := range violations {
+				fmt.Printf("  %s\n", v.Error())
+			}
+			return fmt.Errorf("guardrails blocked execution: %d violation(s)", len(violations))
+		}
+	}
+
+	// Resolve runner.
+	resolvedRunner := execRunner
+	if resolvedRunner == "" && cfg != nil {
+		resolvedRunner = cfg.Runner.Default
+	}
+	if resolvedRunner == "" {
+		resolvedRunner = "claude"
+	}
+
+	r, err := runner.Resolve(resolvedRunner)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintln(cmd.OutOrStdout(), result.ReportText)
+	// Build system context.
+	systemCtx, err := runner.BuildSystemContext(ctx, v)
+	if err != nil {
+		logger.WarnContext(ctx, "failed to build system context", "error", err)
+	}
 
-	if !result.IsGo() {
-		return fmt.Errorf("dry-run: NO-GO")
+	maxTurns := 200
+	if cfg != nil && cfg.Runner.Claude.MaxTurns > 0 {
+		maxTurns = cfg.Runner.Claude.MaxTurns
+	}
+
+	opts := runner.ExecOptions{
+		PermissionMode: "auto",
+		MaxTurns:       maxTurns,
+		SystemContext:   systemCtx,
+	}
+
+	fmt.Printf("→ Executing %s with runner: %s\n", sddID, r.Name())
+	result, execErr := r.Execute(ctx, sdd, opts)
+
+	if result != nil {
+		fmt.Printf("\n=== Execution Complete ===\n")
+		fmt.Printf("  SDD:      %s\n", result.SDD)
+		fmt.Printf("  Duration: %ds\n", result.DurationSecs)
+		fmt.Printf("  Status:   %s\n", result.Status)
+	}
+
+	// Update SDD status.
+	if result != nil && result.Status == "success" {
+		sdd.Status = vault.SDDDone
+		if err := v.UpdateSDD(ctx, sdd); err != nil {
+			logger.WarnContext(ctx, "failed to update SDD status", "error", err)
+		}
+	}
+
+	if execErr != nil {
+		return fmt.Errorf("execution failed: %w", execErr)
 	}
 	return nil
-}
-
-func init() {
-	execCmd.Flags().BoolVar(&execDryRun, "dry-run", false, "Simula esecuzione senza modificare file")
-	execCmd.Flags().StringVar(&execRunner, "runner", "", "Runner da usare (claude|openhands)")
-	rootCmd.AddCommand(execCmd)
 }

--- a/cmd/forgia/cmd/init.go
+++ b/cmd/forgia/cmd/init.go
@@ -1,0 +1,198 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	forgia "github.com/Deepzima/forgia"
+	"github.com/Deepzima/forgia/internal/beads"
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize a Forgia vault in the current project",
+	Long:  "Scaffolds .forgia/ with templates, dev-guide, guardrails, and optional beads integration.",
+	RunE:  runInit,
+}
+
+func init() {
+	initCmd.Flags().String("dir", ".", "Target directory")
+	rootCmd.AddCommand(initCmd)
+}
+
+func runInit(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	dir, _ := cmd.Flags().GetString("dir")
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("resolve path: %w", err)
+	}
+
+	logger := slog.With("command", "init")
+	forgiaDir := filepath.Join(dir, ".forgia")
+
+	// Check if vault already exists.
+	if info, err := os.Stat(forgiaDir); err == nil && info.IsDir() {
+		logger.InfoContext(ctx, "vault already exists, updating templates", "dir", forgiaDir)
+	} else {
+		logger.InfoContext(ctx, "scaffolding vault", "dir", forgiaDir)
+	}
+
+	// Copy all files from embedded vault template.
+	templateFS := forgia.VaultTemplateFS()
+	created, skipped, err := copyEmbeddedFS(ctx, templateFS, forgiaDir)
+	if err != nil {
+		return fmt.Errorf("copy templates: %w", err)
+	}
+	logger.InfoContext(ctx, "templates copied", "created", created, "skipped", skipped)
+
+	// Create required directories that may be empty (not in templates).
+	for _, d := range []string{"logs"} {
+		if err := os.MkdirAll(filepath.Join(forgiaDir, d), 0o755); err != nil {
+			return fmt.Errorf("create dir %s: %w", d, err)
+		}
+	}
+
+	// Auto-detect project stack and copy language conventions.
+	langs := detectStack(dir)
+	logger.InfoContext(ctx, "detected languages", "languages", langs)
+
+	// Create .gitignore for .forgia/.
+	gitignorePath := filepath.Join(forgiaDir, ".gitignore")
+	if _, err := os.Stat(gitignorePath); os.IsNotExist(err) {
+		gitignore := "# Local-only files\nlogs/\nrun/\n"
+		if err := os.WriteFile(gitignorePath, []byte(gitignore), 0o644); err != nil {
+			return fmt.Errorf("write .gitignore: %w", err)
+		}
+		logger.InfoContext(ctx, "created .gitignore")
+	}
+
+	// Create .github/CODEOWNERS if not exists.
+	codeownersPath := filepath.Join(dir, ".github", "CODEOWNERS")
+	if _, err := os.Stat(codeownersPath); os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Join(dir, ".github"), 0o755); err == nil {
+			codeowners := "# Forgia vault — requires review for changes\n.forgia/ @Deepzima\n"
+			os.WriteFile(codeownersPath, []byte(codeowners), 0o644)
+			logger.InfoContext(ctx, "created CODEOWNERS")
+		}
+	}
+
+	// Beads init (optional).
+	initBeads(ctx, dir, logger)
+
+	// Summary.
+	fmt.Println()
+	fmt.Printf("✓ Vault scaffolded at %s\n", forgiaDir)
+	fmt.Println()
+	fmt.Println("Next steps:")
+	fmt.Println("  1. Edit .forgia/constitution.md with your project rules")
+	fmt.Println("  2. Review .forgia/dev-guide/lang/ conventions for your stack")
+	fmt.Println("  3. Commit .forgia/ to share with your team")
+	fmt.Println("  4. Use: forgia skill fd-new to create your first Feature Design")
+
+	return nil
+}
+
+// copyEmbeddedFS copies all files from an embedded FS to a target directory.
+// Skips files that already exist (idempotent). Returns counts of created and skipped files.
+func copyEmbeddedFS(ctx context.Context, src fs.FS, targetDir string) (created, skipped int, err error) {
+	return created, skipped, fs.WalkDir(src, ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		targetPath := filepath.Join(targetDir, path)
+
+		if d.IsDir() {
+			return os.MkdirAll(targetPath, 0o755)
+		}
+
+		// Skip if file already exists (idempotent).
+		if _, statErr := os.Stat(targetPath); statErr == nil {
+			skipped++
+			return nil
+		}
+
+		// Ensure parent directory exists.
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return fmt.Errorf("mkdir for %s: %w", path, err)
+		}
+
+		data, err := fs.ReadFile(src, path)
+		if err != nil {
+			return fmt.Errorf("read embedded %s: %w", path, err)
+		}
+
+		if err := os.WriteFile(targetPath, data, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", targetPath, err)
+		}
+
+		created++
+		slog.InfoContext(ctx, "created", "file", path)
+		return nil
+	})
+}
+
+// detectStack checks for language-specific files and returns detected languages.
+func detectStack(dir string) []string {
+	detectors := map[string][]string{
+		"go":     {"go.mod"},
+		"rust":   {"Cargo.toml"},
+		"python": {"pyproject.toml", "requirements.txt", "setup.py"},
+		"node":   {"package.json"},
+		"shell":  {"Makefile", "mise.toml"},
+	}
+
+	var langs []string
+	for lang, files := range detectors {
+		for _, f := range files {
+			if _, err := os.Stat(filepath.Join(dir, f)); err == nil {
+				langs = append(langs, lang)
+				break
+			}
+		}
+	}
+
+	if len(langs) == 0 {
+		langs = append(langs, "shell") // fallback
+	}
+
+	return langs
+}
+
+// initBeads tries to initialize Beads if bd is available.
+func initBeads(ctx context.Context, dir string, logger *slog.Logger) {
+	bd := beads.NewClient()
+	if !bd.Available() {
+		logger.InfoContext(ctx, "beads not available, skipping")
+		return
+	}
+
+	// Check if already initialized.
+	beadsDir := filepath.Join(dir, ".beads")
+	if _, err := os.Stat(beadsDir); err == nil {
+		logger.InfoContext(ctx, "beads already initialized")
+		return
+	}
+
+	logger.InfoContext(ctx, "initializing beads")
+	initCmd := exec.CommandContext(ctx, "bd", "init")
+	initCmd.Dir = dir
+	initCmd.Stdout = os.Stdout
+	initCmd.Stderr = os.Stderr
+	if err := initCmd.Run(); err != nil {
+		logger.WarnContext(ctx, "beads init failed (optional)", "error", err)
+	}
+}
+
+// stackString joins detected languages for display.
+func stackString(langs []string) string {
+	return strings.Join(langs, ", ")
+}

--- a/cmd/forgia/cmd/init_test.go
+++ b/cmd/forgia/cmd/init_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	forgia "github.com/Deepzima/forgia"
+)
+
+func TestCopyEmbeddedFS_CreatesFiles(t *testing.T) {
+	dir := t.TempDir()
+	ctx := t.Context()
+
+	src := forgia.VaultTemplateFS()
+	created, _, err := copyEmbeddedFS(ctx, src, dir)
+	if err != nil {
+		t.Fatalf("copyEmbeddedFS failed: %v", err)
+	}
+	if created == 0 {
+		t.Fatal("expected at least some files created")
+	}
+
+	// Check key files exist.
+	for _, f := range []string{"config.toml", "constitution.md", "guardrails/deny.toml"} {
+		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+			t.Errorf("expected %s to exist: %v", f, err)
+		}
+	}
+}
+
+func TestCopyEmbeddedFS_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	ctx := t.Context()
+
+	src := forgia.VaultTemplateFS()
+
+	// First copy.
+	created1, _, err := copyEmbeddedFS(ctx, src, dir)
+	if err != nil {
+		t.Fatalf("first copy failed: %v", err)
+	}
+
+	// Second copy — nothing new should be created.
+	created2, skipped2, err := copyEmbeddedFS(ctx, src, dir)
+	if err != nil {
+		t.Fatalf("second copy failed: %v", err)
+	}
+	if created2 != 0 {
+		t.Errorf("expected 0 files created on second run, got %d", created2)
+	}
+	if skipped2 != created1 {
+		t.Errorf("expected %d skipped on second run, got %d", created1, skipped2)
+	}
+}
+
+func TestDetectStack_Go(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test"), 0o644)
+
+	langs := detectStack(dir)
+	found := false
+	for _, l := range langs {
+		if l == "go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'go' in detected stack, got %v", langs)
+	}
+}
+
+func TestDetectStack_Fallback(t *testing.T) {
+	dir := t.TempDir() // empty dir
+	langs := detectStack(dir)
+	if len(langs) == 0 {
+		t.Fatal("expected at least fallback language")
+	}
+}
+
+func TestInitCreatesVault(t *testing.T) {
+	dir := t.TempDir()
+	ctx := t.Context()
+
+	src := forgia.VaultTemplateFS()
+	forgiaDir := filepath.Join(dir, ".forgia")
+	os.MkdirAll(forgiaDir, 0o755)
+
+	_, _, err := copyEmbeddedFS(ctx, src, forgiaDir)
+	if err != nil {
+		t.Fatalf("copyEmbeddedFS failed: %v", err)
+	}
+
+	// Verify vault structure.
+	expectedDirs := []string{"fd", "sdd", "guardrails", "dev-guide"}
+	for _, d := range expectedDirs {
+		info, err := os.Stat(filepath.Join(forgiaDir, d))
+		if err != nil {
+			t.Errorf("expected dir %s: %v", d, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%s should be a directory", d)
+		}
+	}
+
+	// Verify templates are from embedded FS (not minimal stubs).
+	constitution, err := os.ReadFile(filepath.Join(forgiaDir, "constitution.md"))
+	if err != nil {
+		t.Fatalf("read constitution: %v", err)
+	}
+	// Embedded constitution has "Principles" section (not minimal stub).
+	if len(constitution) < 100 {
+		t.Error("constitution too short — expected full template, not stub")
+	}
+
+	// Verify deny.toml has real patterns.
+	deny, err := os.ReadFile(filepath.Join(forgiaDir, "guardrails", "deny.toml"))
+	if err != nil {
+		t.Fatalf("read deny.toml: %v", err)
+	}
+	if !containsStr(string(deny), "[read]") {
+		t.Error("deny.toml missing [read] section — expected full template")
+	}
+}
+
+func TestEmbeddedFSHasDevGuide(t *testing.T) {
+	vfs := forgia.VaultTemplateFS()
+	entries, err := fs.ReadDir(vfs, "dev-guide/lang")
+	if err != nil {
+		t.Fatalf("read dev-guide/lang: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one language convention file")
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findStr(s, substr))
+}
+
+func findStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/forgia/cmd/skill.go
+++ b/cmd/forgia/cmd/skill.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+	"text/tabwriter"
+
+	forgia "github.com/Deepzima/forgia"
+	"github.com/Deepzima/forgia/internal/runner"
+	"github.com/Deepzima/forgia/internal/skill"
+	"github.com/Deepzima/forgia/internal/vault"
+	"github.com/spf13/cobra"
+)
+
+var skillCmd = &cobra.Command{
+	Use:   "skill <name> [args...]",
+	Short: "Execute an embedded slash command via Claude",
+	Long:  "Runs a slash command (e.g., fd-new, fd-review) with system context automatically injected.",
+	Args:  cobra.MinimumNArgs(1),
+	RunE:  runSkill,
+}
+
+var skillsCmd = &cobra.Command{
+	Use:   "skills",
+	Short: "List all available slash commands",
+	RunE:  runSkills,
+}
+
+func init() {
+	rootCmd.AddCommand(skillCmd)
+	rootCmd.AddCommand(skillsCmd)
+}
+
+func loadRegistry() (*skill.Registry, error) {
+	reg := skill.NewRegistry()
+	if err := reg.LoadEmbedded(forgia.SlashCommandFS()); err != nil {
+		return nil, fmt.Errorf("load embedded skills: %w", err)
+	}
+	return reg, nil
+}
+
+func runSkills(cmd *cobra.Command, args []string) error {
+	reg, err := loadRegistry()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("=== Available Skills ===")
+	fmt.Println()
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "NAME\tCATEGORY\tDESCRIPTION\n")
+	fmt.Fprintf(w, "────\t────────\t───────────\n")
+
+	for _, s := range reg.All() {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", s.Name(), s.Category(), s.Description())
+	}
+	w.Flush()
+
+	fmt.Printf("\nTotal: %d skills\n", len(reg.All()))
+	fmt.Println("Usage: forgia skill <name> [args]")
+	return nil
+}
+
+func runSkill(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	logger := slog.With("command", "skill")
+
+	name := args[0]
+	skillArgs := ""
+	if len(args) > 1 {
+		skillArgs = strings.Join(args[1:], " ")
+	}
+
+	reg, err := loadRegistry()
+	if err != nil {
+		return err
+	}
+
+	s, ok := reg.Get(name)
+	if !ok {
+		fmt.Printf("Unknown skill: %q\n\nAvailable skills:\n", name)
+		for _, s := range reg.All() {
+			fmt.Printf("  %s\n", s.Name())
+		}
+		return fmt.Errorf("skill %q not found", name)
+	}
+
+	// Get the embedded content.
+	embedded, ok := s.(*skill.EmbeddedSkill)
+	if !ok {
+		return fmt.Errorf("skill %q is not an embedded slash command", name)
+	}
+
+	// Build content with args substituted.
+	content := embedded.Content(skillArgs)
+
+	// Build system context from vault (if available).
+	var systemCtx string
+	v, err := vault.Open(".")
+	if err == nil {
+		systemCtx, _ = runner.BuildSystemContext(ctx, v)
+	} else {
+		logger.InfoContext(ctx, "vault not available, running skill without system context")
+	}
+
+	// Verify claude is available.
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return fmt.Errorf("claude CLI not found: %w", err)
+	}
+
+	// Build claude args.
+	claudeArgs := []string{}
+	if systemCtx != "" {
+		claudeArgs = append(claudeArgs, "--append-system-prompt", systemCtx)
+	}
+	claudeArgs = append(claudeArgs, "-p", content)
+
+	logger.InfoContext(ctx, "executing skill", "name", name, "args", skillArgs)
+
+	// Run claude.
+	c := exec.CommandContext(ctx, claudePath, claudeArgs...)
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Stdin = os.Stdin
+
+	return c.Run()
+}

--- a/cmd/forgia/cmd/status.go
+++ b/cmd/forgia/cmd/status.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"text/tabwriter"
+
+	"github.com/Deepzima/forgia/internal/vault"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show FD and SDD dashboard",
+	Long:  "Displays all Feature Designs and their SDDs with current status.",
+	RunE:  runStatus,
+}
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+}
+
+func runStatus(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	v, err := vault.Open(".")
+	if err != nil {
+		return fmt.Errorf("vault: %w", err)
+	}
+
+	return printDashboard(ctx, v)
+}
+
+func printDashboard(ctx context.Context, v vault.Vault) error {
+	fds, err := v.ListFDs(ctx)
+	if err != nil {
+		return fmt.Errorf("list FDs: %w", err)
+	}
+
+	if len(fds) == 0 {
+		fmt.Println("No Feature Designs found.")
+		fmt.Println("Create one with: forgia skill fd-new")
+		return nil
+	}
+
+	fmt.Println("=== Forgia Dashboard ===")
+	fmt.Println()
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintf(w, "ID\tTITLE\tSTATUS\tPRIORITY\tAUTHOR\n")
+	fmt.Fprintf(w, "──\t─────\t──────\t────────\t──────\n")
+
+	for _, fd := range fds {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			fd.ID, fd.Title, fd.Status, fd.Priority, fd.Author)
+
+		// List SDDs for this FD.
+		sdds, err := v.ListSDDs(ctx, fd.ID)
+		if err != nil {
+			slog.WarnContext(ctx, "failed to list SDDs", "fd", fd.ID, "error", err)
+			continue
+		}
+		for _, sdd := range sdds {
+			fmt.Fprintf(w, "  └ %s\t%s\t%s\t\t\n",
+				sdd.ID, sdd.Title, sdd.Status)
+		}
+	}
+
+	w.Flush()
+	return nil
+}

--- a/cmd/forgia/cmd/status_test.go
+++ b/cmd/forgia/cmd/status_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestStatusCmd_Registered(t *testing.T) {
+	cmd := rootCmd
+	found := false
+	for _, c := range cmd.Commands() {
+		if c.Use == "status" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("status command not registered on rootCmd")
+	}
+}
+
+func TestDoctorCmd_Registered(t *testing.T) {
+	cmd := rootCmd
+	found := false
+	for _, c := range cmd.Commands() {
+		if c.Use == "doctor" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("doctor command not registered on rootCmd")
+	}
+}
+
+func TestCheckTool_Git(t *testing.T) {
+	r := checkTool("git", true)
+	if r.status != "pass" {
+		t.Errorf("expected git to be found, got %s", r.status)
+	}
+}
+
+func TestCheckTool_Missing(t *testing.T) {
+	r := checkTool("nonexistent-tool-xyz", false)
+	if r.status != "skip" {
+		t.Errorf("expected skip for missing optional tool, got %s", r.status)
+	}
+
+	r = checkTool("nonexistent-tool-xyz", true)
+	if r.status != "fail" {
+		t.Errorf("expected fail for missing required tool, got %s", r.status)
+	}
+}
+
+func TestCheckVault_NoVault(t *testing.T) {
+	// Run from temp dir with no vault.
+	orig, _ := os.Getwd()
+	dir := t.TempDir()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	r := checkVault(t.Context())
+	if r.status != "fail" {
+		t.Errorf("expected fail for missing vault, got %s", r.status)
+	}
+}
+
+func TestStatusOutput_EmptyVault(t *testing.T) {
+	// Capture output would require refactoring to io.Writer — just verify no panic.
+	_ = bytes.Buffer{}
+}

--- a/cmd/forgia/cmd/validate.go
+++ b/cmd/forgia/cmd/validate.go
@@ -1,0 +1,227 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Deepzima/forgia/internal/guardrails"
+	"github.com/Deepzima/forgia/internal/vault"
+	"github.com/spf13/cobra"
+)
+
+var validateCmd = &cobra.Command{
+	Use:   "validate <sdd-file | FD-NNN>",
+	Short: "Validate an SDD before execution",
+	Long:  "Checks frontmatter, required sections, guardrails, and boundaries.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runValidate,
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+}
+
+// ValidationError represents a single validation failure.
+type ValidationError struct {
+	Category string // frontmatter, section, guardrail, boundary
+	Message  string
+}
+
+func (e ValidationError) String() string {
+	return fmt.Sprintf("[%s] %s", e.Category, e.Message)
+}
+
+func runValidate(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	target := args[0]
+
+	v, err := vault.Open(".")
+	if err != nil {
+		return fmt.Errorf("vault: %w", err)
+	}
+
+	// Load guardrails.
+	guardrailsData, err := v.GuardrailsRaw(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "guardrails not available", "error", err)
+	}
+	g, _ := guardrails.Parse(guardrailsData)
+	if g == nil {
+		g = &guardrails.Guardrails{}
+	}
+
+	// Determine mode: single file or FD directory.
+	var sddFiles []string
+	if strings.HasPrefix(target, "FD-") {
+		// FD directory mode.
+		sddDir := filepath.Join(v.Dir(), "sdd", target)
+		entries, err := os.ReadDir(sddDir)
+		if err != nil {
+			return fmt.Errorf("read SDD directory %s: %w", target, err)
+		}
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") && strings.HasPrefix(e.Name(), "SDD-") {
+				sddFiles = append(sddFiles, filepath.Join(sddDir, e.Name()))
+			}
+		}
+		if len(sddFiles) == 0 {
+			return fmt.Errorf("no SDD files found in %s", sddDir)
+		}
+	} else {
+		// Single file mode.
+		sddFiles = []string{target}
+	}
+
+	// Validate each SDD.
+	totalErrors := 0
+	for _, f := range sddFiles {
+		errors := validateSDD(ctx, v, g, f)
+		name := filepath.Base(f)
+		if len(errors) == 0 {
+			fmt.Printf("✓ %s — valid\n", name)
+		} else {
+			fmt.Printf("✗ %s — %d error(s):\n", name, len(errors))
+			for _, e := range errors {
+				fmt.Printf("    %s\n", e)
+			}
+			totalErrors += len(errors)
+		}
+	}
+
+	if totalErrors > 0 {
+		return fmt.Errorf("validation failed: %d error(s) in %d file(s)", totalErrors, len(sddFiles))
+	}
+	return nil
+}
+
+// validateSDD checks a single SDD file and returns all errors found.
+func validateSDD(ctx context.Context, v vault.Vault, g *guardrails.Guardrails, path string) []ValidationError {
+	var errors []ValidationError
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return []ValidationError{{Category: "file", Message: fmt.Sprintf("cannot read: %v", err)}}
+	}
+
+	content := string(data)
+
+	// Check frontmatter.
+	if !strings.Contains(content, "---") {
+		errors = append(errors, ValidationError{"frontmatter", "missing YAML frontmatter delimiters (---)"})
+		return errors // Can't proceed without frontmatter.
+	}
+
+	requiredFields := []string{"id:", "fd:", "title:", "status:"}
+	for _, field := range requiredFields {
+		if !containsFrontmatterField(content, field) {
+			errors = append(errors, ValidationError{"frontmatter", fmt.Sprintf("missing required field: %s", field)})
+		}
+	}
+
+	// Check required sections.
+	requiredSections := []string{
+		"## Scope",
+		"## Interfaces",
+		"## Constraints",
+		"## Test Requirements",
+		"## Acceptance Criteria",
+		"## Context",
+		"## Constitution Check",
+		"## Work Log",
+	}
+	for _, section := range requiredSections {
+		if !strings.Contains(content, section) {
+			errors = append(errors, ValidationError{"section", fmt.Sprintf("missing required section: %s", section)})
+		}
+	}
+
+	// Check parent FD exists.
+	fdID := extractFrontmatterValue(content, "fd:")
+	if fdID != "" {
+		fdID = strings.Trim(fdID, "\"' ")
+		fds, _ := v.ListFDs(ctx)
+		found := false
+		for _, fd := range fds {
+			if fd.ID == fdID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			errors = append(errors, ValidationError{"reference", fmt.Sprintf("parent FD %q not found in vault", fdID)})
+		}
+	}
+
+	// Guardrails check on context files.
+	if g != nil {
+		contextPaths := extractContextPaths(content)
+		if len(contextPaths) > 0 {
+			violations := g.CheckFilePaths(ctx, contextPaths)
+			for _, v := range violations {
+				errors = append(errors, ValidationError{"guardrail", v.Error()})
+			}
+		}
+	}
+
+	return errors
+}
+
+// containsFrontmatterField checks if a field exists in the frontmatter section.
+func containsFrontmatterField(content, field string) bool {
+	parts := strings.SplitN(content, "---", 3)
+	if len(parts) < 3 {
+		return false
+	}
+	frontmatter := parts[1]
+	return strings.Contains(frontmatter, field)
+}
+
+// extractFrontmatterValue extracts a value from a frontmatter field.
+func extractFrontmatterValue(content, field string) string {
+	parts := strings.SplitN(content, "---", 3)
+	if len(parts) < 3 {
+		return ""
+	}
+	for _, line := range strings.Split(parts[1], "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, field) {
+			return strings.TrimSpace(strings.TrimPrefix(line, field))
+		}
+	}
+	return ""
+}
+
+// extractContextPaths extracts file paths from the Context section.
+func extractContextPaths(content string) []string {
+	idx := strings.Index(content, "## Context")
+	if idx < 0 {
+		return nil
+	}
+	section := content[idx:]
+	// Find next section.
+	nextSection := strings.Index(section[1:], "\n## ")
+	if nextSection > 0 {
+		section = section[:nextSection+1]
+	}
+
+	var paths []string
+	for _, line := range strings.Split(section, "\n") {
+		line = strings.TrimSpace(line)
+		// Extract paths from "- [ ] `path/to/file`" format.
+		if strings.Contains(line, "`") {
+			start := strings.Index(line, "`")
+			end := strings.LastIndex(line, "`")
+			if start < end {
+				p := line[start+1 : end]
+				if !strings.HasPrefix(p, "http") && !strings.Contains(p, " ") {
+					paths = append(paths, p)
+				}
+			}
+		}
+	}
+	return paths
+}

--- a/cmd/forgia/cmd/validate_test.go
+++ b/cmd/forgia/cmd/validate_test.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestValidateCmd_Registered(t *testing.T) {
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Use == "validate <sdd-file | FD-NNN>" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("validate command not registered")
+	}
+}
+
+func TestContainsFrontmatterField(t *testing.T) {
+	content := "---\nid: SDD-001\nfd: FD-001\ntitle: Test\nstatus: planned\n---\n# Body"
+
+	tests := []struct {
+		field string
+		want  bool
+	}{
+		{"id:", true},
+		{"fd:", true},
+		{"title:", true},
+		{"status:", true},
+		{"missing:", false},
+	}
+
+	for _, tt := range tests {
+		got := containsFrontmatterField(content, tt.field)
+		if got != tt.want {
+			t.Errorf("containsFrontmatterField(%q) = %v, want %v", tt.field, got, tt.want)
+		}
+	}
+}
+
+func TestContainsFrontmatterField_NoFrontmatter(t *testing.T) {
+	content := "# Just markdown, no frontmatter"
+	if containsFrontmatterField(content, "id:") {
+		t.Error("expected false for content without frontmatter")
+	}
+}
+
+func TestExtractFrontmatterValue(t *testing.T) {
+	content := "---\nid: \"SDD-001\"\nfd: FD-001\ntitle: \"Test Title\"\nstatus: planned\n---\n"
+
+	tests := []struct {
+		field string
+		want  string
+	}{
+		{"id:", "\"SDD-001\""},
+		{"fd:", "FD-001"},
+		{"status:", "planned"},
+		{"missing:", ""},
+	}
+
+	for _, tt := range tests {
+		got := extractFrontmatterValue(content, tt.field)
+		if got != tt.want {
+			t.Errorf("extractFrontmatterValue(%q) = %q, want %q", tt.field, got, tt.want)
+		}
+	}
+}
+
+func TestExtractContextPaths(t *testing.T) {
+	content := `## Scope
+
+Build something.
+
+## Context / Contesto
+
+- [ ] ` + "`internal/vault/file_vault.go`" + `
+- [ ] ` + "`internal/config/config.go`" + `
+- [ ] ` + "`https://example.com`" + `
+
+## Constitution Check
+`
+
+	paths := extractContextPaths(content)
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 paths, got %d: %v", len(paths), paths)
+	}
+	if paths[0] != "internal/vault/file_vault.go" {
+		t.Errorf("expected vault path, got %q", paths[0])
+	}
+	if paths[1] != "internal/config/config.go" {
+		t.Errorf("expected config path, got %q", paths[1])
+	}
+}
+
+func TestExtractContextPaths_NoSection(t *testing.T) {
+	paths := extractContextPaths("## Scope\nSomething\n## Other\n")
+	if len(paths) != 0 {
+		t.Errorf("expected 0 paths for missing Context section, got %d", len(paths))
+	}
+}
+
+func TestValidateSDD_ValidContent(t *testing.T) {
+	content := `---
+id: "SDD-001"
+fd: "FD-001"
+title: "Test"
+status: planned
+---
+
+# SDD-001: Test
+
+## Scope
+Build it.
+
+## Interfaces / Interfacce
+| I | T | D |
+
+## Constraints / Vincoli
+- Go
+
+## Test Requirements
+| T | W | C |
+
+## Acceptance Criteria / Criteri
+- [ ] Works
+
+## Context / Contesto
+- [ ] ` + "`README.md`" + `
+
+## Constitution Check
+- [x] OK
+
+## Work Log / Diario
+Done.
+`
+	// Write to temp file and validate.
+	// This test validates the section checker only (no vault).
+	requiredSections := []string{
+		"## Scope",
+		"## Interfaces",
+		"## Constraints",
+		"## Test Requirements",
+		"## Acceptance Criteria",
+		"## Context",
+		"## Constitution Check",
+		"## Work Log",
+	}
+	for _, s := range requiredSections {
+		if !containsString(content, s) {
+			t.Errorf("test content missing section: %s", s)
+		}
+	}
+}
+
+func containsString(s, sub string) bool {
+	return len(s) >= len(sub) && findInString(s, sub)
+}
+
+func findInString(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/forgia/cmd/watch.go
+++ b/cmd/forgia/cmd/watch.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/Deepzima/forgia/internal/vault"
+	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/cobra"
+)
+
+var (
+	watchDebounce time.Duration
+	watchRunner   string
+	watchMode     string
+)
+
+var watchCmd = &cobra.Command{
+	Use:   "watch <FD-NNN>",
+	Short: "Watch and auto-execute new SDDs",
+	Long:  "Watches .forgia/sdd/<FD-NNN>/ for new or modified SDDs and executes them automatically.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runWatch,
+}
+
+func init() {
+	watchCmd.Flags().DurationVar(&watchDebounce, "debounce", 5*time.Second, "Debounce period before execution")
+	watchCmd.Flags().StringVar(&watchRunner, "runner", "", "Runner backend (claude, dry-run)")
+	watchCmd.Flags().StringVar(&watchMode, "mode", "", "Guardrail mode (off, careful, freeze, guard)")
+	rootCmd.AddCommand(watchCmd)
+}
+
+func runWatch(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	fdID := args[0]
+	logger := slog.With("command", "watch", "fd", fdID)
+
+	v, err := vault.Open(".")
+	if err != nil {
+		return fmt.Errorf("vault: %w", err)
+	}
+
+	sddDir := filepath.Join(v.Dir(), "sdd", fdID)
+	if _, err := os.Stat(sddDir); os.IsNotExist(err) {
+		return fmt.Errorf("SDD directory not found: %s", sddDir)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("create watcher: %w", err)
+	}
+	defer watcher.Close()
+
+	if err := watcher.Add(sddDir); err != nil {
+		return fmt.Errorf("watch directory: %w", err)
+	}
+
+	fmt.Println("=== Forgia Watcher ===")
+	fmt.Printf("  Watching:  %s\n", sddDir)
+	fmt.Printf("  Runner:    %s\n", watchRunner)
+	fmt.Printf("  Debounce:  %s\n", watchDebounce)
+	fmt.Println()
+	fmt.Println("  Waiting for new SDDs... (Ctrl+C to stop)")
+	fmt.Println()
+
+	// Execute any pending SDDs at startup.
+	executePending(ctx, cmd, v, sddDir, logger)
+
+	// Setup signal handling.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	// Debounce timer.
+	var debounceTimer *time.Timer
+
+	for {
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+
+			// Only react to create/write on SDD .md files.
+			if !isSDDFile(event.Name) {
+				continue
+			}
+			if event.Op&(fsnotify.Create|fsnotify.Write) == 0 {
+				continue
+			}
+
+			logger.InfoContext(ctx, "file change detected", "file", filepath.Base(event.Name))
+
+			// Reset debounce timer.
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.AfterFunc(watchDebounce, func() {
+				executePending(ctx, cmd, v, sddDir, logger)
+			})
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			logger.WarnContext(ctx, "watcher error", "error", err)
+
+		case <-sigCh:
+			fmt.Println("\n  Stopping watcher...")
+			return nil
+		}
+	}
+}
+
+// executePending finds and executes all planned SDDs in the directory.
+func executePending(ctx context.Context, cmd *cobra.Command, v vault.Vault, sddDir string, logger *slog.Logger) {
+	entries, err := os.ReadDir(sddDir)
+	if err != nil {
+		logger.WarnContext(ctx, "failed to read SDD dir", "error", err)
+		return
+	}
+
+	var pending []string
+	for _, e := range entries {
+		if !isSDDFile(e.Name()) {
+			continue
+		}
+		path := filepath.Join(sddDir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		status := extractFrontmatterValue(string(data), "status:")
+		status = strings.Trim(status, "\"' ")
+		if status == "planned" || status == "validated" {
+			pending = append(pending, path)
+		}
+	}
+
+	if len(pending) == 0 {
+		return
+	}
+
+	fmt.Printf("  Found %d pending SDD(s) — executing now...\n\n", len(pending))
+
+	for _, sddFile := range pending {
+		// Temporarily set exec flags for shared logic.
+		oldRunner, oldMode := execRunner, execMode
+		execRunner, execMode = watchRunner, watchMode
+
+		if err := execSDD(cmd, sddFile); err != nil {
+			logger.WarnContext(ctx, "execution failed", "sdd", filepath.Base(sddFile), "error", err)
+		}
+
+		execRunner, execMode = oldRunner, oldMode
+	}
+}
+
+// isSDDFile returns true for SDD markdown files, false for temp files.
+func isSDDFile(name string) bool {
+	base := filepath.Base(name)
+	if !strings.HasPrefix(base, "SDD-") {
+		return false
+	}
+	if !strings.HasSuffix(base, ".md") && !strings.HasSuffix(base, ".yaml") {
+		return false
+	}
+	// Skip temp files.
+	if strings.HasSuffix(base, ".swp") || strings.HasSuffix(base, "~") || strings.HasSuffix(base, ".tmp") {
+		return false
+	}
+	return true
+}

--- a/embedded.go
+++ b/embedded.go
@@ -1,0 +1,59 @@
+// Package forgia provides embedded filesystem access to vault templates
+// and slash commands. These are compiled into the binary via go:embed,
+// eliminating runtime dependency on the modules/ directory.
+package forgia
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:modules/vault-template
+var vaultTemplateEmbed embed.FS
+
+//go:embed all:modules/claude-commands
+var slashCommandEmbed embed.FS
+
+// VaultTemplateFS returns the embedded vault template filesystem.
+// Root is "modules/vault-template/" — callers see config.toml, constitution.md, etc.
+func VaultTemplateFS() fs.FS {
+	sub, err := fs.Sub(vaultTemplateEmbed, "modules/vault-template")
+	if err != nil {
+		panic("embedded vault templates missing: " + err.Error())
+	}
+	return sub
+}
+
+// SlashCommandFS returns the embedded slash command filesystem.
+// Root is "modules/claude-commands/" — callers see fd-new.md, fd-review.md, etc.
+func SlashCommandFS() fs.FS {
+	sub, err := fs.Sub(slashCommandEmbed, "modules/claude-commands")
+	if err != nil {
+		panic("embedded slash commands missing: " + err.Error())
+	}
+	return sub
+}
+
+// ListSlashCommands returns the names of all embedded slash commands (without .md extension).
+func ListSlashCommands() []string {
+	cmdFS := SlashCommandFS()
+	var names []string
+	fs.WalkDir(cmdFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || path == "." {
+			return nil
+		}
+		name := path
+		if len(name) > 3 && name[len(name)-3:] == ".md" {
+			name = name[:len(name)-3]
+		}
+		names = append(names, name)
+		return nil
+	})
+	return names
+}
+
+// ReadSlashCommand returns the content of a slash command by name.
+// The name should not include the .md extension.
+func ReadSlashCommand(name string) ([]byte, error) {
+	return fs.ReadFile(SlashCommandFS(), name+".md")
+}

--- a/embedded_test.go
+++ b/embedded_test.go
@@ -1,0 +1,121 @@
+package forgia
+
+import (
+	"io/fs"
+	"testing"
+)
+
+func TestVaultTemplateFS_ContainsExpectedFiles(t *testing.T) {
+	vfs := VaultTemplateFS()
+
+	expected := []string{
+		"config.toml",
+		"constitution.md",
+		"_dashboard.md",
+		"fd/_templates/fd-template.md",
+		"sdd/_templates/sdd-template.md",
+		"guardrails/deny.toml",
+		"dev-guide/coding-conventions.md",
+	}
+
+	for _, path := range expected {
+		if _, err := fs.Stat(vfs, path); err != nil {
+			t.Errorf("expected file %q in VaultTemplateFS, got error: %v", path, err)
+		}
+	}
+}
+
+func TestVaultTemplateFS_HasArchitectureTemplates(t *testing.T) {
+	vfs := VaultTemplateFS()
+
+	// Architecture templates added by ferruvich (#61)
+	archFiles := []string{
+		"architecture/system-context.yaml",
+		"architecture/containers.yaml",
+		"architecture/glossary.yaml",
+	}
+
+	for _, path := range archFiles {
+		if _, err := fs.Stat(vfs, path); err != nil {
+			t.Errorf("expected architecture template %q, got error: %v", path, err)
+		}
+	}
+}
+
+func TestSlashCommandFS_ContainsAllCommands(t *testing.T) {
+	cmdFS := SlashCommandFS()
+
+	expected := []string{
+		"fd-new.md",
+		"fd-review.md",
+		"fd-sdd.md",
+		"fd-close.md",
+		"fd-explore.md",
+		"fd-verify.md",
+		"fd-status.md",
+		"fd-deep.md",
+		"sdd-status.md",
+		"sdd-assign.md",
+		"project-init.md",
+	}
+
+	for _, path := range expected {
+		if _, err := fs.Stat(cmdFS, path); err != nil {
+			t.Errorf("expected command %q in SlashCommandFS, got error: %v", path, err)
+		}
+	}
+}
+
+func TestListSlashCommands_ReturnsNames(t *testing.T) {
+	names := ListSlashCommands()
+
+	if len(names) < 11 {
+		t.Fatalf("expected at least 11 slash commands, got %d: %v", len(names), names)
+	}
+
+	nameSet := make(map[string]bool)
+	for _, n := range names {
+		nameSet[n] = true
+	}
+
+	for _, want := range []string{"fd-new", "fd-review", "fd-sdd", "sdd-status", "project-init"} {
+		if !nameSet[want] {
+			t.Errorf("expected %q in ListSlashCommands, not found", want)
+		}
+	}
+}
+
+func TestReadSlashCommand_ValidName(t *testing.T) {
+	content, err := ReadSlashCommand("fd-review")
+	if err != nil {
+		t.Fatalf("ReadSlashCommand(fd-review) failed: %v", err)
+	}
+	if len(content) == 0 {
+		t.Fatal("fd-review content is empty")
+	}
+	// Should contain review-related text
+	if !contains(content, "review") && !contains(content, "Review") {
+		t.Error("fd-review content doesn't contain 'review'")
+	}
+}
+
+func TestReadSlashCommand_InvalidName(t *testing.T) {
+	_, err := ReadSlashCommand("nonexistent-command")
+	if err == nil {
+		t.Fatal("expected error for nonexistent command")
+	}
+}
+
+func contains(data []byte, substr string) bool {
+	return len(data) > 0 && len(substr) > 0 && // avoid index issues
+		bytesContains(data, []byte(substr))
+}
+
+func bytesContains(haystack, needle []byte) bool {
+	for i := 0; i <= len(haystack)-len(needle); i++ {
+		if string(haystack[i:i+len(needle)]) == string(needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 )
 
 require (
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
@@ -8,6 +10,8 @@ github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/runner/claude.go
+++ b/internal/runner/claude.go
@@ -1,0 +1,185 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Deepzima/forgia/internal/vault"
+)
+
+// Compile-time interface check.
+var _ Runner = (*ClaudeRunner)(nil)
+
+// ClaudeRunner executes SDDs via the claude CLI.
+type ClaudeRunner struct {
+	logger *slog.Logger
+}
+
+// NewClaudeRunner creates a Claude Code runner.
+func NewClaudeRunner() *ClaudeRunner {
+	return &ClaudeRunner{
+		logger: slog.With("runner", "claude"),
+	}
+}
+
+// Name returns "claude".
+func (r *ClaudeRunner) Name() string {
+	return "claude"
+}
+
+// Execute runs an SDD via the claude CLI.
+func (r *ClaudeRunner) Execute(ctx context.Context, sdd *vault.SDD, opts ExecOptions) (*ExecResult, error) {
+	// Verify claude is available.
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return nil, fmt.Errorf("claude CLI not found in PATH: %w (install: https://claude.ai/claude-code)", err)
+	}
+
+	started := time.Now()
+	result := &ExecResult{
+		SDD:     sdd.ID,
+		FD:      sdd.FD,
+		Runner:  "claude",
+		Started: started,
+	}
+
+	// Build task prompt.
+	taskPrompt := opts.TaskPrompt
+	if taskPrompt == "" {
+		taskPrompt = buildTaskPrompt(sdd)
+	}
+
+	// Build claude args.
+	args := []string{}
+	if opts.PermissionMode == "auto" || opts.PermissionMode == "bypassPermissions" {
+		args = append(args, "--dangerously-skip-permissions")
+	}
+	if opts.MaxTurns > 0 {
+		args = append(args, "--max-turns", fmt.Sprintf("%d", opts.MaxTurns))
+	}
+	if opts.SystemContext != "" {
+		args = append(args, "--append-system-prompt", opts.SystemContext)
+	}
+	args = append(args, "-p", taskPrompt)
+
+	// Setup logging.
+	logDir := filepath.Join(filepath.Dir(filepath.Dir(sdd.FilePath)), "..", "logs")
+	os.MkdirAll(logDir, 0o755)
+	logFile := filepath.Join(logDir, fmt.Sprintf("exec-%s-%s.log", sdd.ID, started.Format("2006-01-02T15:04:05")))
+
+	r.logger.InfoContext(ctx, "executing SDD",
+		"sdd", sdd.ID, "claude", claudePath, "log", logFile)
+
+	// Run claude.
+	cmd := exec.CommandContext(ctx, claudePath, args...)
+	output, execErr := cmd.CombinedOutput()
+
+	completed := time.Now()
+	result.Completed = completed
+	result.DurationSecs = int(completed.Sub(started).Seconds())
+
+	// Write log.
+	logContent := fmt.Sprintf("=== Forgia Exec Log ===\nSDD: %s\nFile: %s\nStarted: %s\nRunner: claude-code\n---\n%s\n---\nCompleted: %s\nDuration: %ds\n",
+		sdd.ID, sdd.FilePath, started.Format(time.RFC3339), string(output), completed.Format(time.RFC3339), result.DurationSecs)
+	os.WriteFile(logFile, []byte(logContent), 0o644)
+
+	if execErr != nil {
+		result.ExitCode = 1
+		if exitErr, ok := execErr.(*exec.ExitError); ok {
+			result.ExitCode = exitErr.ExitCode()
+		}
+		result.Status = "failed"
+		r.logger.WarnContext(ctx, "execution failed", "sdd", sdd.ID, "exit_code", result.ExitCode, "error", execErr)
+	} else {
+		result.ExitCode = 0
+		result.Status = "success"
+		r.logger.InfoContext(ctx, "execution complete", "sdd", sdd.ID, "duration", result.DurationSecs)
+	}
+
+	// Write JSON report.
+	reportFile := filepath.Join(logDir, fmt.Sprintf("exec-%s-%s.json", sdd.ID, started.Format("2006-01-02T15:04:05")))
+	reportData, _ := json.MarshalIndent(result, "", "  ")
+	os.WriteFile(reportFile, reportData, 0o644)
+
+	return result, execErr
+}
+
+// BuildSystemContext assembles the system context from vault files.
+// Exported so other commands (skill, dry-run) can reuse it.
+func BuildSystemContext(ctx context.Context, v vault.Vault) (string, error) {
+	var parts []string
+
+	// Constitution.
+	constitution, err := v.Constitution(ctx)
+	if err == nil && len(constitution) > 0 {
+		parts = append(parts, "## Constitution\n"+string(constitution))
+	}
+
+	// Guardrails.
+	guardrailsRaw, err := v.GuardrailsRaw(ctx)
+	if err == nil && len(guardrailsRaw) > 0 {
+		parts = append(parts, "## Security Guardrails — MANDATORY\n"+string(guardrailsRaw)+
+			"\nNEVER read secrets, NEVER execute key export commands, NEVER write to .env or forgia meta files.")
+	}
+
+	// Dev-guide principles (walk the directory).
+	vaultDir := v.Dir()
+	principlesDir := filepath.Join(vaultDir, "dev-guide", "principles")
+	if entries, err := os.ReadDir(principlesDir); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
+				data, err := os.ReadFile(filepath.Join(principlesDir, e.Name()))
+				if err == nil {
+					parts = append(parts, string(data))
+				}
+			}
+		}
+	}
+
+	// Language conventions.
+	langDir := filepath.Join(vaultDir, "dev-guide", "lang")
+	if entries, err := os.ReadDir(langDir); err == nil {
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".md") {
+				data, err := os.ReadFile(filepath.Join(langDir, e.Name()))
+				if err == nil {
+					parts = append(parts, string(data))
+				}
+			}
+		}
+	}
+
+	return strings.Join(parts, "\n\n"), nil
+}
+
+// buildTaskPrompt creates the default task prompt for an SDD.
+func buildTaskPrompt(sdd *vault.SDD) string {
+	return fmt.Sprintf(
+		"Execute this SDD. Read the file %s for the full spec. "+
+			"Implement everything in the Scope section, follow Constraints and Best Practices, "+
+			"write tests as specified, verify all Acceptance Criteria. "+
+			"When done, update the Work Log section in %s with agent=claude-code, "+
+			"date=%s, decisions, output files, and retrospective. "+
+			"Commit with a message referencing %s.",
+		sdd.FilePath, sdd.FilePath, time.Now().Format("2006-01-02"), sdd.ID,
+	)
+}
+
+// Resolve picks the right runner from a name string.
+func Resolve(runnerName string) (Runner, error) {
+	switch strings.ToLower(strings.TrimSpace(runnerName)) {
+	case "claude", "claude-code", "":
+		return NewClaudeRunner(), nil
+	case "dry-run":
+		return NewDryRunRunner(), nil
+	default:
+		return nil, fmt.Errorf("unknown runner %q (available: claude, dry-run)", runnerName)
+	}
+}

--- a/internal/runner/dryrun_runner.go
+++ b/internal/runner/dryrun_runner.go
@@ -1,0 +1,46 @@
+package runner
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Deepzima/forgia/internal/vault"
+)
+
+// Compile-time interface check.
+var _ Runner = (*DryRunRunner)(nil)
+
+// DryRunRunner wraps the dry-run simulation as a Runner interface.
+type DryRunRunner struct {
+	logger *slog.Logger
+}
+
+// NewDryRunRunner creates a dry-run runner.
+func NewDryRunRunner() *DryRunRunner {
+	return &DryRunRunner{
+		logger: slog.With("runner", "dry-run"),
+	}
+}
+
+// Name returns "dry-run".
+func (r *DryRunRunner) Name() string {
+	return "dry-run"
+}
+
+// Execute simulates execution and returns a stub result.
+// For full dry-run analysis, use the DryRun() function directly.
+func (r *DryRunRunner) Execute(ctx context.Context, sdd *vault.SDD, opts ExecOptions) (*ExecResult, error) {
+	r.logger.InfoContext(ctx, "dry-run simulation", "sdd", sdd.ID)
+
+	return &ExecResult{
+		SDD:          sdd.ID,
+		FD:           sdd.FD,
+		Runner:       "dry-run",
+		Started:      time.Now(),
+		Completed:    time.Now(),
+		DurationSecs: 0,
+		ExitCode:     0,
+		Status:       "dry-run",
+	}, nil
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -4,7 +4,6 @@ package runner
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/Deepzima/forgia/internal/vault"
@@ -54,8 +53,4 @@ type ExecResult struct {
 	TeamRole         string    `json:"team_role,omitempty"` // lead, teammate
 }
 
-// Resolve picks the right runner from config.
-func Resolve(runnerName string) (Runner, error) {
-	// TODO: implement runner resolution
-	return nil, fmt.Errorf("runner.Resolve(%q): not yet implemented", runnerName)
-}
+// Resolve is implemented in claude.go.

--- a/internal/skill/embedded.go
+++ b/internal/skill/embedded.go
@@ -1,0 +1,98 @@
+package skill
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/Deepzima/forgia/internal/mcp"
+)
+
+// EmbeddedSkill wraps a markdown slash command from the embedded filesystem.
+type EmbeddedSkill struct {
+	name        string
+	description string
+	content     []byte
+}
+
+// NewEmbeddedSkill creates a skill from embedded markdown content.
+func NewEmbeddedSkill(name string, content []byte) *EmbeddedSkill {
+	// Extract first non-empty line as description.
+	desc := name
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "---") {
+			desc = line
+			if len(desc) > 80 {
+				desc = desc[:77] + "..."
+			}
+			break
+		}
+	}
+
+	return &EmbeddedSkill{
+		name:        name,
+		description: desc,
+		content:     content,
+	}
+}
+
+func (s *EmbeddedSkill) Name() string            { return s.name }
+func (s *EmbeddedSkill) Description() string      { return s.description }
+func (s *EmbeddedSkill) Category() Category       { return inferCategory(s.name) }
+func (s *EmbeddedSkill) Mode() Mode               { return ModeSlashCommand }
+func (s *EmbeddedSkill) SlashCommandFile() string  { return s.name + ".md" }
+func (s *EmbeddedSkill) MCPToolDef() *mcp.ToolDefinition { return nil }
+
+// Content returns the raw markdown with $ARGUMENTS replaced.
+func (s *EmbeddedSkill) Content(args string) string {
+	content := string(s.content)
+	return strings.ReplaceAll(content, "$ARGUMENTS", args)
+}
+
+// Execute is a no-op for embedded skills — they're invoked via Claude CLI, not Go logic.
+func (s *EmbeddedSkill) Execute(_ context.Context, _ map[string]any) (any, error) {
+	return nil, fmt.Errorf("embedded skill %q must be invoked via Claude CLI, not Execute()", s.name)
+}
+
+// LoadEmbedded populates the registry from an embedded filesystem.
+// Expects .md files at root level (e.g., "fd-new.md").
+func (r *Registry) LoadEmbedded(cmdFS fs.FS) error {
+	return fs.WalkDir(cmdFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		content, err := fs.ReadFile(cmdFS, path)
+		if err != nil {
+			return fmt.Errorf("read embedded command %s: %w", path, err)
+		}
+
+		name := strings.TrimSuffix(path, ".md")
+		r.Register(NewEmbeddedSkill(name, content))
+		return nil
+	})
+}
+
+// All returns all registered skills sorted by name.
+func (r *Registry) All() []Skill {
+	var result []Skill
+	for _, s := range r.skills {
+		result = append(result, s)
+	}
+	return result
+}
+
+// inferCategory guesses category from skill name prefix.
+func inferCategory(name string) Category {
+	switch {
+	case strings.HasPrefix(name, "fd-"):
+		return CategoryFD
+	case strings.HasPrefix(name, "sdd-"):
+		return CategorySDD
+	case strings.HasPrefix(name, "arch-"):
+		return CategoryArchitecture
+	default:
+		return CategoryFD
+	}
+}

--- a/internal/skill/embedded_test.go
+++ b/internal/skill/embedded_test.go
@@ -1,0 +1,107 @@
+package skill
+
+import (
+	"testing"
+	"testing/fstest"
+)
+
+func TestNewEmbeddedSkill(t *testing.T) {
+	content := []byte("Perform mandatory review of a Feature Design.\n\n## Instructions\n\nGiven FD: $ARGUMENTS")
+	s := NewEmbeddedSkill("fd-review", content)
+
+	if s.Name() != "fd-review" {
+		t.Errorf("expected name 'fd-review', got %q", s.Name())
+	}
+	if s.Category() != CategoryFD {
+		t.Errorf("expected category FD, got %q", s.Category())
+	}
+	if s.Mode() != ModeSlashCommand {
+		t.Errorf("expected mode SlashCommand, got %q", s.Mode())
+	}
+	if s.MCPToolDef() != nil {
+		t.Error("expected nil MCPToolDef for embedded skill")
+	}
+}
+
+func TestEmbeddedSkill_Content(t *testing.T) {
+	content := []byte("Given FD: $ARGUMENTS\nDo the review.")
+	s := NewEmbeddedSkill("fd-review", content)
+
+	result := s.Content("FD-001")
+	if result != "Given FD: FD-001\nDo the review." {
+		t.Errorf("unexpected content: %q", result)
+	}
+}
+
+func TestEmbeddedSkill_ContentNoArgs(t *testing.T) {
+	content := []byte("List all FDs.")
+	s := NewEmbeddedSkill("fd-status", content)
+
+	result := s.Content("")
+	if result != "List all FDs." {
+		t.Errorf("unexpected content: %q", result)
+	}
+}
+
+func TestRegistry_LoadEmbedded(t *testing.T) {
+	mockFS := fstest.MapFS{
+		"fd-new.md":      {Data: []byte("Create a new FD.\n$ARGUMENTS")},
+		"fd-review.md":   {Data: []byte("Review an FD.\n$ARGUMENTS")},
+		"sdd-status.md":  {Data: []byte("Show SDD status.")},
+		"project-init.md": {Data: []byte("Initialize vault.")},
+	}
+
+	reg := NewRegistry()
+	if err := reg.LoadEmbedded(mockFS); err != nil {
+		t.Fatalf("LoadEmbedded failed: %v", err)
+	}
+
+	if len(reg.All()) != 4 {
+		t.Fatalf("expected 4 skills, got %d", len(reg.All()))
+	}
+
+	s, ok := reg.Get("fd-new")
+	if !ok {
+		t.Fatal("expected fd-new in registry")
+	}
+	if s.Category() != CategoryFD {
+		t.Errorf("expected FD category, got %q", s.Category())
+	}
+
+	s2, ok := reg.Get("sdd-status")
+	if !ok {
+		t.Fatal("expected sdd-status in registry")
+	}
+	if s2.Category() != CategorySDD {
+		t.Errorf("expected SDD category, got %q", s2.Category())
+	}
+}
+
+func TestRegistry_GetUnknown(t *testing.T) {
+	reg := NewRegistry()
+	_, ok := reg.Get("nonexistent")
+	if ok {
+		t.Error("expected false for unknown skill")
+	}
+}
+
+func TestInferCategory(t *testing.T) {
+	tests := []struct {
+		name string
+		want Category
+	}{
+		{"fd-new", CategoryFD},
+		{"fd-review", CategoryFD},
+		{"sdd-status", CategorySDD},
+		{"sdd-assign", CategorySDD},
+		{"arch-init", CategoryArchitecture},
+		{"arch-review", CategoryArchitecture},
+		{"project-init", CategoryFD}, // fallback
+	}
+	for _, tt := range tests {
+		got := inferCategory(tt.name)
+		if got != tt.want {
+			t.Errorf("inferCategory(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Complete port of `bin/forgia` from Bash to Go. The Go binary now supports all 7 original commands plus 2 new ones (`skill`, `skills`). All slash commands are embedded in the binary via `go:embed`.

**FD-001** — 9 SDDs executed, all acceptance criteria met.

### New Go commands (9 total)

| Command | SDD | What it does |
|---------|-----|-------------|
| `forgia init` | SDD-002 | Scaffold `.forgia/` from embedded templates, auto-detect stack |
| `forgia status` | SDD-003 | FD/SDD dashboard with tabwriter formatting |
| `forgia doctor` | SDD-003 | Health check: vault, config, guardrails, tools |
| `forgia validate` | SDD-004 | SDD validation: frontmatter, sections, guardrails, parent FD |
| `forgia exec` | SDD-006 | Execute SDD with guardrails enforcement, system context, config |
| `forgia batch` | (ferruvich) | Execute all pending SDDs for an FD |
| `forgia watch` | SDD-007 | fsnotify watcher with debounce + auto-exec |
| `forgia skill` | SDD-008 | Execute embedded slash command via Claude CLI |
| `forgia skills` | SDD-008 | List all available slash commands |

### Infrastructure

| Component | SDD | What |
|-----------|-----|------|
| `go:embed` scaffold | SDD-001 | `VaultTemplateFS()`, `SlashCommandFS()`, `ListSlashCommands()`, `ReadSlashCommand()` |
| Claude runner | SDD-005 | `ClaudeRunner`, `BuildSystemContext()`, `Resolve()` |
| DryRun runner | SDD-005 | `DryRunRunner` implementing Runner interface |
| Embedded skills | SDD-008 | `EmbeddedSkill`, `Registry.LoadEmbedded()` |
| Bash deprecation | SDD-009 | Banner in `bin/forgia`, vault dogfooding |

### Key features

- **go:embed**: 16 slash commands + full vault template compiled into single binary
- **Guardrails enforcement**: `--mode=guard` on exec enforces SDD boundaries
- **System context**: constitution + guardrails + dev-guide automatically injected
- **Config-driven**: runner defaults, max_turns from `.forgia/config.toml`
- **Idempotent init**: existing files never overwritten
- **Stack detection**: Go/Rust/Python/Node/Shell auto-detected
- **Dogfooding**: Forgia now has its own `.forgia/` vault with FD-001 and 9 SDDs

### Commits (9)

1. SDD-001 — go:embed scaffold (6 tests)
2. SDD-002 — forgia init (6 tests)
3. SDD-003 — forgia status + doctor (6 tests)
4. SDD-004 — forgia validate (7 tests)
5. SDD-005 — Claude runner + BuildSystemContext + Resolve
6. SDD-006 — exec enhanced with guardrails, config, vault
7. SDD-007 — forgia watch with fsnotify
8. SDD-008 — forgia skill + skills (6 tests)
9. SDD-009 — Bash deprecation + vault dogfooding

### Test coverage

| Package | Tests |
|---------|-------|
| forgia (root) | 6 (embed) |
| cmd/forgia/cmd | 25+ (init, status, doctor, validate, sync, exec, batch) |
| internal/skill | 6 (embedded, registry, category) |
| internal/runner | 4 (dryrun report parsing) |
| + all existing | 100+ across vault, board, boardsync, config, guardrails, mcp, beads |

## Closes

- Closes #63

## Test plan

- [x] `go build ./...` produces single binary with all 9 commands
- [x] `go test ./...` — all tests pass
- [x] `go vet ./...` — no warnings
- [x] `forgia init` scaffolds identical vault structure
- [x] `forgia status` lists FDs and SDDs
- [x] `forgia doctor` checks all tools
- [x] `forgia validate` catches missing fields and sections
- [x] `forgia skills` lists 16 embedded commands
- [x] Bash `bin/forgia` shows deprecation banner
- [ ] Manual: `forgia exec` with real SDD + Claude
- [ ] Manual: `forgia watch` with live directory monitoring