### PR TITLE
docs: update README with complete command reference and workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ cd /path/to/your/project
 forgia init
 ```
 
+## Workflow
+
+Forgia enforces a 3-gate workflow with optional analysis steps:
+
+```
+FD Review ──→ Arch Review ──→ Threat Model ──→ SDD Generation ──→ Implementation ──→ Verification ──→ Close
+ /fd-review   /fd-arch-review  /fd-threat-model  /fd-sdd           agent executes     /fd-verify       /fd-close
+ GATE 1        (optional)       (optional)                                              GATE 2           GATE 3
+```
+
+- **Gate 1** (`/fd-review`): FD must pass review before SDDs can be generated
+- **Arch Review** (`/fd-arch-review`): Pattern detection, SOLID compliance, dependency graph (advisory)
+- **Threat Model** (`/fd-threat-model`): STRIDE security analysis, feeds mitigations into SDD constraints (advisory)
+- **Gate 2** (`/fd-verify`): Acceptance criteria met, tests pass, Work Logs filled
+- **Gate 3** (`/fd-close`): Archive, retrospective, changelog
+
 ## Vault Structure
 
 After `forgia init`, your project gets:
@@ -63,15 +79,21 @@ After `forgia init`, your project gets:
 ```
 your-project/
   .forgia/
-    config.toml               # runner and beads configuration
+    config.toml               # runner, beads, knowledge, watcher config
     constitution.md            # immutable project rules
     _dashboard.md              # Obsidian dataview overview
+    guardrails/
+      deny.toml                # security deny patterns (read/write/execute)
+      ignore                   # files to exclude from agent context
     fd/                        # Feature Designs (what & why)
     sdd/                       # Execution Specs (how, for agents)
       _templates/
         sdd-template.md        # markdown format
         sdd-template.yaml      # YAML format (machine-parseable)
     ops/                       # manual operational tasks
+    architecture/              # C4/DDD system design (YAML)
+    contexts/                  # bounded context definitions
+    learnings/                 # retrospective feedback loop
     dev-guide/
       principles/              # clean-code, SOLID, design-patterns
       lang/                    # per-language conventions (auto-detected)
@@ -80,44 +102,79 @@ your-project/
       review-process.md
 ```
 
-## Spells (Commands)
+## Spells (Slash Commands)
 
-> Claude Code slash commands — the core workflow.
+> Claude Code slash commands — the core workflow. Run via `/command` in Claude Code or `forgia skill <name>`.
+
+### Feature Design
 
 | Spell | What it does |
 |-------|--------------|
-| `/fd-new` | **Forge a new design** — create a Feature Design |
-| `/fd-review` | **Trial by fire** — mandatory review gate |
-| `/fd-sdd` | **Temper the specs** — generate N SDDs from an approved FD |
-| `/fd-deep` | **Deep analysis** — 4 agents explore the problem in parallel |
-| `/fd-explore` | **Study the piece** — load FD context |
-| `/fd-verify` | **Quality check** — verify implementation vs spec |
-| `/fd-close` | **Seal the work** — archive completed FD + retrospective |
+| `/fd-new` | **Forge a new design** — create FD from issue or description |
+| `/fd-review` | **Trial by fire** — mandatory review gate (GATE 1) |
+| `/fd-arch-review` | **Inspect the blueprint** — pattern detection, SOLID compliance, dependency graph |
+| `/fd-threat-model` | **Test the armor** — STRIDE security analysis, guardrails suggestions |
 | `/fd-compare` | **Weigh the options** — compare competing FDs side-by-side |
+| `/fd-sdd` | **Temper the specs** — generate N SDDs from approved FD |
+| `/fd-deep` | **Deep analysis** — parallel exploration for complex problems |
+| `/fd-explore` | **Study the piece** — load FD context into session |
+| `/fd-verify` | **Quality check** — verify implementation vs spec (GATE 2) |
+| `/fd-close` | **Seal the work** — archive FD + retrospective (GATE 3) |
+| `/fd-feedback` | **Learn from the forge** — route Work Log insights to architecture/learnings |
 | `/fd-status` | **Forge status** — FD + SDD dashboard |
 
-## CLI Tools
+### SDD Execution
 
-> `forgia` commands and `mise` tasks for workflow management.
+| Spell | What it does |
+|-------|--------------|
+| `/sdd-dry-run` | **Test the fire** — simulate SDD execution, feasibility report (GO/NO-GO) |
+| `/sdd-assign` | **Hand the hammer** — assign SDD to agent backend |
+| `/sdd-status` | **Check the anvil** — execution status of all SDDs |
+
+### Architecture (DDD)
+
+| Spell | What it does |
+|-------|--------------|
+| `/arch-init` | **Lay the foundation** — initialize DDD architecture from brief |
+| `/arch-review` | **Survey the structure** — review coherence across vault |
+| `/arch-update` | **Record the build** — update architecture from SDD Work Logs |
+
+### Setup
+
+| Spell | What it does |
+|-------|--------------|
+| `/project-init` | **Light the forge** — scaffold vault in current project |
+
+## CLI Commands
 
 | Command | What it does |
 |---------|--------------|
 | `forgia init` | Scaffold the vault in the current project |
-| `forgia status` | Dashboard: FDs + SDDs + Beads ready tasks |
-| `forgia doctor` | Health check (docker, bd, vault, mise, fswatch, yq) |
+| `forgia status` | Dashboard: FDs, SDDs, OPS tasks, exec logs, Beads, knowledge stats |
+| `forgia doctor` | Health check: vault, tools, Docker, API keys, knowledge layer |
 | `forgia validate <sdd>` | Validate an SDD before execution |
-| `forgia exec <sdd>` | Execute an SDD (auto-detect runner from config) |
-| `forgia batch <FD-NNN>` | Execute all SDDs for an FD |
+| `forgia exec <sdd>` | Execute an SDD (`--runner`, `--dry-run`, `--mode`) |
+| `forgia batch <FD-NNN>` | Execute all pending SDDs for an FD |
 | `forgia watch <FD-NNN>` | Watch and auto-execute new SDDs |
+| `forgia sync` | Sync vault with project board (GitHub Projects) |
+| `forgia skill <name>` | Execute a slash command via Claude CLI |
+| `forgia skills` | List all available slash commands |
+| `forgia version` | Show version |
 
 ### Runners
 
 ```bash
-# Claude Code — uses your Max subscription (free)
+# Claude Code — uses your Max subscription
 forgia exec .forgia/sdd/FD-001/SDD-001.md --runner=claude
 
-# OpenHands — uses API keys, isolated Docker containers
+# OpenHands — autonomous, N parallel containers
 forgia exec .forgia/sdd/FD-001/SDD-001.md --runner=openhands
+
+# Dry run — simulate without executing
+forgia exec .forgia/sdd/FD-001/SDD-001.md --dry-run
+
+# Guardrail enforcement mode
+forgia exec .forgia/sdd/FD-001/SDD-001.md --mode=guard
 
 # Default from config.toml
 forgia exec .forgia/sdd/FD-001/SDD-001.md
@@ -127,7 +184,23 @@ forgia exec .forgia/sdd/FD-001/SDD-001.md
 |--------|-------------|
 | **Claude Code** | Interactive, Max subscription, git worktree isolation |
 | **OpenHands** | Autonomous, N parallel containers, API keys |
+| **Dry Run** | Feasibility check before committing to execution |
 | **Manual** | Read the SDD and implement yourself |
+
+## Guardrails
+
+Security deny patterns in `.forgia/guardrails/deny.toml` control what agents can and cannot do:
+
+```toml
+[read]    # Files agents must NEVER read (.env, *.pem, .ssh/*, etc.)
+[execute] # Commands agents must NEVER run (pass show, gpg --export-secret, etc.)
+[write]   # Files agents must NEVER modify (constitution.md, config.toml, deny.toml)
+```
+
+Guardrails are **fail-closed** — if a pattern matches, the action is blocked. Three enforcement modes:
+- **careful** — warns on destructive commands
+- **freeze** — restricts writes to SDD boundaries
+- **guard** — careful + freeze combined
 
 ## Beads Integration
 
@@ -146,10 +219,13 @@ Every agent automatically loads:
 ```
 .forgia/dev-guide/
   principles/          ← ALWAYS loaded (clean-code, SOLID, design-patterns)
-  lang/                ← auto-detected per project (rust, python, ts, go, shell)
+  lang/                ← auto-detected per project (rust, python, ts, go, k8s, shell)
   coding-conventions   ← operational rules
   commit-conventions   ← commit format
+  review-process       ← workflow gates
 ```
+
+Optional: [codebase-memory-mcp](https://github.com/nicobailey-ai/codebase-memory-mcp) provides Tier 3 semantic indexing (symbols, edges, dependency graph). Auto-indexed during `forgia init` if installed.
 
 ## Work Log
 
@@ -182,6 +258,7 @@ work_log:
 | `bd` | Optional | Beads task tracker | `mise run bd:install` |
 | `fswatch` | Optional | `forgia watch` | `brew install fswatch` |
 | `yq` | Optional | YAML SDD validation | `brew install yq` |
+| `codebase-memory-mcp` | Optional | Knowledge layer (Tier 3) | [GitHub](https://github.com/nicobailey-ai/codebase-memory-mcp) |
 
 ## Inspired By
 


### PR DESCRIPTION
## Summary

- Updated README to reflect the current state of the codebase after recent FDs (FD-002 through FD-005)
- Added 11 missing slash commands, 4 missing CLI commands, and several new sections

## What changed

- **New section: Workflow** — 3-gate diagram with optional `/fd-arch-review` and `/fd-threat-model` steps
- **New section: Guardrails** — deny.toml structure and 3 enforcement modes (careful/freeze/guard)
- **Slash commands expanded** — from 9 to 19, organized into 4 groups (FD, SDD, Architecture, Setup)
- **CLI commands expanded** — from 7 to 11 (added `sync`, `skill`, `skills`, `version`)
- **Vault structure expanded** — added guardrails/, architecture/, contexts/, learnings/
- **Runners updated** — added `--dry-run`, `--mode` flags, dry-run runner
- **Knowledge layer** — codebase-memory-mcp documented in Knowledge Stack and Prerequisites
- **Prerequisites** — added `codebase-memory-mcp` as optional tool

## Test plan

- [ ] All links and formatting render correctly on GitHub
- [ ] Command names match actual CLI (`forgia skills` output)
- [ ] Vault structure matches `forgia init` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)