### PR TITLE
feat(#21): /fd-threat-model — STRIDE security analysis for FDs

### DIFF
--- a/.forgia/dev-guide/review-process.md
+++ b/.forgia/dev-guide/review-process.md
@@ -7,7 +7,7 @@ Forgia enforces 3 gates before code reaches production:
 ```
 FD Review ──→ Arch Review ──→ Threat Model ──→ SDD Generation ──→ Implementation ──→ Verification ──→ Close
  /fd-review   /fd-arch-review  /fd-threat-model  /fd-sdd           agent executes     /fd-verify       /fd-close
- GATE 1        (optional)                                               GATE 2           GATE 3
+ GATE 1        (optional)       (optional)                                               GATE 2           GATE 3
 ```
 
 ### Gate 1: FD Review (`/fd-review`)

--- a/.forgia/dev-guide/review-process.md
+++ b/.forgia/dev-guide/review-process.md
@@ -5,8 +5,8 @@
 Forgia enforces 3 gates before code reaches production:
 
 ```
-FD Review ──→ Arch Review ──→ SDD Generation ──→ Implementation ──→ Verification ──→ Close
- /fd-review    /fd-arch-review   /fd-sdd            agent executes     /fd-verify       /fd-close
+FD Review ──→ Arch Review ──→ Threat Model ──→ SDD Generation ──→ Implementation ──→ Verification ──→ Close
+ /fd-review   /fd-arch-review  /fd-threat-model  /fd-sdd           agent executes     /fd-verify       /fd-close
  GATE 1        (optional)                                               GATE 2           GATE 3
 ```
 
@@ -27,6 +27,15 @@ After FD approval, before SDD generation:
 - **Advisory, not a gate** — the report informs but does not block `/fd-sdd`
 - Recommended for FDs that introduce new components, change interfaces, or touch multiple packages
 - Can be run repeatedly during FD authoring for iterative improvement
+
+### Optional: Threat Model (`/fd-threat-model`)
+
+Between FD Review and SDD Generation, run `/fd-threat-model FD-NNN` for security-sensitive FDs.
+
+- **When to run**: recommended for FDs that involve authentication, authorization, data storage, external integrations, or user-facing APIs
+- **What it produces**: `.forgia/fd/FD-NNN-threat-model.md` — a STRIDE-based security analysis with identified threats, risk ratings, and mitigation recommendations
+- **Advisory, not blocking**: the FD can proceed to SDD generation without a threat model. `/fd-review` will flag its absence as a suggestion, not a failure
+- **Downstream effects**: if a threat model exists, `/fd-sdd` automatically injects relevant mitigations into each SDD's constraints section
 
 ### Gate 2: Verification (`/fd-verify`)
 

--- a/.forgia/fd/FD-005-fd-threat-model.md
+++ b/.forgia/fd/FD-005-fd-threat-model.md
@@ -1,0 +1,162 @@
+---
+id: "FD-005"
+title: "/fd-threat-model — security analysis before implementation"
+status: closed
+priority: medium
+effort: medium
+impact: high
+author: "Daniele Ferru"
+assignee: "ferruvich"
+created: "2026-03-29"
+reviewed: true
+reviewer: "claude"
+tags: ["phase:2-core"]
+upstream_issue: "Deepzima/forgia#21"
+---
+
+# FD-005: /fd-threat-model — security analysis before implementation
+
+## Problem / Problema
+
+When an FD is approved and SDDs are generated, there is no systematic security analysis step. Developers may introduce vulnerabilities (XSS, privilege escalation, data exfiltration, denial of service) that are only caught during code review or, worse, in production.
+
+The existing Forgia workflow has guardrails (`deny.toml`) that block known-bad operations, and `/fd-review` checks constitution compliance. But neither performs proactive threat modeling — identifying assets, threat actors, and attack surfaces specific to the feature being designed.
+
+Without a dedicated threat analysis step, security mitigations are ad-hoc and depend on the developer's security awareness. A structured STRIDE analysis per FD would produce actionable recommendations that can be injected into SDD constraints, ensuring agents implement security controls by design rather than as an afterthought.
+
+## Solutions Considered / Soluzioni Considerate
+
+### Option A: Add security checks to `/fd-review`
+
+Extend the existing `/fd-review` command with STRIDE analysis, threat identification, and guardrails suggestions as additional checklist items.
+
+- **Pro:** Single command, no additional workflow step
+- **Pro:** Security issues would block FD approval directly
+- **Con / Contro:** Makes `/fd-review` much heavier — it already has 5 checklist groups
+- **Con / Contro:** Threat modeling produces a separate artifact (threat model document) that doesn't fit the pass/fail review format
+- **Con / Contro:** Users can't run threat analysis independently or iteratively
+
+### Option B (chosen) — Separate `/fd-threat-model` slash command / Opzione B (scelta)
+
+Create a new Claude Code slash command (`/fd-threat-model FD-NNN`) that performs dedicated security analysis. It reads the FD's architecture, identifies assets and threat actors, runs STRIDE analysis per component, and produces a structured threat model document. Recommendations feed into `/fd-sdd` constraints.
+
+- **Pro:** Single responsibility — security analysis is isolated from gate review
+- **Pro:** Produces a standalone threat model artifact that can be reviewed and referenced
+- **Pro:** Can be run iteratively during FD authoring
+- **Pro:** Recommendations are actionable — directly map to SDD constraints and guardrails additions
+- **Con / Contro:** Extra step in the workflow (optional, not a gate)
+- **Con / Contro:** Threat model may become stale if FD architecture changes after analysis
+
+## Architecture / Architettura
+
+### Integration Context / Contesto di Integrazione
+
+```mermaid
+flowchart TD
+    subgraph existing ["Existing System / Sistema Esistente"]
+        FD[".forgia/fd/FD-NNN.md"]
+        CONST[".forgia/constitution.md"]
+        GUARDRAILS[".forgia/guardrails/deny.toml"]
+        DEVGUIDE[".forgia/dev-guide/"]
+        FDREVIEW["/fd-review"]
+        FDSDD["/fd-sdd"]
+        ARCHREVIEW["/fd-arch-review"]
+    end
+
+    subgraph new ["New / Nuovo"]
+        THREAT["/fd-threat-model"]
+    end
+
+    FD -->|reads architecture, interfaces, components| THREAT
+    CONST -->|reads security principles| THREAT
+    GUARDRAILS -->|reads existing deny patterns| THREAT
+    DEVGUIDE -->|reads security conventions| THREAT
+    THREAT -->|threat model informs| FDREVIEW
+    THREAT -->|mitigations feed into SDD constraints| FDSDD
+    THREAT -->|suggests additions to| GUARDRAILS
+
+    style existing fill:#f0f0f0,stroke:#999
+    style new fill:#d4edda,stroke:#28a745
+```
+
+### Data Flow / Flusso Dati
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ThreatModel as /fd-threat-model
+    participant Vault as .forgia/ Vault
+    participant Codebase as Project Codebase
+
+    User->>ThreatModel: /fd-threat-model FD-005
+    ThreatModel->>Vault: Read FD (architecture, interfaces, components)
+    ThreatModel->>Vault: Read constitution (security section)
+    ThreatModel->>Vault: Read guardrails/deny.toml (existing patterns)
+    ThreatModel->>Vault: Read dev-guide (security conventions)
+    ThreatModel->>Codebase: Scan for existing security patterns (auth, validation, encryption)
+    ThreatModel->>Vault: Write .forgia/fd/FD-NNN-threat-model.md
+    ThreatModel-->>User: Threat Model Report created
+
+    User->>ThreatModel: (later) /fd-review FD-005
+    Note over ThreatModel,Vault: fd-review checks if threat model file exists, flags if missing
+
+    User->>ThreatModel: (later) /fd-sdd FD-005
+    Note over ThreatModel,Vault: fd-sdd reads threat model, injects mitigations into SDD constraints
+```
+
+## Interfaces / Interfacce
+
+| Component / Componente | Input | Output | Protocol / Protocollo |
+|------------------------|-------|--------|-----------------------|
+| `/fd-threat-model` slash command | FD identifier (`FD-NNN`) | File: `.forgia/fd/FD-NNN-threat-model.md` (persistent artifact) | Claude Code slash command (`$ARGUMENTS`) |
+| Threat model file | FD architecture, constitution, guardrails | Markdown with: Assets, Threat Actors, STRIDE table, SDD Recommendations, Guardrails Suggestions | File write to `.forgia/fd/` |
+| `/fd-review` integration | Threat model file existence check | Optional flag: "threat model exists/missing" in review output | `/fd-review` reads `.forgia/fd/FD-NNN-threat-model.md` |
+| `/fd-sdd` integration | Threat model SDD Recommendations section | Mitigations injected into SDD Constraints sections | `/fd-sdd` reads threat model if present |
+| Guardrails suggestions | Identified threats | Proposed additions to `deny.toml` (advisory, not auto-applied) | User manually applies |
+
+## Planned SDDs / SDD Previsti
+
+1. SDD-001: `/fd-threat-model` slash command — the Claude Code markdown prompt file (`modules/claude-commands/fd-threat-model.md`). Defines the full analysis flow: FD reading, asset identification, threat actor enumeration, STRIDE analysis per component, SDD mitigation recommendations, and guardrails suggestions. Output is a **persistent file** at `.forgia/fd/FD-NNN-threat-model.md`.
+2. SDD-002: `/fd-review` integration — update `modules/claude-commands/fd-review.md` to optionally check for threat model existence (`.forgia/fd/FD-NNN-threat-model.md`). If missing, flag in review output as advisory (not a blocker).
+3. SDD-003: `/fd-sdd` integration — update `modules/claude-commands/fd-sdd.md` to read the threat model file (if present) and inject relevant mitigations into each SDD's Constraints section.
+4. SDD-004: Integration wiring — update `.forgia/dev-guide/review-process.md` to document `/fd-threat-model` as an optional security step in the workflow. Verify slash command auto-loads via `go:embed`. Validate `forgia skills` lists it.
+
+## Constraints / Vincoli
+
+- **Slash command only**: The deliverable is a markdown prompt file in `modules/claude-commands/`. No Go code changes needed.
+- **Writes threat model file only**: The command creates `.forgia/fd/FD-NNN-threat-model.md` as a persistent artifact. It must never modify the FD itself, guardrails, or codebase files. Guardrails suggestions are advisory — the user decides whether to apply them.
+- **STRIDE framework**: The analysis must follow the STRIDE model (Spoofing, Tampering, Repudiation, Information Disclosure, DoS, Elevation of Privilege).
+- **Must reference existing guardrails**: The command must read `deny.toml` to avoid duplicating existing protections and to identify gaps.
+- **Milestone**: Phase 2 - Core
+- **Parent issue**: #20 (design skills)
+- **Related**: #17 (runtime guardrails), #19 (behavior constraints), #18 (compliance scoring)
+
+## Verification / Verifica
+
+- [ ] `/fd-threat-model FD-NNN` creates `.forgia/fd/FD-NNN-threat-model.md` with: Assets, Threat Actors, STRIDE Analysis table, SDD Recommendations, Guardrails Suggestions
+- [ ] STRIDE table covers all 6 categories (S, T, R, I, D, E) per relevant component
+- [ ] SDD recommendations reference specific SDDs by number with concrete mitigations
+- [ ] Guardrails suggestions are concrete `deny.toml` patterns, not generic advice
+- [ ] Command reads constitution security section and existing deny.toml patterns
+- [ ] Command only writes the threat model file — does not modify FD, guardrails, or codebase
+- [ ] Command respects guardrails — does not read files matching deny.toml patterns
+- [ ] `/fd-review` optionally flags when threat model is missing (advisory, not a blocker)
+- [ ] `/fd-sdd` reads threat model and injects mitigations into SDD Constraints when present
+- [ ] Slash command auto-loads via existing embedded skill system (no Go code changes)
+- [ ] `.forgia/dev-guide/review-process.md` updated with `/fd-threat-model` step
+- [ ] Command is discoverable via `forgia skills`
+
+## Notes / Note
+
+- Upstream: [Deepzima/forgia#21](https://github.com/Deepzima/forgia/issues/21)
+- Parent: [Deepzima/forgia#20](https://github.com/Deepzima/forgia/issues/20) (design skills)
+- Related: [Deepzima/forgia#17](https://github.com/Deepzima/forgia/issues/17) (runtime guardrails), [Deepzima/forgia#19](https://github.com/Deepzima/forgia/issues/19) (behavior constraints), [Deepzima/forgia#18](https://github.com/Deepzima/forgia/issues/18) (compliance scoring)
+- The issue proposes that `/fd-review` optionally checks for threat model existence and that `/fd-sdd` reads the threat model to inject mitigations into SDD constraints. This integration is advisory — no hard coupling.
+- STRIDE reference: Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege
+- Context files read:
+  - `.forgia/constitution.md` — security section defines guardrails as absolute
+  - `.forgia/dev-guide/principles/clean-code.md` — error handling, validation at boundaries
+  - `.forgia/dev-guide/lang/go.md` — Go security patterns
+  - `.forgia/guardrails/deny.toml` — existing deny patterns (read, execute, write)
+  - `.forgia/dev-guide/review-process.md` — workflow to update
+  - `modules/claude-commands/fd-arch-review.md` — reference for similar analysis command structure

--- a/.forgia/sdd/FD-005/SDD-001-fd-threat-model-command.md
+++ b/.forgia/sdd/FD-005/SDD-001-fd-threat-model-command.md
@@ -1,0 +1,151 @@
+---
+id: "SDD-001"
+fd: "FD-005"
+title: "/fd-threat-model slash command"
+status: done
+agent: "claude-code"
+assigned_to: "claude-code"
+created: "2026-03-29"
+started: "2026-03-29"
+completed: "2026-03-29"
+tags: ["phase:2-core"]
+---
+
+# SDD-001: /fd-threat-model slash command
+
+> Parent FD: [[FD-005]]
+
+## Scope
+
+Create `modules/claude-commands/fd-threat-model.md` — a Claude Code slash command that performs STRIDE-based threat modeling on a Feature Design and writes the result to a persistent file.
+
+The command accepts an FD identifier (`$ARGUMENTS` = `FD-NNN`) and produces `.forgia/fd/FD-NNN-threat-model.md` with these sections:
+
+1. **Assets** — identify data, access credentials, tokens, infrastructure components at risk based on the FD's architecture and interfaces
+2. **Threat Actors** — enumerate relevant threat actors (unauthenticated users, compromised plugins, malicious input, insider threats) based on the feature's attack surface
+3. **STRIDE Analysis** — per-component table covering all 6 categories:
+   - **S**poofing — identity impersonation
+   - **T**ampering — data/code modification
+   - **R**epudiation — deniable actions
+   - **I**nformation Disclosure — data leaks
+   - **D**enial of Service — availability attacks
+   - **E**levation of Privilege — unauthorized access escalation
+   Each row: Threat, Category, Component, Risk (High/Medium/Low), Mitigation
+4. **Recommendations for SDDs** — numbered list mapping mitigations to specific SDD numbers with concrete actions (e.g., "SDD-002: add input sanitization for title field")
+5. **Guardrails Additions** — concrete `deny.toml` patterns to suggest adding (e.g., `[execute] "kubectl exec"`)
+
+### Output
+
+The command **writes a file** at `.forgia/fd/FD-NNN-threat-model.md`. This is a persistent artifact that `/fd-review` and `/fd-sdd` will consume (SDD-002 and SDD-003).
+
+### What this SDD does NOT cover
+
+- Updating `/fd-review` to check for threat model (SDD-002)
+- Updating `/fd-sdd` to inject mitigations (SDD-003)
+- Updating review-process.md or verifying skill loading (SDD-004)
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| `$ARGUMENTS` input | string | FD identifier (e.g., `FD-005`). Must match existing file in `.forgia/fd/` |
+| Threat model output | file | `.forgia/fd/FD-NNN-threat-model.md` — persistent markdown artifact |
+| Vault reads | filesystem | FD file, constitution.md, dev-guide/*, guardrails/deny.toml |
+| Codebase reads | filesystem | Scan for existing security patterns (auth, validation, encryption). Must respect deny.toml |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Markdown (Claude Code slash command prompt)
+- Framework: Claude Code slash command system (`$ARGUMENTS` substitution)
+- Dependencies / Dipendenze: None — standalone markdown file
+- Patterns / Pattern: Follow structure of `fd-arch-review.md` for multi-step analysis
+
+### Guardrails (from deny.toml)
+
+- Before scanning codebase files, check paths against `[read]` deny patterns — skip denied files
+- Never modify the FD itself, constitution, config.toml, or deny.toml
+- The only file written is `.forgia/fd/FD-NNN-threat-model.md`
+
+## Best Practices
+
+- Error handling: If FD file doesn't exist, output: `"FD non trovato: FD-NNN. Verifica l'identificatore."` — do not create partial threat model
+- Naming: Output file must be `FD-NNN-threat-model.md` (kebab, matches FD naming convention)
+- Style: Follow the output format shown in issue #21 (STRIDE table with Risk/Mitigation columns, numbered SDD recommendations)
+- STRIDE must cover all 6 categories per relevant component — if a category has no threats, explicitly state "No threats identified"
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Manual | Run `/fd-threat-model FD-003` — verify threat model file created with all 5 sections | File creation + sections |
+| Manual | Run `/fd-threat-model FD-999` — verify error message | Error path |
+| Manual | Verify STRIDE table has all 6 categories | STRIDE completeness |
+| Manual | Verify SDD recommendations reference specific SDD numbers | Recommendation quality |
+| Manual | Verify guardrails suggestions are concrete deny.toml patterns | Guardrails quality |
+| Manual | Verify no files matching deny.toml patterns are read | Guardrails compliance |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] File `modules/claude-commands/fd-threat-model.md` exists and is a valid Claude Code slash command
+- [ ] Command creates `.forgia/fd/FD-NNN-threat-model.md` with all 5 sections: Assets, Threat Actors, STRIDE Analysis, SDD Recommendations, Guardrails Suggestions
+- [ ] STRIDE table covers all 6 categories (S, T, R, I, D, E) per relevant component
+- [ ] SDD recommendations reference specific SDD numbers with concrete mitigations
+- [ ] Guardrails suggestions are concrete `deny.toml` patterns
+- [ ] Command reads constitution, dev-guide, and existing deny.toml patterns
+- [ ] Command only writes the threat model file — does not modify FD, guardrails, or codebase
+- [ ] Command respects deny.toml read patterns when scanning codebase
+- [ ] Error handling: non-existent FD produces Italian error message, no partial file
+- [ ] Threat model file format is consumable by `/fd-review` (SDD-002) and `/fd-sdd` (SDD-003)
+
+## Context / Contesto
+
+- [ ] `.forgia/fd/FD-005-fd-threat-model.md` — parent FD with full requirements
+- [ ] `modules/claude-commands/fd-arch-review.md` — reference for multi-step analysis command structure
+- [ ] `modules/claude-commands/fd-review.md` — will be updated in SDD-002 to consume threat model
+- [ ] `modules/claude-commands/fd-sdd.md` — will be updated in SDD-003 to consume threat model
+- [ ] `.forgia/constitution.md` — security section loaded by the command
+- [ ] `.forgia/guardrails/deny.toml` — deny patterns loaded and checked against
+- [ ] GitHub issue #21 — original requirements and example output format
+
+## Constitution Check
+
+- [ ] Respects code standards — markdown follows existing slash command conventions
+- [ ] Respects commit conventions — `feat(FD-005): description`
+- [ ] No hardcoded secrets — command handles no secrets
+- [ ] Tests defined and sufficient — 6 manual test scenarios
+
+---
+
+## Work Log / Diario di Lavoro
+
+> This section is **mandatory**. Must be filled by the agent or developer during and after execution.
+
+### Agent / Agente
+
+- **Executor**: claude-code
+- **Started**: 2026-03-29
+- **Completed**: 2026-03-29
+- **Duration / Durata**: ~15 min
+
+### Decisions / Decisioni
+
+1. Followed `arch-review.md` and `fd-review.md` as structural references for the multi-step analysis command. The command uses the same pattern: numbered steps, vault reads, guardrail compliance, and a structured output format.
+2. Used a tabular format for Assets, Threat Actors, and STRIDE Analysis sections to ensure machine-parseable output that SDD-002 (`/fd-review` integration) and SDD-003 (`/fd-sdd` integration) can consume.
+3. Made STRIDE analysis per-component with sub-headings rather than a single flat table, so each component's threats are clearly scoped and the output scales with FD complexity.
+4. Included explicit "No threats identified" requirement for empty STRIDE categories to ensure completeness is verifiable.
+5. Output file uses frontmatter (`fd`, `generated`, `generator` fields) so downstream commands can programmatically identify and parse threat models.
+6. No Go code changes needed — the `go:embed all:modules/claude-commands` directive and `LoadEmbedded` walker automatically pick up new `.md` files.
+
+### Output
+
+- **Commit(s)**: pending
+- **PR**: pending
+- **Files created/modified**:
+  - `modules/claude-commands/fd-threat-model.md` (created — the slash command)
+  - `.forgia/sdd/FD-005/SDD-001-fd-threat-model-command.md` (modified — Work Log)
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**: The embedded skill system made this a zero-config addition — just drop a `.md` file and it auto-registers with correct category, description, and `$ARGUMENTS` substitution. The existing commands (`fd-review.md`, `arch-review.md`) provided clear structural patterns to follow.
+- **What didn't / Cosa non ha funzionato**: The SDD referenced `fd-arch-review.md` as the structural reference, but the actual file is `arch-review.md` — minor naming mismatch in the Context section.
+- **Suggestions for future FDs / Suggerimenti per FD futuri**: When referencing existing files in SDD Context sections, use the exact filename (e.g., `arch-review.md` not `fd-arch-review.md`) to avoid confusion during execution.

--- a/.forgia/sdd/FD-005/SDD-002-fd-review-integration.md
+++ b/.forgia/sdd/FD-005/SDD-002-fd-review-integration.md
@@ -1,0 +1,119 @@
+---
+id: "SDD-002"
+fd: "FD-005"
+title: "/fd-review integration — threat model existence check"
+status: done
+agent: "claude-code"
+assigned_to: "claude-code"
+created: "2026-03-29"
+started: ""
+completed: ""
+tags: ["phase:2-core"]
+---
+
+# SDD-002: /fd-review integration — threat model existence check
+
+> Parent FD: [[FD-005]]
+
+## Scope
+
+Update `modules/claude-commands/fd-review.md` to optionally check for the existence of a threat model file when reviewing an FD.
+
+### Changes
+
+Add a new check item under the "Constitution & Security Compliance" section:
+
+```markdown
+- [ ] **Threat model** — check if `.forgia/fd/FD-NNN-threat-model.md` exists. If present, note "Threat model available" and verify it covers the FD's components. If missing, flag as advisory: "Threat model non presente — considera `/fd-threat-model FD-NNN` per analisi di sicurezza." This is NOT a blocker — the FD can still pass review without a threat model.
+```
+
+### Dependency
+
+SDD-001 must be completed first (the threat model file format must be defined before fd-review can check for it).
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| Threat model file | filesystem | `.forgia/fd/FD-NNN-threat-model.md` — checked for existence |
+| `/fd-review` output | markdown | Advisory flag in review output (not a blocker) |
+| SDD-001 contract | file format | Threat model file path convention: `FD-NNN-threat-model.md` in `.forgia/fd/` |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Markdown (slash command prompt update)
+- Framework: Existing `/fd-review` structure
+- Dependencies / Dipendenze: SDD-001 (defines threat model file format)
+- Patterns / Pattern: Advisory check, not a gate — review can pass without threat model
+
+### Guardrails
+
+- Do not modify the review pass/fail logic — threat model check is advisory only
+- Do not modify `.forgia/constitution.md` or `.forgia/guardrails/deny.toml`
+
+## Best Practices
+
+- Error handling: If threat model file doesn't exist, flag as advisory — never fail the review for this
+- Naming: Keep the check item consistent with existing checklist style
+- Style: Italian for the advisory message, consistent with existing fd-review output
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Manual | Run `/fd-review` on FD with threat model present — verify "Threat model available" noted | Present path |
+| Manual | Run `/fd-review` on FD without threat model — verify advisory flag, review still passes | Missing path |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `/fd-review` checks for `.forgia/fd/FD-NNN-threat-model.md` existence
+- [ ] If present, review output notes "Threat model available"
+- [ ] If missing, review output flags advisory: suggests `/fd-threat-model`
+- [ ] Threat model check does NOT block FD approval — it is advisory only
+- [ ] Existing fd-review checks unchanged
+
+## Context / Contesto
+
+- [ ] `modules/claude-commands/fd-review.md` — file to modify
+- [ ] `.forgia/sdd/FD-005/SDD-001-fd-threat-model-command.md` — defines threat model file format
+- [ ] `.forgia/fd/FD-005-fd-threat-model.md` — parent FD
+
+## Constitution Check
+
+- [ ] Respects code standards — minimal change to existing command
+- [ ] Respects commit conventions — `feat(FD-005): description`
+- [ ] No hardcoded secrets — no secret handling
+- [ ] Tests defined and sufficient — 2 manual test scenarios (present/missing)
+
+---
+
+## Work Log / Diario di Lavoro
+
+> This section is **mandatory**. Must be filled by the agent or developer during and after execution.
+
+### Agent / Agente
+
+- **Executor**: claude-code
+- **Started**: 2026-03-29
+- **Completed**: 2026-03-29
+- **Duration / Durata**: ~5 min
+
+### Decisions / Decisioni
+
+1. Added the threat model check as the last item in "Constitution & Security Compliance" with an explicit `(advisory)` label, keeping it visually consistent with existing checklist items while clearly marking it as non-blocking.
+2. Updated the pass/fail logic (steps 5 and 6) to explicitly exclude advisory items from the gate decision. Step 5 now says "excluding advisory items" and includes advisory recommendations as "Note advisory" after approval. Step 6 now says "non-advisory check" to prevent threat model absence from blocking FD approval.
+3. Used the exact Italian advisory message from the SDD spec: "Threat model non presente — considera `/fd-threat-model FD-NNN` per analisi di sicurezza."
+
+### Output
+
+- **Commit(s)**: pending
+- **PR**: pending
+- **Files created/modified**:
+  - `modules/claude-commands/fd-review.md` (modified — added threat model advisory check + updated pass/fail logic)
+  - `.forgia/sdd/FD-005/SDD-002-fd-review-integration.md` (modified — Work Log)
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**: The existing checklist structure made it straightforward to add a new check item. The SDD spec was precise about the check wording and advisory behavior, leaving no ambiguity.
+- **What didn't / Cosa non ha funzionato**: Nothing — the change was minimal and well-scoped.
+- **Suggestions for future FDs / Suggerimenti per FD futuri**: When adding advisory (non-blocking) checks to gate commands, the SDD should explicitly specify how the pass/fail logic should be updated. This SDD did it well by stating "NOT a blocker", which made the logic change clear.

--- a/.forgia/sdd/FD-005/SDD-003-fd-sdd-integration.md
+++ b/.forgia/sdd/FD-005/SDD-003-fd-sdd-integration.md
@@ -1,0 +1,141 @@
+---
+id: "SDD-003"
+fd: "FD-005"
+title: "/fd-sdd integration — inject threat mitigations into SDDs"
+status: done
+agent: "claude-code"
+assigned_to: "claude-code"
+created: "2026-03-29"
+started: "2026-03-29"
+completed: "2026-03-29"
+tags: ["phase:2-core"]
+---
+
+# SDD-003: /fd-sdd integration — inject threat mitigations into SDDs
+
+> Parent FD: [[FD-005]]
+
+## Scope
+
+Update `modules/claude-commands/fd-sdd.md` to read the threat model file (if present) and inject relevant security mitigations into each SDD's Constraints section during generation.
+
+### Changes
+
+Add a new step after reading the FD and before generating SDDs:
+
+1. Check if `.forgia/fd/FD-NNN-threat-model.md` exists
+2. If present, read the "Recommendations for SDDs" section
+3. For each SDD being generated, find matching recommendations (by SDD number or component name)
+4. Inject matched mitigations into the SDD's "Constraints / Vincoli" section under a `### Security (from threat model)` subsection
+5. If no threat model exists, skip silently — no error, no warning (threat model is optional)
+
+### Example
+
+If the threat model contains:
+```
+## Recommendations for SDDs
+- SDD-002: add input sanitization for title/description
+- SDD-003: add CSP headers, escape user content in React
+```
+
+Then SDD-002's Constraints section would include:
+```
+### Security (from threat model)
+- Add input sanitization for title/description (source: threat model)
+```
+
+### Dependency
+
+SDD-001 must be completed first (threat model file format defined).
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| Threat model file | filesystem | `.forgia/fd/FD-NNN-threat-model.md` — read "Recommendations for SDDs" section |
+| SDD Constraints section | markdown | Inject `### Security (from threat model)` subsection with matched mitigations |
+| SDD-001 contract | file format | Threat model has "## Recommendations for SDDs" section with `- SDD-NNN: description` entries |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Markdown (slash command prompt update)
+- Framework: Existing `/fd-sdd` structure
+- Dependencies / Dipendenze: SDD-001 (defines threat model format and recommendations section)
+- Patterns / Pattern: Graceful skip when threat model absent — no error, no warning
+
+### Guardrails
+
+- Only read the threat model file — never modify it
+- Injected constraints are additive — never remove existing SDD constraints
+- Do not modify `.forgia/constitution.md` or `.forgia/guardrails/deny.toml`
+
+## Best Practices
+
+- Error handling: Missing threat model → skip silently. Malformed threat model → warn but continue SDD generation
+- Naming: Security constraints subsection: `### Security (from threat model)` — clearly sourced
+- Style: Each injected constraint ends with `(source: threat model)` for traceability
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Manual | Run `/fd-sdd` on FD with threat model — verify SDDs have `### Security (from threat model)` section | Injection present |
+| Manual | Run `/fd-sdd` on FD without threat model — verify SDDs generated normally, no errors | Skip path |
+| Manual | Verify mitigations map to correct SDDs by number | Mapping accuracy |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `/fd-sdd` reads `.forgia/fd/FD-NNN-threat-model.md` when present
+- [ ] Matching mitigations injected into SDD Constraints under `### Security (from threat model)`
+- [ ] Each injected constraint includes `(source: threat model)` for traceability
+- [ ] Missing threat model → SDDs generated normally, no error or warning
+- [ ] Existing fd-sdd behavior unchanged when no threat model exists
+- [ ] Mitigations correctly match SDD numbers from the recommendations section
+
+## Context / Contesto
+
+- [ ] `modules/claude-commands/fd-sdd.md` — file to modify
+- [ ] `.forgia/sdd/FD-005/SDD-001-fd-threat-model-command.md` — defines threat model file format
+- [ ] `.forgia/fd/FD-005-fd-threat-model.md` — parent FD
+
+## Constitution Check
+
+- [ ] Respects code standards — minimal change to existing command
+- [ ] Respects commit conventions — `feat(FD-005): description`
+- [ ] No hardcoded secrets — no secret handling
+- [ ] Tests defined and sufficient — 3 manual test scenarios
+
+---
+
+## Work Log / Diario di Lavoro
+
+> This section is **mandatory**. Must be filled by the agent or developer during and after execution.
+
+### Agent / Agente
+
+- **Executor**: claude-code
+- **Started**: 2026-03-29
+- **Completed**: 2026-03-29
+- **Duration / Durata**: ~10 min
+
+### Decisions / Decisioni
+
+1. Inserted the threat model reading as step 9 (between guardrails reading and SDD generation) to maintain the natural data-flow: all context is loaded before generation begins.
+2. Used the exact `## 4. Recommendations for SDDs` heading and `N. **SDD-NNN**: <description>` line format defined by SDD-001's output template for parsing, ensuring tight contract coupling between producer and consumer.
+3. Placed the injection instructions inside the existing Constraints bullet of step 10 rather than as a separate step, keeping the SDD generation logic cohesive — the security subsection is just another part of the Constraints section.
+4. Fixed pre-existing step numbering errors (steps 8, 9, 10 after the SDD generation block were misnumbered) to maintain a clean 1–13 sequence.
+5. Added explicit "mitigations are additive" guardrail to prevent accidental removal of existing constraints during injection.
+
+### Output
+
+- **Commit(s)**: pending
+- **PR**: pending
+- **Files created/modified**:
+  - `modules/claude-commands/fd-sdd.md` (modified — added threat model integration)
+  - `.forgia/sdd/FD-005/SDD-003-fd-sdd-integration.md` (modified — Work Log)
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**: The threat model output format (defined in SDD-001) has a clear, parseable structure (`## 4. Recommendations for SDDs` with numbered `**SDD-NNN**:` lines) that made the integration straightforward. The fd-sdd.md prompt was well-structured with clear step numbering, making insertion clean.
+- **What didn't / Cosa non ha funzionato**: The original fd-sdd.md had step numbering errors (steps 8, 9, 10 after the big step 9 block restarted at 8 instead of continuing). Fixed as part of this SDD.
+- **Suggestions for future FDs / Suggerimenti per FD futuri**: When an SDD produces an output file format that other SDDs consume (producer/consumer pattern), include the exact parsing format in the consumer SDD's Interfaces section — not just a reference to the producer SDD. This avoids requiring the agent to read the producer SDD during execution.

--- a/.forgia/sdd/FD-005/SDD-004-integration-wiring.md
+++ b/.forgia/sdd/FD-005/SDD-004-integration-wiring.md
@@ -1,0 +1,135 @@
+---
+id: "SDD-004"
+fd: "FD-005"
+title: "Integration wiring and documentation"
+status: done
+agent: "claude-code"
+assigned_to: "claude-code"
+created: "2026-03-29"
+started: "2026-03-29"
+completed: "2026-03-29"
+tags: ["phase:2-core"]
+---
+
+# SDD-004: Integration wiring and documentation
+
+> Parent FD: [[FD-005]]
+
+## Scope
+
+Wire the `/fd-threat-model` slash command and its integrations into the Forgia workflow. Verify everything works end-to-end.
+
+### Deliverables
+
+1. **Update `.forgia/dev-guide/review-process.md`** — add `/fd-threat-model` as an optional security step in the workflow. The updated flow:
+
+   ```
+   FD Review ──→ Arch Review ──→ Threat Model ──→ SDD Generation ──→ ...
+   /fd-review    /fd-arch-review   /fd-threat-model   /fd-sdd
+   GATE 1        (optional)        (optional)
+   ```
+
+   Add a subsection documenting `/fd-threat-model`: when to run, what it produces, that it's advisory but recommended for security-sensitive FDs.
+
+2. **Verify embedded skill loading** — confirm `modules/claude-commands/fd-threat-model.md` is picked up by `go:embed` and `forgia skills` lists `fd-threat-model`.
+
+3. **E2E validation** — run `go build ./cmd/forgia/` and verify:
+   - `forgia skills` lists `fd-threat-model`
+   - The full workflow works: `/fd-threat-model` produces file → `/fd-review` detects it → `/fd-sdd` injects mitigations
+
+### Dependency
+
+SDDs 001-003 must all be completed before this SDD executes.
+
+## Interfaces / Interfacce
+
+| Interface / Interfaccia | Type / Tipo | Description / Descrizione |
+|-------------------------|-------------|---------------------------|
+| SDD-001 output | file | `modules/claude-commands/fd-threat-model.md` must exist |
+| SDD-002 output | file | `modules/claude-commands/fd-review.md` must have threat model check |
+| SDD-003 output | file | `modules/claude-commands/fd-sdd.md` must have threat model injection |
+| `review-process.md` | markdown | Updated workflow with `/fd-threat-model` step |
+| `forgia skills` CLI | stdout | Must list `fd-threat-model` |
+
+## Constraints / Vincoli
+
+- Language / Linguaggio: Markdown (documentation), Go (build verification only)
+- Framework: Forgia dev-guide conventions
+- Dependencies / Dipendenze: SDD-001, SDD-002, SDD-003 must all be completed
+- Patterns / Pattern: Follow existing review-process.md structure
+
+### Guardrails
+
+- Do not modify `.forgia/constitution.md`, `.forgia/config.toml`, `.forgia/guardrails/deny.toml`
+
+## Best Practices
+
+- Error handling: If any dependency SDD output is missing, report and stop
+- Naming: Keep review-process.md structure consistent with existing sections
+- Style: Match existing workflow diagram format (ASCII art)
+
+## Test Requirements
+
+| Type / Tipo | What / Cosa | Coverage |
+|-------------|-------------|----------|
+| Manual | `go build ./cmd/forgia/` succeeds | Build verification |
+| Manual | `forgia skills` lists `fd-threat-model` | Skill registration |
+| Manual | review-process.md has `/fd-threat-model` in workflow | Documentation |
+
+## Acceptance Criteria / Criteri di Accettazione
+
+- [ ] `.forgia/dev-guide/review-process.md` updated with `/fd-threat-model` in workflow diagram
+- [ ] New subsection in review-process.md documents `/fd-threat-model`: purpose, output, advisory nature
+- [ ] `go build ./cmd/forgia/` succeeds
+- [ ] `forgia skills` lists `fd-threat-model`
+- [ ] No Go code was modified — only markdown files
+- [ ] Full workflow verified: threat model file → fd-review detection → fd-sdd injection
+
+## Context / Contesto
+
+- [ ] `.forgia/dev-guide/review-process.md` — file to update
+- [ ] `modules/claude-commands/fd-threat-model.md` — created by SDD-001
+- [ ] `modules/claude-commands/fd-review.md` — updated by SDD-002
+- [ ] `modules/claude-commands/fd-sdd.md` — updated by SDD-003
+- [ ] `internal/skill/embedded.go` — `inferCategory()` confirms `fd-` prefix → `CategoryFD`
+- [ ] `embedded.go` — `go:embed all:modules/claude-commands`
+
+## Constitution Check
+
+- [ ] Respects code standards — documentation follows existing conventions
+- [ ] Respects commit conventions — `feat(FD-005): description`
+- [ ] No hardcoded secrets — no secret handling
+- [ ] Tests defined and sufficient — 3 verification steps
+
+---
+
+## Work Log / Diario di Lavoro
+
+> This section is **mandatory**. Must be filled by the agent or developer during and after execution.
+
+### Agent / Agente
+
+- **Executor**: claude-code
+- **Started**: 2026-03-29
+- **Completed**: 2026-03-29
+- **Duration / Durata**: ~5 min
+
+### Decisions / Decisioni
+
+1. Placed `/fd-threat-model` as an optional step between Gate 1 (FD Review) and SDD Generation in the workflow diagram, matching the SDD spec's requested flow
+2. Added a dedicated subsection documenting purpose, output, advisory nature, and downstream effects — kept it concise and consistent with existing gate descriptions
+3. Confirmed no Go code changes needed — `go:embed all:modules/claude-commands` automatically picks up the new `fd-threat-model.md` file
+
+### Output
+
+- **Commit(s)**: pending
+- **PR**: part of ferruvich/issues-21 branch
+- **Files created/modified**:
+  - `.forgia/dev-guide/review-process.md` — updated workflow diagram and added `/fd-threat-model` subsection
+  - `.forgia/sdd/FD-005/SDD-004-integration-wiring.md` — Work Log filled
+
+### Retrospective / Retrospettiva
+
+- **What worked / Cosa ha funzionato**: Clean dependency chain — all SDD-001/002/003 outputs were in place, making integration straightforward. The `go:embed` auto-discovery pattern meant zero Go changes were needed.
+- **What didn't / Cosa non ha funzionato**: Nothing blocked execution.
+- **Suggestions for future FDs / Suggerimenti per FD futuri**: Integration/wiring SDDs are ideal for verifying the full chain works. Consider making E2E validation a standard final SDD in multi-SDD FDs.

--- a/modules/claude-commands/fd-review.md
+++ b/modules/claude-commands/fd-review.md
@@ -38,17 +38,19 @@ Given FD identifier: $ARGUMENTS
 - [ ] Security guardrails reviewed (`.forgia/guardrails/deny.toml`)
 - [ ] No proposed interfaces expose or require secrets in plaintext
 - [ ] No file patterns in the FD would violate deny.toml read/write/execute rules
+- [ ] **Threat model** (advisory) — check if `.forgia/fd/FD-NNN-threat-model.md` exists. If present, note "Threat model available" and verify it covers the FD's components. If missing, flag as advisory: "Threat model non presente — considera `/fd-threat-model FD-NNN` per analisi di sicurezza." This is NOT a blocker — the FD can still pass review without a threat model.
 
 ### Verification
 - [ ] Verification criteria are defined and sufficient
 - [ ] Each criterion is objectively testable
 
-5. If ALL checks pass:
+5. If ALL checks pass (excluding advisory items):
    - Set `reviewed: true` and `reviewer: "claude"` in frontmatter
    - Update status to "approved"
    - Report: "APPROVATO — FD pronto per generazione SDD. Usa /fd-sdd FD-NNN"
+   - If any advisory items have recommendations, include them after the approval as "Note advisory" (e.g., missing threat model suggestion)
 
-6. If ANY check fails:
+6. If ANY non-advisory check fails:
    - Keep `reviewed: false`
    - List all failed checks with specific feedback
    - Report: "REVISIONE RICHIESTA" with action items

--- a/modules/claude-commands/fd-sdd.md
+++ b/modules/claude-commands/fd-sdd.md
@@ -12,13 +12,26 @@ Given FD identifier: $ARGUMENTS
 6. Read principles from `.forgia/dev-guide/principles/` (clean-code, SOLID, design-patterns)
 7. Read language-specific conventions from `.forgia/dev-guide/lang/` — load only the files relevant to each SDD's language/stack
 8. Read guardrails from `.forgia/guardrails/deny.toml` — include the deny list in each SDD's constraints
-9. For each component listed in "SDD Previsti" in the FD, create an SDD:
+9. **Read threat model** (if present):
+   - Check if `.forgia/fd/FD-NNN-threat-model.md` exists (where `FD-NNN` matches the FD identifier from step 1)
+   - If the file exists, read it and extract the `## 4. Recommendations for SDDs` section
+   - Parse each recommendation line (format: `N. **SDD-NNN**: <mitigation description>`)
+   - Store the mapping of SDD numbers to their security mitigations for use in step 10
+   - If the file does not exist, skip silently — no error, no warning. Proceed with SDD generation normally.
+10. For each component listed in "SDD Previsti" in the FD, create an SDD:
    - Create directory `.forgia/sdd/FD-NNN/`
    - Create `SDD-001-kebab-name.md`, `SDD-002-kebab-name.md`, etc.
    - Populate each SDD with:
      - **Scope**: derived from the FD's component description
      - **Interfaces**: from the FD's interface definitions
      - **Constraints**: language, framework, versions from the FD's architecture
+       - If threat model mitigations were found in step 9 for this SDD number, add a `### Security (from threat model)` subsection at the end of the Constraints section. Each injected constraint is a bullet point ending with `(source: threat model)`. Example:
+         ```
+         ### Security (from threat model)
+         - Add input sanitization for title/description (source: threat model)
+         ```
+       - If no mitigations match this SDD number, do not add the subsection
+       - Mitigations are additive — never remove or modify existing constraints
      - **Best Practices**: from dev-guide + constitution + language conventions from `lang/`
      - **Test Requirements**: specific to this component
      - **Acceptance Criteria**: verifiable, derived from FD verification criteria
@@ -38,13 +51,13 @@ Given FD identifier: $ARGUMENTS
    modules are never wired, functions are never called from the startup path, and integration
    is left as an implicit assumption that nobody verifies.
 
-8. Update the FD status to "in-progress"
-9. **Beads integration** (if `bd` is available and `.beads/` exists):
+11. Update the FD status to "in-progress"
+12. **Beads integration** (if `bd` is available and `.beads/` exists):
    - Create a bd epic for the FD: `bd create "FD-NNN: <title>" --type=epic`
    - For each SDD, create a bd subtask: `bd create "SDD-NNN: <title>" --parent=<epic-id>`
    - Add dependencies between SDDs if they have interface contracts
    - Tag each bd task with the SDD id for cross-reference
-10. Show the user:
+13. Show the user:
    - List of generated SDDs with file paths
    - Beads epic and task IDs (if created)
    - Suggested next steps:

--- a/modules/claude-commands/fd-threat-model.md
+++ b/modules/claude-commands/fd-threat-model.md
@@ -1,0 +1,155 @@
+Perform STRIDE-based threat modeling on a Feature Design and write the result to a persistent file.
+
+## Instructions
+
+Given FD identifier: $ARGUMENTS
+
+1. **Pre-flight check**:
+
+   a. Parse `$ARGUMENTS` to extract the FD identifier (e.g., `FD-005`).
+   b. Find the matching FD file in `.forgia/fd/` — look for a file matching `FD-NNN-*.md` (e.g., `.forgia/fd/FD-005-*.md`).
+   c. If no matching FD file exists, output: `"FD non trovato: $ARGUMENTS. Verifica l'identificatore."` — then **stop**. Do NOT create any file.
+
+2. **Read vault context** — load all of these:
+
+   - The FD file (full content: architecture, interfaces, components, constraints, SDD plan)
+   - `.forgia/constitution.md` — especially the Security section
+   - `.forgia/guardrails/deny.toml` — existing deny patterns (read, execute, write sections)
+   - `.forgia/dev-guide/review-process.md` (if exists)
+   - `.forgia/dev-guide/principles/clean-code.md` — error handling, validation at boundaries
+   - `.forgia/dev-guide/lang/*.md` — all language-specific conventions (security patterns)
+   - Actually **read the content** of every file — do not just list them.
+
+3. **Scan codebase for existing security patterns**:
+
+   - Search for authentication, authorization, input validation, encryption, and access control patterns in the project source code.
+   - **CRITICAL**: Before reading any file, check its path against the `[read]` deny patterns in `.forgia/guardrails/deny.toml`. If a file matches a deny pattern, **skip it** and do not include it in context. Specifically, never read: `.env`, `*.pem`, `*.key`, `*.p12`, `*.pfx`, `*.jks`, `*.keystore`, `.aws/credentials`, `.ssh/id_*`, `.gnupg/**`, `credentials.json`, `*.tfstate`, or any other pattern listed in the `[read]` section.
+   - Note any existing security mechanisms that are already in place (middleware, validators, sanitizers, encryption helpers).
+
+4. **Identify Assets**:
+
+   Based on the FD's architecture, interfaces, and data flow, identify:
+   - Data assets (user data, configuration, tokens, API keys, session data)
+   - Access credentials and authentication mechanisms
+   - Infrastructure components (databases, message queues, file storage, APIs)
+   - Trust boundaries (where data crosses from trusted to untrusted zones)
+
+5. **Enumerate Threat Actors**:
+
+   Based on the feature's attack surface, enumerate relevant threat actors:
+   - Unauthenticated external users
+   - Authenticated users with limited privileges
+   - Compromised plugins or extensions
+   - Malicious input (injection, crafted payloads)
+   - Insider threats (compromised accounts, rogue agents)
+   - Supply chain threats (compromised dependencies)
+   - Only include actors relevant to the specific feature — do not list generic actors that have no bearing on this FD.
+
+6. **Perform STRIDE Analysis**:
+
+   For each relevant component identified in the FD's architecture, analyze all 6 STRIDE categories:
+
+   - **S**poofing — Can an attacker impersonate another identity or component?
+   - **T**ampering — Can data or code be modified without detection?
+   - **R**epudiation — Can actions be performed without accountability/audit trail?
+   - **I**nformation Disclosure — Can sensitive data leak through this component?
+   - **D**enial of Service — Can availability be degraded or destroyed?
+   - **E**levation of Privilege — Can an attacker gain unauthorized access levels?
+
+   For each component, produce a table row for each identified threat. If a STRIDE category has no threats for a given component, explicitly state "No threats identified" for that category — all 6 categories must be covered per relevant component.
+
+   Each threat row must include: Threat description, STRIDE Category (S/T/R/I/D/E), Component, Risk level (High/Medium/Low), and Mitigation.
+
+7. **Generate SDD Recommendations**:
+
+   Map identified mitigations to specific SDDs listed in the FD's "Planned SDDs / SDD Previsti" section. Each recommendation must:
+   - Reference a specific SDD by number (e.g., "SDD-002")
+   - Describe a concrete mitigation action (e.g., "add input sanitization for title field", "enforce rate limiting on API endpoint")
+   - Be actionable — an agent reading the SDD should know exactly what security control to implement.
+   - If a mitigation applies to a component not covered by any planned SDD, note it as a gap.
+
+8. **Suggest Guardrails Additions**:
+
+   Based on identified threats, propose concrete additions to `.forgia/guardrails/deny.toml`. Each suggestion must:
+   - Specify the section (`[read]`, `[execute]`, or `[write]`)
+   - Provide the exact glob/command pattern
+   - Include a comment explaining why
+   - Not duplicate patterns already in the current `deny.toml`
+   - Example: `[execute] "kubectl exec*"  # Prevent direct container shell access`
+
+9. **Write the threat model file** at `.forgia/fd/FD-NNN-threat-model.md` using this exact format:
+
+```markdown
+---
+fd: "FD-NNN"
+generated: "YYYY-MM-DD"
+generator: "/fd-threat-model"
+---
+
+# Threat Model: FD-NNN — <FD title>
+
+> Generated by `/fd-threat-model` on YYYY-MM-DD.
+> Based on: <FD file path>
+
+## 1. Assets
+
+| Asset | Type | Location | Sensitivity |
+|-------|------|----------|-------------|
+| ... | Data / Credential / Infrastructure | Component or boundary | High / Medium / Low |
+
+## 2. Threat Actors
+
+| Actor | Motivation | Access Level | Relevance to FD |
+|-------|-----------|--------------|-----------------|
+| ... | ... | ... | Why this actor matters for this feature |
+
+## 3. STRIDE Analysis
+
+### <Component Name>
+
+| Threat | Category | Risk | Mitigation |
+|--------|----------|------|------------|
+| ... | S / T / R / I / D / E | High / Medium / Low | ... |
+
+<!-- Repeat for each relevant component -->
+
+## 4. Recommendations for SDDs
+
+1. **SDD-NNN**: <concrete mitigation action>
+2. **SDD-NNN**: <concrete mitigation action>
+...
+
+## 5. Guardrails Additions
+
+Proposed additions to `.forgia/guardrails/deny.toml`:
+
+```toml
+[section]
+# Reason for addition
+"pattern"
+```
+
+If no additions are needed, state: "No additional guardrails patterns identified — existing deny.toml coverage is sufficient."
+```
+
+10. **Report to the user**:
+
+    - Confirm the file was created: `"Threat model creato: .forgia/fd/FD-NNN-threat-model.md"`
+    - Summarize: number of assets, threat actors, STRIDE threats found, SDD recommendations, and guardrails suggestions
+    - Suggest next steps:
+      - "Rivedi il threat model e applica le raccomandazioni ai vincoli degli SDD"
+      - "Usa `/fd-review $ARGUMENTS` per la revisione completa dell'FD"
+      - "Usa `/fd-sdd $ARGUMENTS` per generare gli SDD (le mitigazioni verranno iniettate automaticamente)"
+
+## Important
+
+- This command **writes exactly one file**: `.forgia/fd/FD-NNN-threat-model.md` — it must NEVER modify the FD itself, constitution, config.toml, guardrails/deny.toml, or any codebase file
+- Guardrails suggestions in the output are **advisory** — the user decides whether to apply them
+- STRIDE analysis must cover **all 6 categories** per relevant component — no category may be silently skipped
+- Each STRIDE category with no threats must explicitly state "No threats identified"
+- SDD recommendations must reference **specific SDD numbers** from the FD's planned SDDs
+- Guardrails suggestions must be **concrete `deny.toml` patterns**, not generic advice
+- The threat model file is a **persistent artifact** consumed by `/fd-review` (SDD-002) and `/fd-sdd` (SDD-003)
+- Do NOT read files matching `[read]` deny patterns in `.forgia/guardrails/deny.toml`
+- Do NOT write to: `.forgia/constitution.md`, `.forgia/config.toml`, `.forgia/guardrails/deny.toml`
+- If the FD has no architecture diagrams or component breakdown, note this as a limitation but still perform analysis based on available information


### PR DESCRIPTION
## Summary

- New `/fd-threat-model FD-NNN` slash command that performs STRIDE-based threat modeling on Feature Designs
- Output is a **persistent file** (`.forgia/fd/FD-NNN-threat-model.md`) consumed by downstream commands
- `/fd-review` updated with advisory threat model existence check (non-blocking)
- `/fd-sdd` updated to inject mitigations from threat model into SDD Constraints
- Updated review workflow in `review-process.md`

## What's included

| File | Purpose |
|------|---------|
| `modules/claude-commands/fd-threat-model.md` | New slash command — STRIDE analysis |
| `modules/claude-commands/fd-review.md` | Updated — advisory threat model check |
| `modules/claude-commands/fd-sdd.md` | Updated — inject mitigations into SDDs |
| `.forgia/dev-guide/review-process.md` | Updated workflow diagram |
| `.forgia/fd/FD-005-fd-threat-model.md` | Feature Design (closed) |
| `.forgia/sdd/FD-005/SDD-001..004` | 4 SDDs (all done) |

## Threat model output

The command produces a file with 5 sections:
1. **Assets** — data, credentials, infrastructure at risk
2. **Threat Actors** — relevant attackers and attack vectors
3. **STRIDE Analysis** — per-component table (Spoofing, Tampering, Repudiation, Info Disclosure, DoS, Elevation)
4. **Recommendations for SDDs** — mitigations mapped to specific SDD numbers
5. **Guardrails Suggestions** — concrete `deny.toml` patterns to consider

## Integration

- `/fd-review` checks if threat model exists → advisory flag (not a blocker)
- `/fd-sdd` reads recommendations → injects into SDD Constraints as `### Security (from threat model)`

## Test plan

- [ ] `go build ./cmd/forgia/` succeeds
- [ ] `forgia skills` lists `fd-threat-model`
- [ ] `/fd-threat-model FD-NNN` produces threat model file with all 5 sections
- [ ] `/fd-review` flags missing threat model as advisory (does not block approval)
- [ ] `/fd-sdd` injects mitigations when threat model present, skips silently when absent
- [ ] Command respects `deny.toml` patterns during codebase scanning

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)